### PR TITLE
Enable Flax ResNet on v5e and v5p

### DIFF
--- a/apis/gcp_config.py
+++ b/apis/gcp_config.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 from apis import metric_config
+from configs import vm_resource
 
 
 @dataclasses.dataclass
@@ -23,11 +24,13 @@ class GCPConfig:
   """This is a class to set up configs of GCP.
 
   Attributes:
-    project_name: The name of a project to run a test job.
-    zone: The zone to run a test job.
-    dataset_name: The option of dataset for metrics
+    project_name: The name of a project to provision resource and run a test job.
+    zone: The zone to provision resource and run a test job.
+    dataset_name: The option of dataset for metrics.
+    composer_project: The name of a project that hosts the composer env.
   """
 
   project_name: str
   zone: str
   dataset_name: metric_config.DatasetOption
+  composer_project: str = vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS

--- a/configs/vm_resource.py
+++ b/configs/vm_resource.py
@@ -17,7 +17,9 @@
 import enum
 
 
+# TODO(ranran): update to enum class (this change has been included in an on-going PR)
 PROJECT_CLOUD_ML_AUTO_SOLUTIONS = "cloud-ml-auto-solutions"
+PROJECT_TPU_PROD_ENV_AUTOMATED = "tpu-prod-env-automated"
 
 
 class Zone(enum.Enum):
@@ -26,7 +28,9 @@ class Zone(enum.Enum):
       "us-central2-b"
   )
   US_CENTRAL1_C = "us-central1-c"  # reservation for v2-8 in cloud-ml-auto-solutions
+  US_EAST1_C = "us-east1-c"  # reservation for v5e in tpu-prod-env-automated
   US_EAST1_D = "us-east1-d"  # reservation for v3-8 & v3-32 in cloud-ml-auto-solutions
+  US_EAST5_A = "us-east5-a"  # reservation for v5p in tpu-prod-env-automated
 
 
 class RuntimeVersion(enum.Enum):
@@ -34,6 +38,8 @@ class RuntimeVersion(enum.Enum):
   TPU_VM_TF_NIGHTLY_POD = "tpu-vm-tf-nightly-pod"
   TPU_UBUNTU2204_BASE = "tpu-ubuntu2204-base"
   TPU_VM_V4_BASE = "tpu-vm-v4-base"
+  V2_ALPHA_TPUV5_LITE = "v2-alpha-tpuv5-lite"
+  V2_ALPHA_TPUV5 = "v2-alpha-tpuv5"
 
 
 class ClusterName(enum.Enum):

--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -32,10 +32,14 @@ def get_flax_resnet_config(
     tpu_zone: str,
     time_out_in_min: int,
     data_dir: str = gcs_bucket.TFDS_DATA_DIR,
+    project_name: str = PROJECT_NAME,
+    runtime_version: str = RUNTIME_IMAGE,
+    network: str = "default",
+    subnetwork: str = "default",
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=PROJECT_NAME,
+      project_name=project_name,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
@@ -56,8 +60,10 @@ def get_flax_resnet_config(
       test_config.Tpu(
           version=tpu_version,
           cores=tpu_cores,
-          runtime_version=RUNTIME_IMAGE,
+          runtime_version=runtime_version,
           reserved=IS_TPU_RESERVED,
+          network=network,
+          subnetwork=subnetwork,
       ),
       test_name="flax_resnet_imagenet",
       set_up_cmds=set_up_cmds,

--- a/dags/xlml/solutionsteam_flax_latest_supported.py
+++ b/dags/xlml/solutionsteam_flax_latest_supported.py
@@ -22,6 +22,10 @@ from configs.xlml.jax import solutionsteam_flax_latest_supported_config as flax_
 
 # Run once a day at 2 am UTC (6 pm PST)
 SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
+NETWORK_PREFIX = "projects/tpu-prod-env-automated"
+V5_NETWORKS = f"{NETWORK_PREFIX}/global/networks/mas-test"
+V5E_SUBNETWORKS = f"{NETWORK_PREFIX}/regions/us-east1/subnetworks/mas-test"
+V5P_SUBNETWORKS = f"{NETWORK_PREFIX}/regions/us-east5/subnetworks/mas-test"
 
 
 with models.DAG(
@@ -71,6 +75,50 @@ with models.DAG(
       tpu_version="4",
       tpu_cores=32,
       tpu_zone=vm_resource.Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+  ).run()
+
+  jax_resnet_v5e_4 = flax_config.get_flax_resnet_config(
+      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      tpu_version="5litepod",
+      tpu_cores=4,
+      tpu_zone=vm_resource.Zone.US_EAST1_C.value,
+      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
+      network=V5_NETWORKS,
+      subnetwork=V5E_SUBNETWORKS,
+      time_out_in_min=60,
+  ).run()
+
+  jax_resnet_v5e_16 = flax_config.get_flax_resnet_config(
+      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      tpu_version="5litepod",
+      tpu_cores=16,
+      tpu_zone=vm_resource.Zone.US_EAST1_C.value,
+      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
+      network=V5_NETWORKS,
+      subnetwork=V5E_SUBNETWORKS,
+      time_out_in_min=60,
+  ).run()
+
+  jax_resnet_v5p_8 = flax_config.get_flax_resnet_config(
+      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      tpu_version="5p",
+      tpu_cores=8,
+      tpu_zone=vm_resource.Zone.US_EAST5_A.value,
+      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5.value,
+      network=V5_NETWORKS,
+      subnetwork=V5E_SUBNETWORKS,
+      time_out_in_min=60,
+  ).run()
+
+  jax_resnet_v5p_32 = flax_config.get_flax_resnet_config(
+      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      tpu_version="5p",
+      tpu_cores=32,
+      tpu_zone=vm_resource.Zone.US_EAST5_A.value,
+      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5.value,
+      network=V5_NETWORKS,
+      subnetwork=V5E_SUBNETWORKS,
       time_out_in_min=60,
   ).run()
 
@@ -227,6 +275,8 @@ with models.DAG(
   jax_resnet_v2_8 >> jax_resnet_v2_32
   jax_resnet_v3_8 >> jax_resnet_v3_32
   jax_resnet_v4_8 >> jax_resnet_v4_32
+  jax_resnet_v5e_4 >> jax_resnet_v5e_16
+  jax_resnet_v5p_8 >> jax_resnet_v5p_32
   jax_vit_v4_8 >> jax_vit_v4_32
   jax_gpt2_v4_8 >> jax_gpt2_v4_32
   jax_sd_v4_8 >> jax_sd_v4_32

--- a/implementations/utils/metric.py
+++ b/implementations/utils/metric.py
@@ -481,7 +481,7 @@ def process_metrics(
 
   # add default airflow metadata
   metadata_history_rows_list = add_airflow_metadata(
-      base_id, task_gcp_config.project_name, metadata_history_rows_list
+      base_id, task_gcp_config.composer_project, metadata_history_rows_list
   )
 
   # append profile metrics to metric_history_rows_list if any


### PR DESCRIPTION
# Description

Enable Flax ResNet on v5e and v5p:
* Capacities for both v5e and v5p are in project `tpu-prod-env-automated`
* Currently I manually set up VPC peering and firewall rules to unblock PT test release, but we should do it in Terraform for management

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Tests for v5e and v5p pass: [link](https://screenshot.googleplex.com/47dfSQJCw7Dbt4J)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.