### PR TITLE
Add v5e tests for Pax

### DIFF
--- a/configs/vm_resource.py
+++ b/configs/vm_resource.py
@@ -17,6 +17,12 @@
 import enum
 
 
+V5_NETWORKS_PREFIX = "projects/tpu-prod-env-automated"
+V5_NETWORKS = f"{V5_NETWORKS_PREFIX}/global/networks/mas-test"
+V5E_SUBNETWORKS = f"{V5_NETWORKS_PREFIX}/regions/us-east1/subnetworks/mas-test"
+V5P_SUBNETWORKS = f"{V5_NETWORKS_PREFIX}/regions/us-east5/subnetworks/mas-test"
+
+
 # TODO(ranran): update to enum class (this change has been included in an on-going PR)
 PROJECT_CLOUD_ML_AUTO_SOLUTIONS = "cloud-ml-auto-solutions"
 PROJECT_TPU_PROD_ENV_AUTOMATED = "tpu-prod-env-automated"

--- a/configs/xlml/pax/solutionsteam_pax_supported_config.py
+++ b/configs/xlml/pax/solutionsteam_pax_supported_config.py
@@ -69,13 +69,18 @@ def get_setup_cmds(
     raise RuntimeError(f"Please specify set up cmds for: {pax_version.value}.")
 
 
-def get_runtime_version(pax_version: PaxVersion) -> str:
-  if pax_version is PaxVersion.STABLE:
-    return vm_resource.RuntimeVersion.TPU_VM_V4_BASE.value
-  elif pax_version is PaxVersion.NIGHTLY:
-    return vm_resource.RuntimeVersion.TPU_UBUNTU2204_BASE.value
+def get_runtime_version(pax_version: PaxVersion, tpu_version: str) -> str:
+  if tpu_version == "5litepod":
+    return vm_resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE.value
+  elif tpu_version == "5p":
+    return vm_resource.RuntimeVersion.V2_ALPHA_TPUV5.value
   else:
-    raise RuntimeError(f"Please specify runtime version for: {pax_version.value}.")
+    if pax_version is PaxVersion.STABLE:
+      return vm_resource.RuntimeVersion.TPU_VM_V4_BASE.value
+    elif pax_version is PaxVersion.NIGHTLY:
+      return vm_resource.RuntimeVersion.TPU_UBUNTU2204_BASE.value
+    else:
+      raise RuntimeError(f"Please specify runtime version for: {pax_version.value}.")
 
 
 def get_pax_lm_config(
@@ -87,11 +92,14 @@ def get_pax_lm_config(
     model_name: str,
     log_dir: str,
     pax_version: PaxVersion = PaxVersion.STABLE,
+    project_name: str = vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
     ckp_path: str = "",
     extraFlags: str = "",
+    network: str = "default",
+    subnetwork: str = "default",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+      project_name=project_name,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
@@ -111,8 +119,10 @@ def get_pax_lm_config(
       test_config.Tpu(
           version=tpu_version,
           cores=tpu_cores,
-          runtime_version=get_runtime_version(pax_version),
+          runtime_version=get_runtime_version(pax_version, tpu_version),
           reserved=True,
+          network=network,
+          subnetwork=subnetwork,
       ),
       test_name=f"pax_{pax_version.value}_{model_name}",
       set_up_cmds=set_up_cmds,

--- a/configs/xlml/pax/solutionsteam_pax_supported_config.py
+++ b/configs/xlml/pax/solutionsteam_pax_supported_config.py
@@ -92,7 +92,7 @@ def get_pax_lm_config(
     model_name: str,
     log_dir: str,
     pax_version: PaxVersion = PaxVersion.STABLE,
-    project_name: str = vm_resource.PROJECT_CLOUD_ML_AUTO_SOLUTIONS,
+    project_name: str = vm_resource.Project.TPU_PROD_ENV_AUTOMATED.value,
     ckp_path: str = "",
     extraFlags: str = "",
     network: str = "default",

--- a/dags/xlml/solutionsteam_flax_latest_supported.py
+++ b/dags/xlml/solutionsteam_flax_latest_supported.py
@@ -22,10 +22,6 @@ from configs.xlml.jax import solutionsteam_flax_latest_supported_config as flax_
 
 # Run once a day at 2 am UTC (6 pm PST)
 SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
-NETWORK_PREFIX = "projects/tpu-prod-env-automated"
-V5_NETWORKS = f"{NETWORK_PREFIX}/global/networks/mas-test"
-V5E_SUBNETWORKS = f"{NETWORK_PREFIX}/regions/us-east1/subnetworks/mas-test"
-V5P_SUBNETWORKS = f"{NETWORK_PREFIX}/regions/us-east5/subnetworks/mas-test"
 
 
 with models.DAG(
@@ -84,8 +80,8 @@ with models.DAG(
       tpu_cores=4,
       tpu_zone=vm_resource.Zone.US_EAST1_C.value,
       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
-      network=V5_NETWORKS,
-      subnetwork=V5E_SUBNETWORKS,
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5E_SUBNETWORKS,
       time_out_in_min=60,
   ).run()
 
@@ -95,8 +91,8 @@ with models.DAG(
       tpu_cores=16,
       tpu_zone=vm_resource.Zone.US_EAST1_C.value,
       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
-      network=V5_NETWORKS,
-      subnetwork=V5E_SUBNETWORKS,
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5E_SUBNETWORKS,
       time_out_in_min=60,
   ).run()
 
@@ -106,8 +102,8 @@ with models.DAG(
       tpu_cores=8,
       tpu_zone=vm_resource.Zone.US_EAST5_A.value,
       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5.value,
-      network=V5_NETWORKS,
-      subnetwork=V5E_SUBNETWORKS,
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5P_SUBNETWORKS,
       time_out_in_min=60,
   ).run()
 
@@ -117,8 +113,8 @@ with models.DAG(
       tpu_cores=32,
       tpu_zone=vm_resource.Zone.US_EAST5_A.value,
       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5.value,
-      network=V5_NETWORKS,
-      subnetwork=V5E_SUBNETWORKS,
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5P_SUBNETWORKS,
       time_out_in_min=60,
   ).run()
 

--- a/dags/xlml/solutionsteam_pax_nightly_supported.py
+++ b/dags/xlml/solutionsteam_pax_nightly_supported.py
@@ -95,7 +95,7 @@ with models.DAG(
   ).run()
 
   pax_nightly_lmtransformeradam_v5e_4 = pax_config.get_pax_lm_config(
-      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      project_name=vm_resource.Project.TPU_PROD_ENV_AUTOMATED.value,
       tpu_version="5litepod",
       tpu_cores=4,
       tpu_zone=vm_resource.Zone.US_EAST1_C.value,
@@ -110,7 +110,7 @@ with models.DAG(
   ).run()
 
   pax_nightly_lmtransformeradam_v5e_16 = pax_config.get_pax_lm_config(
-      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      project_name=vm_resource.Project.TPU_PROD_ENV_AUTOMATED.value,
       tpu_version="5litepod",
       tpu_cores=16,
       tpu_zone=vm_resource.Zone.US_EAST1_C.value,

--- a/dags/xlml/solutionsteam_pax_nightly_supported.py
+++ b/dags/xlml/solutionsteam_pax_nightly_supported.py
@@ -94,6 +94,37 @@ with models.DAG(
       extraFlags=" ".join(pax_transformer_adam_extra_flags),
   ).run()
 
+  pax_nightly_lmtransformeradam_v5e_4 = pax_config.get_pax_lm_config(
+      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      tpu_version="5litepod",
+      tpu_cores=4,
+      tpu_zone=vm_resource.Zone.US_EAST1_C.value,
+      time_out_in_min=60,
+      log_dir=f"{log_dir_prefix}/lmtransformeradam/v5litepod-4",
+      exp_path=lmtransformeradam_exp_path,
+      pax_version=pax_config.PaxVersion.NIGHTLY,
+      model_name="lmtransformer",
+      extraFlags=" ".join(pax_transformer_adam_extra_flags),
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5E_SUBNETWORKS,
+  ).run()
+
+  pax_nightly_lmtransformeradam_v5e_16 = pax_config.get_pax_lm_config(
+      project_name=vm_resource.PROJECT_TPU_PROD_ENV_AUTOMATED,
+      tpu_version="5litepod",
+      tpu_cores=16,
+      tpu_zone=vm_resource.Zone.US_EAST1_C.value,
+      time_out_in_min=60,
+      log_dir=f"{log_dir_prefix}/lmtransformeradam/v5litepod-16",
+      exp_path=lmtransformeradam_exp_path,
+      pax_version=pax_config.PaxVersion.NIGHTLY,
+      model_name="lmtransformer",
+      extraFlags=" ".join(pax_transformer_adam_extra_flags),
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5E_SUBNETWORKS,
+  ).run()
+
   # Test dependencies
   pax_nightly_lmspmd2b_v4_8 >> pax_nightly_lmspmd2b_ckpt_v4_8
   pax_nightly_lmtransformeradam_v4_8 >> pax_nightly_lmtransformeradam_v4_16
+  pax_nightly_lmtransformeradam_v5e_4 >> pax_nightly_lmtransformeradam_v5e_16


### PR DESCRIPTION
# Description

Add v5litepod tests for Pax.
* Resources are in project `tpu-prod-env-automated`

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test: [link](https://screenshot.googleplex.com/9RuBPKXZvEGiy2T) - unfortunately, it's failing at `Could not find a version that satisfies the requirement flax (unavailable) (from praxis) (from versions: 0.1.0rc1,...` - same error as now

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.