### PR TITLE
Update pax test names

### DIFF
--- a/configs/xlml/jax/solutionsTeam_pax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsTeam_pax_latest_supported_config.py
@@ -28,6 +28,7 @@ def get_pax_lm_config(
     exp_path: str,
     model_name: str,
     log_dir: str,
+    pax_version: str = "stable",
     ckp_path: str = "",
     extraFlags: str = "",
 ) -> task.TpuTask:
@@ -56,7 +57,7 @@ def get_pax_lm_config(
           runtime_version=vm_resource.RuntimeVersion.TPU_VM_V4_BASE.value,
           reserved=True,
       ),
-      test_name=f"pax_{model_name}_c4",
+      test_name=f"pax_{pax_version}_{model_name}",
       set_up_cmds=set_up_cmds,
       run_model_cmds=run_model_cmds,
       time_out_in_min=time_out_in_min,


### PR DESCRIPTION
# Description

Currently pax stable tests are [running fine](https://screenshot.googleplex.com/9AYsxQJCBydH6oL). A minor change to update test names with `stable` to be consistent with existing tests:
* Add pax version - stable
* Remove unexpected `_c4` 

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and check names

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test [link](https://screenshot.googleplex.com/548BCegZbzLTYZy)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.