### PR TITLE
Build JSonnet files as part of the postsubmit

### DIFF
--- a/pipeline/auto-push.cloudbuild.yml
+++ b/pipeline/auto-push.cloudbuild.yml
@@ -1,6 +1,22 @@
 steps:
-  - name: google/cloud-sdk
-    args:
-      - scripts/upload-tests.sh
-      - gs://us-central1-ml-automation-s-bc954647-bucket/dags
-    entrypoint: bash
+- name: golang:alpine
+  id: download-jsonnet
+  entrypoint: 'go'
+  args:
+  - 'install'
+  - 'github.com/google/go-jsonnet/cmd/jsonnet@latest'
+- name: golang:alpine
+  id: build-templates
+  entrypoint: sh
+  args:
+  - scripts/gen-configs.sh
+- name: google/cloud-sdk:slim
+  args:
+    - scripts/upload-tests.sh
+    - gs://us-central1-ml-automation-s-bc954647-bucket/dags
+  entrypoint: bash
+options:
+  machineType: E2_HIGHCPU_32
+  volumes:
+  - name: go-modules
+    path: /go

--- a/pipeline/auto-push.cloudbuild.yml
+++ b/pipeline/auto-push.cloudbuild.yml
@@ -3,8 +3,8 @@ steps:
   id: download-jsonnet
   entrypoint: 'go'
   args:
-  - 'install'
-  - 'github.com/google/go-jsonnet/cmd/jsonnet@latest'
+  - install
+  - github.com/google/go-jsonnet/cmd/jsonnet@latest
 - name: golang:alpine
   id: build-templates
   entrypoint: sh


### PR DESCRIPTION
# Description

Build the configs from the other repository before uploading configs to the DAGs bucket. Updated from an old snippet we used to use when we worked out of Cloud Source Repositories.

# Tests

Test run: http://shortn/_01mv8E9kv8

We can actually still run the postsubmit in less than a minute (vs ~3 minutes before) by using `slim`/`alpine` images to cut out overhead from image pulls.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.