### PR TITLE
Add ViT convergence test on Flax

### DIFF
--- a/dags/xlml/solutionsTeam_flax_latest_supported.py
+++ b/dags/xlml/solutionsTeam_flax_latest_supported.py
@@ -87,12 +87,15 @@ with models.DAG(
       extraFlags=" ".join(jax_vit_v4_extra_flags),
   ).run()
 
-  jax_vit_v4_32 = flax_config.get_flax_vit_config(
+  jax_vit_v4_32_extra_flags = jax_vit_v4_extra_flags + [
+      "--model_name_or_path google/vit-base-patch16-224-in21k",
+  ]
+  jax_vit_v4_32 = flax_config.get_flax_vit_conv_config(
       tpu_version="4",
       tpu_cores=32,
       tpu_zone=vm_resource.Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      extraFlags=" ".join(jax_vit_v4_extra_flags),
+      extraFlags=" ".join(jax_vit_v4_32_extra_flags),
   ).run()
 
   # GPT2


### PR DESCRIPTION
# Description

Update ViT v4-32 on Flax as an convergence test example in XL ML (similar to benchmark tests).

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
* Test: [Link](https://screenshot.googleplex.com/6AhSnwWBmpBL89K)
* Dataset: [Link](https://screenshot.googleplex.com/dsVFZn9SKS3g3Qg)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.