### PR TITLE
Enable xpk with multislice tests

### DIFF
--- a/apis/gcp_config.py
+++ b/apis/gcp_config.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 from apis import metric_config
+from typing import Optional
 
 
 @dataclasses.dataclass
@@ -23,11 +24,15 @@ class GCPConfig:
   """This is a class to set up configs of GCP.
 
   Attributes:
-    project_name: The name of a project to run a test job.
+    project_name: The name of a project for Composer env to run a test job.
     zone: The zone to run a test job.
-    dataset_name: The option of dataset for metrics
+    dataset_name: The option of dataset for metrics.
+    cluster_project: The project of a cluster, i.e. a cluster running xpk workloads.
+    cluster_name: The name of a cluster that has provisioned resources.
   """
 
   project_name: str
   zone: str
   dataset_name: metric_config.DatasetOption
+  cluster_project: Optional[str] = None
+  cluster_name: Optional[str] = None

--- a/apis/task.py
+++ b/apis/task.py
@@ -223,9 +223,9 @@ class TpuXpkTask(BaseTask):
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
       run_workload = xpk.run_workload(
           task_id="run_workload",
-          project_id=self.task_gcp_config.project_name,
+          cluster_project=self.task_gcp_config.cluster_project,
           zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
+          cluster_name=self.task_gcp_config.cluster_name,
           benchmark_id=self.task_test_config.benchmark_id,
           workload_id=workload_id,
           docker_image=self.task_test_config.docker_image,
@@ -238,9 +238,9 @@ class TpuXpkTask(BaseTask):
           timeout=self.task_test_config.time_out_in_min * 60,
       )(
           workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
+          project_id=self.task_gcp_config.cluster_project,
           region=self.task_gcp_config.zone[:-2],
-          cluster_name=self.task_test_config.cluster_name,
+          cluster_name=self.task_gcp_config.cluster_name,
       )
 
       workload_id >> run_workload >> wait_for_workload_completion

--- a/apis/test_config.py
+++ b/apis/test_config.py
@@ -161,7 +161,6 @@ class TpuGkeTest(TestConfig[Tpu]):
 
   Attributes:
     test_name: Unique name for this test/model.
-    cluster_name: Name of the cluster that has provisioned TPUs.
     docker_image: Image of the docker to run.
     set_up_cmds: List of commands to run once when TPU is created.
     run_model_cmds: List of commands to run the model under test.
@@ -169,7 +168,6 @@ class TpuGkeTest(TestConfig[Tpu]):
   """
 
   test_name: str
-  cluster_name: str
   docker_image: str
   set_up_cmds: Iterable[str]
   run_model_cmds: Iterable[str]

--- a/configs/benchmark/pytorch/pytorchxla_torchbench_config.py
+++ b/configs/benchmark/pytorch/pytorchxla_torchbench_config.py
@@ -72,7 +72,7 @@ def get_torchbench_config(
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      project_name=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.BENCHMARK_DATASET,
   )

--- a/configs/example/xpk.Dockerfile
+++ b/configs/example/xpk.Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for xpk examples in xpk_example_dag.py,
+# and is saved at gcr.io/cloud-ml-auto-solutions/xpk_jax_test:latest.
+FROM python:3.10
+RUN pip install --upgrade pip
+RUN pip install "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+RUN pip install --no-cache-dir --upgrade clu tensorflow tensorflow-datasets
+RUN git clone https://github.com/google/flax.git /tmp/flax
+RUN pip install --no-cache-dir flax
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+RUN mkdir -p /usr/local/gcloud \
+  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+RUN gcloud components install kubectl
+RUN gcloud components install gke-gcloud-auth-plugin
+ENV TFDS_DATA_DIR=gs://xl-ml-test-us-central2/tfds-data
+ENV JAX_PLATFORM_NAME=TPU

--- a/configs/example/xpk_example_config.py
+++ b/configs/example/xpk_example_config.py
@@ -22,14 +22,19 @@ def get_flax_resnet_xpk_config(
     tpu_version: str,
     tpu_cores: int,
     tpu_zone: str,
+    test_name: str,
+    cluster_project: str,
     cluster_name: str,
     docker_image: str,
     time_out_in_min: int,
+    num_slices: int = 1,
 ) -> task.TpuXpkTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      project_name=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
+      cluster_project=cluster_project,
+      cluster_name=cluster_name,
   )
 
   run_model_cmds = (
@@ -43,13 +48,13 @@ def get_flax_resnet_xpk_config(
           version=tpu_version,
           cores=tpu_cores,
       ),
-      test_name="flax-resnet-xpk-example",
-      cluster_name=cluster_name,
+      test_name=test_name,
       docker_image=docker_image,
       run_model_cmds=run_model_cmds,
       set_up_cmds=None,
       time_out_in_min=time_out_in_min,
       task_owner=test_owner.RAN_R,
+      num_slices=num_slices,
   )
 
   return task.TpuXpkTask(

--- a/configs/vm_resource.py
+++ b/configs/vm_resource.py
@@ -17,7 +17,9 @@
 import enum
 
 
-PROJECT_CLOUD_ML_AUTO_SOLUTIONS = "cloud-ml-auto-solutions"
+class Project(enum.Enum):
+  CLOUD_ML_AUTO_SOLUTIONS = "cloud-ml-auto-solutions"
+  TPU_PROD_ENV_MULTIPOD = "tpu-prod-env-multipod"
 
 
 class Zone(enum.Enum):
@@ -41,6 +43,9 @@ class ClusterName(enum.Enum):
   V4_32_CLUSTER = "mas-v4-32"
   V5E_4_CLUSTER = "mas-v5e-4"
   V5E_16_CLUSTER = "mas-v5e-16"
+  V4_128_MULTISLICE_CLUSTER = "v4-bodaborg"
+  V5E_16_MULTISLICE_CLUSTER = "v5e-16-bodaborg"
+  V5E_256_MULTISLICE_CLUSTER = "v5e-256-bodaborg"
 
 
 class DockerImage(enum.Enum):

--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -21,7 +21,7 @@ from configs import gcs_bucket, test_owner, vm_resource
 from configs.xlml.jax import common
 
 
-PROJECT_NAME = vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS
+PROJECT_NAME = vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value
 RUNTIME_IMAGE = vm_resource.RuntimeVersion.TPU_UBUNTU2204_BASE.value
 IS_TPU_RESERVED = True
 

--- a/configs/xlml/pax/solutionsteam_pax_supported_config.py
+++ b/configs/xlml/pax/solutionsteam_pax_supported_config.py
@@ -91,7 +91,7 @@ def get_pax_lm_config(
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      project_name=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )

--- a/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -32,7 +32,7 @@ def get_tf_resnet_config(
     validation_interval: int = 320,
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      project_name=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
@@ -104,7 +104,7 @@ def get_tf_bert_config(
     validation_interval: int = 1000,
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      project_name=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )

--- a/dags/example/xpk_example_dag.py
+++ b/dags/example/xpk_example_dag.py
@@ -31,11 +31,25 @@ with models.DAG(
     start_date=datetime.datetime(2023, 11, 29),
     catchup=False,
 ) as dag:
-  jax_resnet_tpu_xpk = config.get_flax_resnet_xpk_config(
+  flax_resnet_tpu_singleslice_v4_8 = config.get_flax_resnet_xpk_config(
       tpu_version="4",
       tpu_cores=8,
       tpu_zone=vm_resource.Zone.US_CENTRAL2_B.value,
+      test_name="resnet-single-slice",
+      cluster_project=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
       cluster_name=vm_resource.ClusterName.V4_8_CLUSTER.value,
       docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
       time_out_in_min=60,
+  ).run()
+
+  flax_resnet_tpu_multislice_v4_128 = config.get_flax_resnet_xpk_config(
+      tpu_version="4",
+      tpu_cores=128,
+      tpu_zone=vm_resource.Zone.US_CENTRAL2_B.value,
+      test_name="resnet-multi-slice",
+      cluster_project=vm_resource.Project.TPU_PROD_ENV_MULTIPOD.value,
+      cluster_name=vm_resource.ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+      docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
+      time_out_in_min=60,
+      num_slices=4,
   ).run()

--- a/dags/xlml/pytorchxla_huggingface.py
+++ b/dags/xlml/pytorchxla_huggingface.py
@@ -21,12 +21,12 @@ from configs import composer_env, vm_resource
 # Run once a day at 10 pm UTC (2 pm PST)
 SCHEDULED_TIME = "0 22 * * *" if composer_env.is_prod_env() else None
 US_CENTRAL1_C = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL1_C.value,
     metric_config.DatasetOption.XLML_DATASET,
 )
 US_CENTRAL2_B = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL2_B.value,
     metric_config.DatasetOption.XLML_DATASET,
 )

--- a/dags/xlml/pytorchxla_llama.py
+++ b/dags/xlml/pytorchxla_llama.py
@@ -20,7 +20,7 @@ from configs import composer_env, vm_resource
 # Run once a day at 6 pm UTC (10 am PST)
 SCHEDULED_TIME = "0 18 * * *" if composer_env.is_prod_env() else None
 US_CENTRAL2_B = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL2_B.value,
     metric_config.DatasetOption.XLML_DATASET,
 )

--- a/dags/xlml/pytorchxla_torchvision.py
+++ b/dags/xlml/pytorchxla_torchvision.py
@@ -21,12 +21,12 @@ from configs import composer_env, vm_resource
 # Run once a day at 2 pm UTC (6 am PST)
 SCHEDULED_TIME = "0 14 * * *" if composer_env.is_prod_env() else None
 US_CENTRAL1_C = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL1_C.value,
     metric_config.DatasetOption.XLML_DATASET,
 )
 US_CENTRAL2_B = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL2_B.value,
     metric_config.DatasetOption.XLML_DATASET,
 )

--- a/dags/xlml/solutionsteam_jax_integration.py
+++ b/dags/xlml/solutionsteam_jax_integration.py
@@ -21,12 +21,12 @@ from configs import composer_env, vm_resource
 # Run once a day at 10 am UTC (2 am PST)
 SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 US_CENTRAL1_A = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL1_A.value,
     metric_config.DatasetOption.XLML_DATASET,
 )
 US_CENTRAL1_C = gcp_config.GCPConfig(
-    vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     vm_resource.Zone.US_CENTRAL1_C.value,
     metric_config.DatasetOption.XLML_DATASET,
 )

--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -83,6 +83,14 @@ resource "google_project_iam_member" "vertex_ai_admin_role" {
   role     = "roles/aiplatform.admin"
 }
 
+resource "google_project_iam_member" "artifactr_registry_admin_role" {
+  provider = google-beta
+  for_each = local.environment_config_dict
+  project  = var.project_config.project_name
+  member   = format("serviceAccount:%s", google_service_account.custom_service_account[each.key].email)
+  role     = "roles/artifactregistry.admin"
+}
+
 resource "google_service_account_iam_member" "custom_service_account" {
   provider           = google-beta
   for_each           = local.environment_config_dict

--- a/implementations/utils/metric.py
+++ b/implementations/utils/metric.py
@@ -501,7 +501,7 @@ def process_metrics(
       task_gcp_config.project_name, task_gcp_config.dataset_name.value
   )
 
-  if hasattr(task_test_config, "cluster_name"):
+  if task_gcp_config.cluster_name:
     test_job_status = get_gke_job_status(task_test_config.benchmark_id)
   else:
     test_job_status = get_gce_job_status(task_test_config.benchmark_id)


### PR DESCRIPTION
# Description

Enable Multislice ResNet test with xpk.
* Update helper `xpk_example_config.py` to pass `num_slices` and `cluster_project`
* Add `xpk.Dockerfile` to example config folder
* Move `cluster_project` and `cluster_name` to GCP config 
* Other small refactor

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test in project `cloud-ml-auto-solutions`

**List links for your tests (use go/shortn-gen for any internal link):** ...
Airflow UI: link.

The workload has been added to the queue. Unfortunately, I didn't get a chance to get a successful run, as they are blocked by other jobs.

```
resnet-multi-slice-v4-128-78a3e88d         2023-12-12T01:27:13Z   medium     64               <none>                <none>         Admitted   couldn't assign flavors to pod set slice-job: insufficient unused quota for google.com/tpu in flavor 4xv4-128, 128 more needed   2023-12-12T01:27:13Z
```



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.