### PR TITLE
Add TF Keras API tests

### DIFF
--- a/configs/xlml/tensorflow/common.py
+++ b/configs/xlml/tensorflow/common.py
@@ -21,15 +21,25 @@ def set_up_pjrt_nightly() -> Tuple[str]:
   """Common set up for PJRT nightly tests."""
   return (
       "pip install tensorflow-text-nightly",
-      "gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/tf-nightly/latest/*.whl /tmp/ && pip install /tmp/tf*.whl --force",
+      "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/tf-nightly/latest/*.whl /tmp/ && pip install /tmp/tf*.whl --force",
       "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/libtpu/latest/libtpu.so /lib/",
-      "sudo mkdir -p /usr/share/tpu && cd /usr/share/tpu && git clone https://github.com/tensorflow/models.git",
+  )
+
+
+# TODO(ranran): migrate repo `tf2-api-tests` from xl-ml-test to cloud-ml-auto-solutions project
+def set_up_tensorflow_keras() -> Tuple[str]:
+  """Common set up for tensorflow Keras tests."""
+  return (
+      "pip install --upgrade --force-reinstall tf-keras-nightly",
+      "export PATH=$PATH:/root/google-cloud-sdk/bin && cd /tmp && sudo gcloud source repos clone tf2-api-tests --project=xl-ml-test",
+      "cd /tmp/tf2-api-tests && pip install behave matplotlib",
   )
 
 
 def set_up_google_tensorflow_models() -> Tuple[str]:
-  """Common set up for tensorflow."""
+  """Common set up for tensorflow models."""
   return (
+      "sudo mkdir -p /usr/share/tpu && cd /usr/share/tpu && git clone https://github.com/tensorflow/models.git",
       "pip install -r /usr/share/tpu/models/official/requirements.txt",
       "pip install tensorflow-recommenders --no-deps",
       "pip install --upgrade --force-reinstall tf-keras-nightly",

--- a/dags/xlml/solutionsteam_tf_nightly_supported.py
+++ b/dags/xlml/solutionsteam_tf_nightly_supported.py
@@ -25,13 +25,96 @@ from configs.xlml.tensorflow import solutionsteam_tf_nightly_supported_config as
 SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
 
 
+# TODO(ranran): remove concurrency param when we have enough v2-8 capacity for Keras
 with models.DAG(
     dag_id="tf_nightly_supported",
     schedule=SCHEDULED_TIME,
     tags=["solutions_team", "tf", "nightly", "supported", "xlml"],
     start_date=datetime.datetime(2023, 8, 16),
+    concurrency=6,
     catchup=False,
 ) as dag:
+  # Keras API
+  AAA_CONNECTION = "aaa_connection"
+  CUSTOM_LAYERS_MODEL = "custom_layers_model"
+  CUSTOM_TRAINING_LOOP = "custom_training_loop"
+  FEATURE_COLUMN = "feature_column"
+  RNN = "rnn"
+  UPSAMPLE = "upsample"
+  SAVE_AND_LOAD_LOCAL_DRIVER = "save_and_load_io_device_local_drive"
+  SAVE_AND_LOAD_FEATURE = "save_and_load.feature"
+  TRAIN_AND_EVALUATE = "train_and_evaluate"
+  TRANSFER_LEARNING = "transfer_learning"
+
+  feature_name = {
+      AAA_CONNECTION: "connection",
+      CUSTOM_LAYERS_MODEL: "custom_layers",
+      CUSTOM_TRAINING_LOOP: "ctl",
+      FEATURE_COLUMN: "feature_column",
+      RNN: "rnn",
+      UPSAMPLE: "upsample",
+      SAVE_AND_LOAD_LOCAL_DRIVER: "save_load_localhost",
+      SAVE_AND_LOAD_FEATURE: "save_and_load",
+      TRAIN_AND_EVALUATE: "train_and_evaluate",
+      TRANSFER_LEARNING: "transfer_learning",
+  }
+
+  feature_timeout = {
+      AAA_CONNECTION: 60,
+      CUSTOM_LAYERS_MODEL: 60,
+      CUSTOM_TRAINING_LOOP: 60,
+      FEATURE_COLUMN: 120,
+      RNN: 60,
+      UPSAMPLE: 60,
+      SAVE_AND_LOAD_LOCAL_DRIVER: 120,
+      SAVE_AND_LOAD_FEATURE: 120,
+      TRAIN_AND_EVALUATE: 180,
+      TRANSFER_LEARNING: 60,
+  }
+
+  # Keras
+  tf_keras_v2_8 = [
+      tf_config.get_tf_keras_config(
+          tpu_version=TpuVersion.V2,
+          tpu_cores=8,
+          tpu_zone=Zone.US_CENTRAL1_C.value,
+          time_out_in_min=feature_timeout.get(feature),
+          test_feature=feature,
+          test_name=name,
+      ).run()
+      for feature, name in feature_name.items()
+  ]
+
+  tf_keras_v5e_4 = [
+      tf_config.get_tf_keras_config(
+          project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+          tpu_version=TpuVersion.V5E,
+          tpu_cores=4,
+          tpu_zone=Zone.US_EAST1_C.value,
+          time_out_in_min=feature_timeout.get(feature),
+          test_feature=feature,
+          test_name=name,
+          network=V5_NETWORKS,
+          subnetwork=V5E_SUBNETWORKS,
+      ).run()
+      for feature, name in feature_name.items()
+  ]
+
+  tf_keras_v5p_8 = [
+      tf_config.get_tf_keras_config(
+          project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+          tpu_version=TpuVersion.V5E,
+          tpu_cores=8,
+          tpu_zone=Zone.US_EAST5_A.value,
+          time_out_in_min=feature_timeout.get(feature),
+          test_feature=feature,
+          test_name=name,
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+      ).run()
+      for feature, name in feature_name.items()
+  ]
+
   # ResNet
   tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
       tpu_version=TpuVersion.V2,
@@ -77,6 +160,9 @@ with models.DAG(
   ).run()
 
   # Test dependencies
+  tf_keras_v2_8
+  tf_keras_v5e_4
+  tf_keras_v5p_8
   tf_resnet_v2_8
   tf_resnet_v3_8
   tf_resnet_v4_8

--- a/dags/xlml/solutionsteam_tf_nightly_supported.py
+++ b/dags/xlml/solutionsteam_tf_nightly_supported.py
@@ -103,7 +103,7 @@ with models.DAG(
   tf_keras_v5p_8 = [
       tf_config.get_tf_keras_config(
           project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
-          tpu_version=TpuVersion.V5E,
+          tpu_version=TpuVersion.V5P,
           tpu_cores=8,
           tpu_zone=Zone.US_EAST5_A.value,
           time_out_in_min=feature_timeout.get(feature),


### PR DESCRIPTION
# Description

Add TF Keras API tests:
* Add tests for v2-8, v5e-4, and v5p-8
* TF Pod tests are blocked by this [PR](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/15)
* simplified old tests by removing unneeded scripts/commands (please review and see if I missed anything)


# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Some tests are passing and some of them are failed. Similar like existing tests, but not exactly the same. We could migrate tests first and then debug if don't notice the difference. 


Overal test: [link](https://screenshot.googleplex.com/BTCmjF8zYohKMYX) - passed tests are green

A few failed examples:
* [connection](https://screenshot.googleplex.com/88nVRVpqu9eqy6M)
* [custom_layers](https://screenshot.googleplex.com/BJqNUtrDAm748Fz)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.