### PR TITLE
Upscale scheduler

### DIFF
--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -118,6 +118,27 @@ resource "google_composer_environment" "example_environment" {
       }
     }
 
+    workloads_config {
+      scheduler {
+        cpu        = 2
+        memory_gb  = 8
+        storage_gb = 10
+        count      = 2
+      }
+      web_server {
+        cpu        = 2
+        memory_gb  = 8
+        storage_gb = 10
+      }
+      worker {
+        cpu        = 2
+        memory_gb  = 8
+        storage_gb = 10
+        min_count  = 1
+        max_count  = 3
+      }
+    }
+
     node_config {
       service_account = google_service_account.custom_service_account[each.key].email
     }


### PR DESCRIPTION
Change-Id: I781a1cfdd73424febf0449d17a8c63e0317abbf8

# Description

Noticed the high usage of scheduler CPU in prod stage [~90%](https://screenshot.googleplex.com/B4QwkhunPj6L8NY), so scale it up to 2 from 1. Other metrics are fine so far.
* I need to add all workload configs; otherwise other values will be set to null instead of default (if I only indicate scheduler count).
* Also, noticed dev env created manually has diff settings. So this PR will also fix that.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Run terraform plan.

**List links for your tests (use go/shortn-gen for any internal link):** ...

```
Terraform will perform the following actions:

  # google_composer_environment.example_environment["ml-automation-solutions"] will be updated in-place
  ~ resource "google_composer_environment" "example_environment" {
        id      = "projects/cloud-ml-auto-solutions/locations/us-central1/environments/ml-automation-solutions"
        name    = "ml-automation-solutions"
        # (3 unchanged attributes hidden)

      ~ config {
            # (6 unchanged attributes hidden)

          ~ workloads_config {
              ~ scheduler {
                  ~ count      = 1 -> 2
                    # (3 unchanged attributes hidden)
                }

                # (2 unchanged blocks hidden)
            }

            # (7 unchanged blocks hidden)
        }
    }
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.