### PR TITLE
Add failed and missed job status

### DIFF
--- a/apis/task.py
+++ b/apis/task.py
@@ -163,7 +163,7 @@ class TpuTask(BaseTask):
     """
     with TaskGroup(group_id="post_process") as group:
       process_id = metric.generate_process_id.override(retries=1)()
-      metric.process_metrics(
+      metric.process_metrics.override(retries=1)(
           process_id,
           self.task_test_config,
           self.task_metric_config,

--- a/implementations/utils/bigquery.py
+++ b/implementations/utils/bigquery.py
@@ -63,9 +63,8 @@ class TestRun:
 
 class JobStatus(enum.Enum):
   SUCCESS = 0
-  FAILURE = 1
-  TIMEOUT = 2
-  MISSED = 3
+  FAILED = 1
+  MISSED = 2
 
 
 class BigQueryMetricClient:

--- a/implementations/utils/metric.py
+++ b/implementations/utils/metric.py
@@ -414,12 +414,12 @@ def get_job_status(benchmark_id: str) -> bigquery.JobStatus:
   setup_ti = TaskInstance(setup_task, execution_date)
   setup_state = setup_ti.current_state()
   if setup_state == TaskState.UPSTREAM_FAILED.value:
-    print("The setup state is upstream_failed, so the job status is missed.")
+    print("The setup state is upstream_failed, and the job status is missed.")
     return bigquery.JobStatus.MISSED
 
   # check setup status to see if setup step is successful
   if setup_state == TaskState.FAILED.value:
-    print("The setup state is failed, so the job status is failure.")
+    print("The setup state is failed, and the job status is failed.")
     return bigquery.JobStatus.FAILED
 
   # check run_model status to see if run_model step is successful
@@ -428,10 +428,10 @@ def get_job_status(benchmark_id: str) -> bigquery.JobStatus:
   run_model_state = run_model_ti.current_state()
 
   if run_model_state == TaskState.SUCCESS.value:
-    print("The run_model state is succuess, so the job status is success.")
+    print("The run_model state is succuess, and the job status is success.")
     return bigquery.JobStatus.SUCCESS
 
-  print("The run_model state is failed, so the job status is failed.")
+  print("The run_model state is failed, and the job status is failed.")
   return bigquery.JobStatus.FAILED
 
 

--- a/implementations/utils/metric.py
+++ b/implementations/utils/metric.py
@@ -17,6 +17,7 @@
 
 import dataclasses
 import datetime
+import enum
 import hashlib
 import os
 import re
@@ -24,6 +25,7 @@ from typing import Dict, Iterable, List, Optional
 import uuid
 from absl import logging
 from airflow.decorators import task
+from airflow.models import TaskInstance
 from airflow.operators.python import get_current_context
 from apis import gcp_config, test_config
 from apis import metric_config
@@ -41,6 +43,12 @@ from tensorflow.core.util import event_pb2
 class TensorBoardScalar:
   metric_value: float
   step: int
+
+
+class TaskState(enum.Enum):
+  FAILED = "failed"
+  UPSTREAM_FAILED = "upstream_failed"
+  SUCCESS = "success"
 
 
 def is_valid_tag(
@@ -355,7 +363,7 @@ def generate_row_uuid(base_id: str, index: int) -> str:
   return hashlib.sha256(str(base_id + str(index)).encode("utf-8")).hexdigest()
 
 
-@task
+@task(trigger_rule="all_done")
 def generate_process_id() -> str:
   """Generate a process id that will be a base id for uuid of test runs.
 
@@ -389,9 +397,45 @@ def is_valid_entry() -> bool:
   return True
 
 
-# TODO(ranran):
-# 1) handle job status
-# 2) handle Airflow retry to avoid duplicate records in tables
+def get_job_status(benchmark_id: str) -> bigquery.JobStatus:
+  """Get job status for the run.
+
+  MISSED - if any failure occurs in initialize & create_queued_resource
+  FAILED - if any failure occurs in setup & run_model (including timeout of
+  run_model)
+  SUCCESS - end-to-end model tests are successful from provision to run_model
+  """
+  context = get_current_context()
+  execution_date = context["dag_run"].logical_date
+  current_dag = context["dag"]
+
+  # check setup status to see if provision step is successful
+  setup_task = current_dag.get_task(task_id=f"{benchmark_id}.provision.setup")
+  setup_ti = TaskInstance(setup_task, execution_date)
+  setup_state = setup_ti.current_state()
+  if setup_state == TaskState.UPSTREAM_FAILED.value:
+    print("The setup state is upstream_failed, so the job status is missed.")
+    return bigquery.JobStatus.MISSED
+
+  # check setup status to see if setup step is successful
+  if setup_state == TaskState.FAILED.value:
+    print("The setup state is failed, so the job status is failure.")
+    return bigquery.JobStatus.FAILED
+
+  # check run_model status to see if run_model step is successful
+  run_model_task = current_dag.get_task(task_id=f"{benchmark_id}.run_model")
+  run_model_ti = TaskInstance(run_model_task, execution_date)
+  run_model_state = run_model_ti.current_state()
+
+  if run_model_state == TaskState.SUCCESS.value:
+    print("The run_model state is succuess, so the job status is success.")
+    return bigquery.JobStatus.SUCCESS
+
+  print("The run_model state is failed, so the job status is failed.")
+  return bigquery.JobStatus.FAILED
+
+
+# TODO(ranran): handle Airflow retry to avoid duplicate records in tables
 @task
 def process_metrics(
     base_id: str,
@@ -449,13 +493,14 @@ def process_metrics(
       task_gcp_config.project_name, task_gcp_config.dataset_name.value
   )
 
+  test_job_status = get_job_status(task_test_config.benchmark_id)
   for index in range(len(metadata_history_rows_list)):
     job_history_row = bigquery.JobHistoryRow(
         uuid=generate_row_uuid(base_id, index),
         timestamp=current_time,
         owner=task_test_config.task_owner,
         job_name=benchmark_id,
-        job_status=bigquery.JobStatus.SUCCESS.value,
+        job_status=test_job_status.value,
     )
     test_run_row = bigquery.TestRun(
         job_history_row,

--- a/implementations/utils/metric.py
+++ b/implementations/utils/metric.py
@@ -47,7 +47,7 @@ class TensorBoardScalar:
 
 class TaskState(enum.Enum):
   FAILED = "failed"
-  UPSTREAM_FAILED = "upstream_failed"
+  SKIPPED = "upstream_failed"
   SUCCESS = "success"
 
 
@@ -413,8 +413,8 @@ def get_job_status(benchmark_id: str) -> bigquery.JobStatus:
   setup_task = current_dag.get_task(task_id=f"{benchmark_id}.provision.setup")
   setup_ti = TaskInstance(setup_task, execution_date)
   setup_state = setup_ti.current_state()
-  if setup_state == TaskState.UPSTREAM_FAILED.value:
-    print("The setup state is upstream_failed, and the job status is missed.")
+  if setup_state == TaskState.SKIPPED.value:
+    print("The setup state is skipped, and the job status is missed.")
     return bigquery.JobStatus.MISSED
 
   # check setup status to see if setup step is successful
@@ -428,7 +428,7 @@ def get_job_status(benchmark_id: str) -> bigquery.JobStatus:
   run_model_state = run_model_ti.current_state()
 
   if run_model_state == TaskState.SUCCESS.value:
-    print("The run_model state is succuess, and the job status is success.")
+    print("The run_model state is success, and the job status is success.")
     return bigquery.JobStatus.SUCCESS
 
   print("The run_model state is failed, and the job status is failed.")


### PR DESCRIPTION
# Description

Add failed and missed job status
* missed: issues related to initialization & QR to get the machine
* failed: issues during setup and run model process, including timeout in run model

Also:
* set `post_process` retry at 1 as we have TODO to `handle Airflow retry to avoid duplicate records in tables`
* add trigger rule for generate_process_id with all_done, so the post_process will always be triggered no matter the states of upstream tasks

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Tested it on Airflow & check metrics in logs of process process

**List links for your tests (use go/shortn-gen for any internal link):** ...

UI: [link](https://screenshot.googleplex.com/4hyZPJfumCn2bqY)

```
1) Set timeout=2min for run_model on v2-8, and get job_status=1 (failed)

[2023-11-02, 05:33:40 UTC] {logging_mixin.py:150} INFO - Test run rows: 
[TestRun(job_history=JobHistoryRow(uuid='345e7bcdec8817a50b97a9bbaef10be0465c
b6f64f41b01497fd394f36dcad01', timestamp=datetime.datetime(2023, 11, 2, 5, 33, 40, 
87691), owner='Shiva S.', job_name='flax_resnet_imagenet-v2-8', job_status=1), 
metric_history=[], metadata_history=
[MetadataHistoryRow(job_uuid='345e7bcdec8817a50b97a9bbaef10be0465cb6f64f41b
01497fd394f36dcad01', metadata_key='run_id', metadata_value='manual__2023-11-
02T02:57:35.601337+00:00'), 
MetadataHistoryRow(job_uuid='345e7bcdec8817a50b97a9bbaef10be0465cb6f64f41b0
1497fd394f36dcad01', metadata_key='prev_start_date_success', 
metadata_value='2023-11-01T16:59:31.105103+00:00'), 
MetadataHistoryRow(job_uuid='345e7bcdec8817a50b97a9bbaef10be0465cb6f64f41b0
1497fd394f36dcad01', metadata_key='airflow_dag_run_link', 
metadata_value='https://46c56b977f2b44158661f1ef150119c7-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-11-
02T02%3A57%3A35.601337%2B00%3A00&task_id=flax_resnet_imagenet-v2-
8.post_process.process_metrics')])]

2) set invalid zone for the v2-32, and get job_status=2 (missed)

[2023-11-02, 03:30:43 UTC] {logging_mixin.py:150} INFO - Test run rows: 
[TestRun(job_history=JobHistoryRow(uuid='259be4644c6309bb84bb092869735f04c3
35906d7fd2eb997ce9c285d37c2449', timestamp=datetime.datetime(2023, 11, 2, 3, 30, 
43, 256990), owner='Shiva S.', job_name='flax_resnet_imagenet-v2-32', job_status=2), 
metric_history=[], metadata_history=
[MetadataHistoryRow(job_uuid='259be4644c6309bb84bb092869735f04c335906d7fd
2eb997ce9c285d37c2449', metadata_key='run_id', metadata_value='manual__2023-11-
02T02:57:35.601337+00:00'), 
MetadataHistoryRow(job_uuid='259be4644c6309bb84bb092869735f04c335906d7fd2
eb997ce9c285d37c2449', metadata_key='prev_start_date_success', 
metadata_value='2023-11-01T16:59:31.105103+00:00'), 
MetadataHistoryRow(job_uuid='259be4644c6309bb84bb092869735f04c335906d7fd2
eb997ce9c285d37c2449', metadata_key='airflow_dag_run_link', 
metadata_value='https://46c56b977f2b44158661f1ef150119c7-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-11-
02T02%3A57%3A35.601337%2B00%3A00&task_id=flax_resnet_imagenet-v2-
32.post_process.process_metrics')])]

3) set invalid arg in run_model on v3-32, and get job_status=1 (failed)

[2023-11-02, 03:33:30 UTC] {logging_mixin.py:150} INFO - Test run rows: 
[TestRun(job_history=JobHistoryRow(uuid='1265b19f9686db8427dfe3c7e4a47c27b805
317c6e098a6101511a7fea005726', timestamp=datetime.datetime(2023, 11, 2, 3, 33, 29, 
854890), owner='Shiva S.', job_name='flax_resnet_imagenet-v3-32', job_status=1), 
metric_history=[], metadata_history=
[MetadataHistoryRow(job_uuid='1265b19f9686db8427dfe3c7e4a47c27b805317c6e098
a6101511a7fea005726', metadata_key='run_id', metadata_value='manual__2023-11-
02T02:57:35.601337+00:00'), 
MetadataHistoryRow(job_uuid='1265b19f9686db8427dfe3c7e4a47c27b805317c6e098a
6101511a7fea005726', metadata_key='prev_start_date_success', 
metadata_value='2023-11-01T16:59:31.105103+00:00'), 
MetadataHistoryRow(job_uuid='1265b19f9686db8427dfe3c7e4a47c27b805317c6e098a
6101511a7fea005726', metadata_key='airflow_dag_run_link', 
metadata_value='https://46c56b977f2b44158661f1ef150119c7-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-11-
02T02%3A57%3A35.601337%2B00%3A00&task_id=flax_resnet_imagenet-v3-
32.post_process.process_metrics')])]

4) set invalid TPU type, i.e. v4-33, and get job_status=2 (missed)

[2023-11-02, 03:29:51 UTC] {logging_mixin.py:150} INFO - Test run rows: 
[TestRun(job_history=JobHistoryRow(uuid='69bdc07f93970655d57879989f1cecc5259
d22f5267410d0fb80c7a78d8cad77', timestamp=datetime.datetime(2023, 11, 2, 3, 29, 51, 
241015), owner='Shiva S.', job_name='flax_resnet_imagenet-v4-33', job_status=2), 
metric_history=[], metadata_history=
[MetadataHistoryRow(job_uuid='69bdc07f93970655d57879989f1cecc5259d22f526741
0d0fb80c7a78d8cad77', metadata_key='run_id', metadata_value='manual__2023-11-
02T02:57:35.601337+00:00'), 
MetadataHistoryRow(job_uuid='69bdc07f93970655d57879989f1cecc5259d22f5267410
d0fb80c7a78d8cad77', metadata_key='prev_start_date_success', 
metadata_value='2023-11-01T16:59:31.105103+00:00'), 
MetadataHistoryRow(job_uuid='69bdc07f93970655d57879989f1cecc5259d22f5267410
d0fb80c7a78d8cad77', metadata_key='airflow_dag_run_link', 
metadata_value='https://46c56b977f2b44158661f1ef150119c7-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-11-
02T02%3A57%3A35.601337%2B00%3A00&task_id=flax_resnet_imagenet-v4-
33.post_process.process_metrics')])]

```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.