### PR TITLE
Enable docker image feature with xpk

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -2,6 +2,8 @@ apache-airflow-providers-sendgrid
 fabric
 google-cloud-bigquery
 google-cloud-storage
+google-cloud-container
 google-cloud-tpu>=1.16.0
 jsonlines
 tensorflow-cpu
+apache-airflow-providers-cncf-kubernetes

--- a/configs/benchmark/jax/solutionsteam_jax_npi_config.py
+++ b/configs/benchmark/jax/solutionsteam_jax_npi_config.py
@@ -25,7 +25,7 @@ def get_jax_vit_config(
     tpu_cores: int,
     tpu_zone: str,
     time_out_in_min: int,
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
       zone=tpu_zone,
@@ -99,7 +99,7 @@ def get_jax_vit_config(
       )
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,

--- a/configs/benchmark/pytorch/pytorchxla_torchbench_config.py
+++ b/configs/benchmark/pytorch/pytorchxla_torchbench_config.py
@@ -70,7 +70,7 @@ def get_torchbench_config(
     time_out_in_min: int,
     model_name: str = "",
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
       zone=tpu_zone,
@@ -114,7 +114,7 @@ def get_torchbench_config(
       )
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,

--- a/configs/example/xpk_example_config.py
+++ b/configs/example/xpk_example_config.py
@@ -1,0 +1,58 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to construct configs for example_dag."""
+
+from apis import gcp_config, metric_config, task, test_config
+from configs import test_owner, vm_resource
+
+
+def get_flax_resnet_xpk_config(
+    tpu_version: str,
+    tpu_cores: int,
+    tpu_zone: str,
+    cluster_name: str,
+    docker_image: str,
+    time_out_in_min: int,
+) -> task.TpuXpkTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  run_model_cmds = (
+      "python3 /tmp/flax/examples/imagenet/main.py"
+      " --config=/tmp/flax/examples/imagenet/configs/tpu.py"
+      " --workdir=/tmp/imagenet --config.num_epochs=1"
+  )
+
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+      ),
+      test_name="flax-resnet-xpk-example",
+      cluster_name=cluster_name,
+      docker_image=docker_image,
+      run_model_cmds=run_model_cmds,
+      set_up_cmds=None,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.RAN_R,
+  )
+
+  return task.TpuXpkTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+  )

--- a/configs/vm_resource.py
+++ b/configs/vm_resource.py
@@ -32,3 +32,14 @@ class RuntimeVersion(enum.Enum):
   TPU_VM_TF_NIGHTLY_POD = "tpu-vm-tf-nightly-pod"
   TPU_UBUNTU2204_BASE = "tpu-ubuntu2204-base"
   TPU_VM_V4_BASE = "tpu-vm-v4-base"
+
+
+class ClusterName(enum.Enum):
+  V4_8_CLUSTER = "mas-v4-8"
+  V4_32_CLUSTER = "mas-v4-32"
+  V5E_4_CLUSTER = "mas-v5e-4"
+  V5E_16_CLUSTER = "mas-v5e-16"
+
+
+class DockerImage(enum.Enum):
+  XPK_JAX_TEST = "gcr.io/cloud-ml-auto-solutions/xpk_jax_test:latest"

--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -33,7 +33,7 @@ def get_flax_resnet_config(
     time_out_in_min: int,
     data_dir: str = gcs_bucket.TFDS_DATA_DIR,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -66,7 +66,7 @@ def get_flax_resnet_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
@@ -110,7 +110,7 @@ def get_flax_vit_config(
     time_out_in_min: int,
     num_train_epochs: int = 3,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -134,7 +134,7 @@ def get_flax_vit_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
@@ -147,7 +147,7 @@ def get_flax_vit_conv_config(
     time_out_in_min: int,
     num_train_epochs: int = 30,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -191,7 +191,7 @@ def get_flax_vit_conv_config(
       )
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
@@ -204,7 +204,7 @@ def get_flax_gpt2_config(
     tpu_zone: str,
     time_out_in_min: int,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -252,7 +252,7 @@ def get_flax_gpt2_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
@@ -265,7 +265,7 @@ def get_flax_sd_config(
     time_out_in_min: int,
     num_train_epochs: int,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -307,7 +307,7 @@ def get_flax_sd_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
@@ -319,7 +319,7 @@ def get_flax_bart_config(
     tpu_zone: str,
     time_out_in_min: int,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -358,7 +358,7 @@ def get_flax_bart_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
@@ -372,7 +372,7 @@ def get_flax_bert_config(
     task_name: str,
     num_train_epochs: int = 1,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -408,7 +408,7 @@ def get_flax_bert_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
@@ -422,7 +422,7 @@ def get_flax_wmt_config(
     num_train_steps: int,
     data_dir: str = gcs_bucket.TFDS_DATA_DIR,
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=PROJECT_NAME,
       zone=tpu_zone,
@@ -461,7 +461,7 @@ def get_flax_wmt_config(
       task_owner=test_owner.SHIVA_S,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )

--- a/configs/xlml/pax/solutionsteam_pax_supported_config.py
+++ b/configs/xlml/pax/solutionsteam_pax_supported_config.py
@@ -95,7 +95,7 @@ def get_pax_lm_config(
     pax_version: PaxVersion = PaxVersion.STABLE,
     ckp_path: str = "",
     extraFlags: str = "",
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
       zone=tpu_zone,
@@ -127,7 +127,7 @@ def get_pax_lm_config(
       task_owner=test_owner.GERSON_K,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )

--- a/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -30,7 +30,7 @@ def get_tf_resnet_config(
     tfds_data_dir: str = gcs_bucket.TFDS_DATA_DIR,
     train_steps: int = 320,
     validation_interval: int = 320,
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
       zone=tpu_zone,
@@ -84,7 +84,7 @@ def get_tf_resnet_config(
       task_owner=test_owner.CHANDRA_D,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       custom_tpu_name=tpu_name,
@@ -103,7 +103,7 @@ def get_tf_bert_config(
     tfds_data_dir: str = gcs_bucket.TFDS_DATA_DIR,
     train_steps: int = 2000,
     validation_interval: int = 1000,
-) -> task.TpuTask:
+) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
       zone=tpu_zone,
@@ -165,7 +165,7 @@ def get_tf_bert_config(
       task_owner=test_owner.CHANDRA_D,
   )
 
-  return task.TpuTask(
+  return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       custom_tpu_name=tpu_name,

--- a/dags/example/xpk_example_dag.py
+++ b/dags/example/xpk_example_dag.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run all GKE examples."""
+
+import datetime
+from airflow import models
+from configs import vm_resource
+from configs.example import xpk_example_config as config
+
+
+# TODO(ranran): add following examples:
+# 1) jax_resnet_tpu_qr (diff dag)
+# 2) jax_vit_tpu_qr_benchmark (diff dag)
+# 3) jax_vit_tpu_xpk_benchmark (same dag)
+with models.DAG(
+    dag_id="gke_example_dag",
+    schedule=None,
+    tags=["example", "gke", "xlml", "benchmark"],
+    start_date=datetime.datetime(2023, 11, 29),
+    catchup=False,
+) as dag:
+  jax_resnet_tpu_xpk = config.get_flax_resnet_xpk_config(
+      tpu_version="4",
+      tpu_cores=8,
+      tpu_zone=vm_resource.Zone.US_CENTRAL2_B.value,
+      cluster_name=vm_resource.ClusterName.V4_8_CLUSTER.value,
+      docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
+      time_out_in_min=60,
+  ).run()

--- a/dags/xlml/pytorchxla_huggingface.py
+++ b/dags/xlml/pytorchxla_huggingface.py
@@ -39,19 +39,19 @@ with models.DAG(
     start_date=datetime.datetime(2023, 7, 12),
     catchup=False,
 ):
-  accelerate_v2_8 = task.TpuTask(
+  accelerate_v2_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-accelerate-smoke-v2-8-1vm"
       ),
       US_CENTRAL1_C,
   ).run()
-  accelerate_v4_8 = task.TpuTask(
+  accelerate_v4_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-accelerate-smoke-v4-8-1vm"
       ),
       US_CENTRAL2_B,
   ).run()
-  diffusers_v4_8 = task.TpuTask(
+  diffusers_v4_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-hf-diffusers-func-v4-8-1vm"
       ),
@@ -61,7 +61,7 @@ with models.DAG(
   accelerate_v4_8 >> accelerate_v2_8
   accelerate_v4_8 >> diffusers_v4_8
 
-  task.TpuTask(
+  task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-hf-fsmt-pjrt-func-v4-8-1vm"
       ),

--- a/dags/xlml/pytorchxla_llama.py
+++ b/dags/xlml/pytorchxla_llama.py
@@ -33,13 +33,13 @@ with models.DAG(
     start_date=datetime.datetime(2023, 7, 12),
     catchup=False,
 ):
-  llama_inference_v4_8 = task.TpuTask(
+  llama_inference_v4_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-llama2-pjrt-infer-func-v4-8-1vm-1vm"
       ),
       US_CENTRAL2_B,
   ).run()
-  llama_train_v4_8 = task.TpuTask(
+  llama_train_v4_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-llama2-pjrt-train-spmd-func-v4-8-1vm-1vm"
       ),

--- a/dags/xlml/pytorchxla_torchvision.py
+++ b/dags/xlml/pytorchxla_torchvision.py
@@ -39,19 +39,19 @@ with models.DAG(
     start_date=datetime.datetime(2023, 7, 12),
     catchup=False,
 ):
-  mnist_v2_8 = task.TpuTask(
+  mnist_v2_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-mnist-pjrt-func-v2-8-1vm"
       ),
       US_CENTRAL1_C,
   ).run()
-  resnet_v2_8 = task.TpuTask(
+  resnet_v2_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-resnet50-pjrt-fake-v2-8-1vm"
       ),
       US_CENTRAL1_C,
   ).run()
-  resnet_v4_8 = task.TpuTask(
+  resnet_v4_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-resnet50-pjrt-fake-v4-8-1vm"
       ),

--- a/dags/xlml/solutionsTeam_jax_integration.py
+++ b/dags/xlml/solutionsTeam_jax_integration.py
@@ -39,21 +39,21 @@ with models.DAG(
     start_date=datetime.datetime(2023, 7, 12),
     catchup=False,
 ):
-  compilation_cache = task.TpuTask(
+  compilation_cache = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
           "jax-compilation-cache-test-func-v2-8-1vm"
       ),
       US_CENTRAL1_C,
   ).run()
 
-  pod_latest = task.TpuTask(
+  pod_latest = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
           "jax-pod-latest-tpu-ubuntu2204-base-func-v2-32-1vm"
       ),
       US_CENTRAL1_A,
   ).run()
 
-  pod_head = task.TpuTask(
+  pod_head = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
           "jax-pod-head-tpu-ubuntu2204-base-func-v2-32-1vm"
       ),

--- a/dags/xlml/solutionsteam_jax_latest_integration.py
+++ b/dags/xlml/solutionsteam_jax_latest_integration.py
@@ -39,13 +39,13 @@ with models.DAG(
     start_date=datetime.datetime(2023, 7, 12),
     catchup=False,
 ):
-  compilation_cache = task.TpuTask(
+  compilation_cache = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
           "jax-compilation-cache-test-func-v2-8-1vm"
       ),
       US_CENTRAL1_C,
   ).run()
-  pod = task.TpuTask(
+  pod = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
           "jax-pod-latest-tpu-ubuntu2204-base-func-v2-32-1vm"
       ),

--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -112,7 +112,9 @@ resource "google_composer_environment" "example_environment" {
         # See https://cloud.google.com/composer/docs/concepts/versioning/composer-versions
         # google-cloud-bigquery             = ""
         # google-cloud-storage              = ""
+        # google-cloud-container            = ""
         # tensorflow-cpu                    = ""
+        # apache-airflow-providers-cncf-kubernetes = ""
       }
     }
 

--- a/implementations/utils/xpk.py
+++ b/implementations/utils/xpk.py
@@ -1,0 +1,133 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to run workloads with xpk (https://github.com/google/xpk)."""
+
+import base64
+from tempfile import NamedTemporaryFile
+import uuid
+from absl import logging
+from airflow.decorators import task
+from airflow.hooks.subprocess import SubprocessHook
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from configs import vm_resource
+import google.auth
+import google.auth.transport.requests
+from google.cloud import container_v1
+from kubernetes import client as k8s_client
+
+
+@task
+def generate_workload_id(benchmark_id: str) -> str:
+  """Generate a workload ID."""
+  short_id = str(uuid.uuid4())[:8]
+  return f"{benchmark_id}-{short_id}"
+
+
+def run_workload(
+    task_id: str,
+    project_id: str,
+    zone: str,
+    cluster_name: str,
+    benchmark_id: str,
+    workload_id: str,
+    docker_image: str,
+    accelerator_type: str,
+    run_cmds: str,
+    task_owner: str,
+    num_slices: int = 1,
+) -> KubernetesPodOperator:
+  """Run workload through xpk tool.
+
+  The reason to use KubernetesPodOperator instead of BashOperator is that
+  xpk must run with Python 3.10 or greater; however, the latest version in
+  Composer is Python 3.8, and it's non-trivial to upgrade it as the  Composer
+  uses docker images that bundle Airflow releases with Python and other
+  libraries.
+  """
+
+  cmds = (
+      "set -x",
+      f"gcloud config set project {project_id}",
+      f"gcloud config set compute/zone {zone}",
+      "git clone https://github.com/google/xpk.git /tmp/xpk",
+      "cd /tmp/xpk",
+      (
+          "python3 xpk.py workload create"
+          f" --cluster={cluster_name} --workload={workload_id} --command='{run_cmds}'"
+          f" --tpu-type={accelerator_type} --num-slices={num_slices} --docker-image={docker_image}"
+      ),
+  )
+
+  return KubernetesPodOperator(
+      task_id=task_id,
+      name=benchmark_id,
+      cmds=["/bin/bash", "-c"],
+      arguments=[";".join(cmds)],
+      namespace="composer-user-workloads",
+      image=docker_image,
+      config_file="/home/airflow/composer_kube_config",
+      kubernetes_conn_id="kubernetes_default",
+      owner=task_owner,
+  )
+
+
+@task.sensor(poke_interval=60, timeout=600, mode="reschedule")
+def wait_for_workload_completion(
+    workload_id: str, project_id: str, region: str, cluster_name: str
+) -> bool:
+  """Check the workload status."""
+
+  # Get cluster configuration
+  container_client = container_v1.ClusterManagerClient()
+  cluster_path = (
+      f"projects/{project_id}/locations/{region}/clusters/{cluster_name}"
+  )
+  response = container_client.get_cluster(name=cluster_path)
+  creds, _ = google.auth.default()
+  auth_req = google.auth.transport.requests.Request()
+  creds.refresh(auth_req)
+  configuration = k8s_client.Configuration()
+  configuration.host = f"https://{response.endpoint}"
+  with NamedTemporaryFile(delete=False) as ca_cert:
+    ca_cert.write(base64.b64decode(response.master_auth.cluster_ca_certificate))
+  configuration.ssl_ca_cert = ca_cert.name
+  configuration.api_key_prefix["authorization"] = "Bearer"
+  configuration.api_key["authorization"] = creds.token
+
+  # Initilize the client
+  core_api = k8s_client.CoreV1Api(k8s_client.ApiClient(configuration))
+  logging.info("Successful initilize k8s client from cluster response.")
+
+  # Get pods for the workload
+  logging.info(f"Getting pods for workload_id: {workload_id}")
+  pods = core_api.list_namespaced_pod(
+      label_selector=f"jobset.sigs.k8s.io/jobset-name={workload_id}",
+      namespace="default",
+  )
+
+  # Check status of pods
+  if not pods.items:
+    RuntimeError(f"No pod is found for workload selector: {pods}.")
+  print(f"pods: {pods}")
+
+  for pod in pods.items:
+    if pod.status.phase in ["Pending", "Running"]:
+      logging.info(f"One pod phase is: {pod.status.phase}")
+      return False
+    elif pod.status.phase in ["Failed", "Unknown"]:
+      RuntimeError(f"Bad pod phase: {pod.status.phase}")
+
+  logging.info("All pod(s) phase are succeeded.")
+  return True


### PR DESCRIPTION
# Description

Original [PR](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/28).

Enable docker image feature with xpk:
* Add this as an GKE example, and plan to add more examples for quick start
* Add `TpuXpkTask` to execute run_model and post_process task groups 
* Add cluster configs under `configs/cluster` folder, so Airflow has the access to the created cluster with TPUs. It seems `certificate-authority-data` is safe to share based on this stackoverflow [thread](https://stackoverflow.com/questions/71444145/should-the-k8s-cluster-certificate-authority-be-kept-secret).
* Update `TpuTask` to `TpuQueuedResourceTask` to distinguish `TpuXpkTask`, and similar for test config

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
* Upload codes to GCS bucket and test

**List links for your tests (use go/shortn-gen for any internal link):** ...
* Airflow test: [link](https://screenshot.googleplex.com/4uVjRBGjNY5B6Q5)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.