### PR TITLE
Add dataset project attribute

### DIFF
--- a/apis/gcp_config.py
+++ b/apis/gcp_config.py
@@ -27,10 +27,12 @@ class GCPConfig:
     project_name: The name of a project to provision resource and run a test job.
     zone: The zone to provision resource and run a test job.
     dataset_name: The option of dataset for metrics.
+    dataset_project: The name of a project that hosts the dataset.
     composer_project: The name of a project that hosts the composer env.
   """
 
   project_name: str
   zone: str
   dataset_name: metric_config.DatasetOption
+  dataset_project: str = vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS
   composer_project: str = vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS

--- a/implementations/utils/metric.py
+++ b/implementations/utils/metric.py
@@ -498,7 +498,7 @@ def process_metrics(
 
   test_run_rows = []
   bigquery_metric = bigquery.BigQueryMetricClient(
-      task_gcp_config.project_name, task_gcp_config.dataset_name.value
+      task_gcp_config.dataset_project, task_gcp_config.dataset_name.value
   )
 
   if hasattr(task_test_config, "cluster_name"):


### PR DESCRIPTION
# Description

Add dataset project attribute, so customers are able to specify which project to store the data. By default, use datasets in `cloud-ml-auto-solutions`.

In v5 cases, both composer env and database are hosted in `cloud-ml-auto-solutions`, and machines are provisioned in project `tpu-prod-env-automated`. 

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow, and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test: [link](https://screenshot.googleplex.com/55NvAYpBnHjF7CS).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.