### PR TITLE
Add TF SE nightly tests for Keras and ResNet

### DIFF
--- a/configs/vm_resource.py
+++ b/configs/vm_resource.py
@@ -51,6 +51,8 @@ class TpuVersion(enum.Enum):
 class RuntimeVersion(enum.Enum):
   TPU_VM_TF_NIGHTLY = "tpu-vm-tf-nightly"
   TPU_VM_TF_NIGHTLY_POD = "tpu-vm-tf-nightly-pod"
+  TPU_VM_TF_2150_SE = "tpu-vm-tf-2.15.0-se"
+  TPU_VM_TF_2150_POD_SE = "tpu-vm-tf-2.15.0-pod-se"
   TPU_VM_TF_2150_PJRT = "tpu-vm-tf-2.15.0-pjrt"
   TPU_VM_TF_2150_POD_PJRT = "tpu-vm-tf-2.15.0-pod-pjrt"
   TPU_UBUNTU2204_BASE = "tpu-ubuntu2204-base"

--- a/configs/xlml/tensorflow/common.py
+++ b/configs/xlml/tensorflow/common.py
@@ -17,6 +17,43 @@
 from typing import Tuple
 
 
+# Keras API
+AAA_CONNECTION = "aaa_connection"
+CUSTOM_LAYERS_MODEL = "custom_layers_model"
+CUSTOM_TRAINING_LOOP = "custom_training_loop"
+FEATURE_COLUMN = "feature_column"
+RNN = "rnn"
+UPSAMPLE = "upsample"
+SAVE_AND_LOAD_LOCAL_DRIVER = "save_and_load_io_device_local_drive"
+SAVE_AND_LOAD_FEATURE = "save_and_load.feature"
+TRAIN_AND_EVALUATE = "train_and_evaluate"
+TRANSFER_LEARNING = "transfer_learning"
+FEATURE_NAME = {
+    AAA_CONNECTION: "connection",
+    CUSTOM_LAYERS_MODEL: "custom_layers",
+    CUSTOM_TRAINING_LOOP: "ctl",
+    FEATURE_COLUMN: "feature_column",
+    RNN: "rnn",
+    UPSAMPLE: "upsample",
+    SAVE_AND_LOAD_LOCAL_DRIVER: "save_load_localhost",
+    SAVE_AND_LOAD_FEATURE: "save_and_load",
+    TRAIN_AND_EVALUATE: "train_and_evaluate",
+    TRANSFER_LEARNING: "transfer_learning",
+}
+FEATURE_TIMEOUT = {
+    AAA_CONNECTION: 60,
+    CUSTOM_LAYERS_MODEL: 60,
+    CUSTOM_TRAINING_LOOP: 60,
+    FEATURE_COLUMN: 120,
+    RNN: 60,
+    UPSAMPLE: 60,
+    SAVE_AND_LOAD_LOCAL_DRIVER: 120,
+    SAVE_AND_LOAD_FEATURE: 120,
+    TRAIN_AND_EVALUATE: 180,
+    TRANSFER_LEARNING: 60,
+}
+
+
 def set_up_pjrt_nightly() -> Tuple[str]:
   """Common set up for PJRT nightly tests."""
   return (

--- a/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -31,6 +31,7 @@ def get_tf_keras_config(
     project_name: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     runtime_version: str = RuntimeVersion.TPU_VM_TF_2150_PJRT.value,
     is_pod: bool = False,
+    is_pjrt: bool = True,
     network: str = "default",
     subnetwork: str = "default",
 ) -> task.TpuQueuedResourceTask:
@@ -46,10 +47,10 @@ def get_tf_keras_config(
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
-  env_variable = export_env_variable(is_pod)
+  env_variable = export_env_variable(is_pod, is_pjrt)
   skipped_tag = "--tags=-failspod" if is_pod else ""
   run_model_cmds = (
-      "sudo chmod -R 777 /tmp/",
+      "sudo chmod -R 777 ./model_dir/",
       (
           "export PATH=$PATH:/home/ml-auto-solutions/.local/bin &&"
           f" export TPU_NAME={tpu_name} && {env_variable} &&"
@@ -93,6 +94,7 @@ def get_tf_resnet_config(
     network: str = "default",
     subnetwork: str = "default",
     is_pod: bool = False,
+    is_pjrt: bool = True,
     imagenet_dir: str = gcs_bucket.IMAGENET_DIR,
     tfds_data_dir: str = gcs_bucket.TFDS_DATA_DIR,
     global_batch_size: int = 4096,
@@ -131,7 +133,7 @@ def get_tf_resnet_config(
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
-  env_variable = export_env_variable(is_pod)
+  env_variable = export_env_variable(is_pod, is_pjrt)
   run_model_cmds = (
       "sudo chmod -R 777 /tmp/",
       (
@@ -168,10 +170,12 @@ def get_tf_resnet_config(
   )
 
 
-def export_env_variable(is_pod: bool) -> str:
+def export_env_variable(is_pod: bool, is_pjrt: bool) -> str:
   """Export environment variables for training if any."""
-  return (
-      "export TPU_LOAD_LIBRARY=0"
-      if is_pod
-      else "export NEXT_PLUGGABLE_DEVICE_USE_C_API=true && export TF_PLUGGABLE_DEVICE_LIBRARY_PATH=/lib/libtpu.so"
-  )
+  if is_pod:
+    return "export TPU_LOAD_LIBRARY=0"
+  elif is_pjrt:
+    return "export NEXT_PLUGGABLE_DEVICE_USE_C_API=true && export TF_PLUGGABLE_DEVICE_LIBRARY_PATH=/lib/libtpu.so"
+  else:
+    # dummy command
+    return "echo"

--- a/dags/xlml/solutionsteam_tf_nightly_supported.py
+++ b/dags/xlml/solutionsteam_tf_nightly_supported.py
@@ -19,6 +19,7 @@ from airflow import models
 from configs import composer_env
 from configs.vm_resource import TpuVersion, Project, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
 from configs.xlml.tensorflow import solutionsteam_tf_nightly_supported_config as tf_config
+from configs.xlml.tensorflow import common
 
 
 # Run once a day at 6 am UTC (10 pm PST)
@@ -34,55 +35,17 @@ with models.DAG(
     concurrency=6,
     catchup=False,
 ) as dag:
-  # Keras API
-  AAA_CONNECTION = "aaa_connection"
-  CUSTOM_LAYERS_MODEL = "custom_layers_model"
-  CUSTOM_TRAINING_LOOP = "custom_training_loop"
-  FEATURE_COLUMN = "feature_column"
-  RNN = "rnn"
-  UPSAMPLE = "upsample"
-  SAVE_AND_LOAD_LOCAL_DRIVER = "save_and_load_io_device_local_drive"
-  SAVE_AND_LOAD_FEATURE = "save_and_load.feature"
-  TRAIN_AND_EVALUATE = "train_and_evaluate"
-  TRANSFER_LEARNING = "transfer_learning"
-
-  feature_name = {
-      AAA_CONNECTION: "connection",
-      CUSTOM_LAYERS_MODEL: "custom_layers",
-      CUSTOM_TRAINING_LOOP: "ctl",
-      FEATURE_COLUMN: "feature_column",
-      RNN: "rnn",
-      UPSAMPLE: "upsample",
-      SAVE_AND_LOAD_LOCAL_DRIVER: "save_load_localhost",
-      SAVE_AND_LOAD_FEATURE: "save_and_load",
-      TRAIN_AND_EVALUATE: "train_and_evaluate",
-      TRANSFER_LEARNING: "transfer_learning",
-  }
-
-  feature_timeout = {
-      AAA_CONNECTION: 60,
-      CUSTOM_LAYERS_MODEL: 60,
-      CUSTOM_TRAINING_LOOP: 60,
-      FEATURE_COLUMN: 120,
-      RNN: 60,
-      UPSAMPLE: 60,
-      SAVE_AND_LOAD_LOCAL_DRIVER: 120,
-      SAVE_AND_LOAD_FEATURE: 120,
-      TRAIN_AND_EVALUATE: 180,
-      TRANSFER_LEARNING: 60,
-  }
-
   # Keras
   tf_keras_v2_8 = [
       tf_config.get_tf_keras_config(
           tpu_version=TpuVersion.V2,
           tpu_cores=8,
           tpu_zone=Zone.US_CENTRAL1_C.value,
-          time_out_in_min=feature_timeout.get(feature),
+          time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
           test_feature=feature,
           test_name=name,
       ).run()
-      for feature, name in feature_name.items()
+      for feature, name in common.FEATURE_NAME.items()
   ]
 
   tf_keras_v5e_4 = [
@@ -91,13 +54,13 @@ with models.DAG(
           tpu_version=TpuVersion.V5E,
           tpu_cores=4,
           tpu_zone=Zone.US_EAST1_C.value,
-          time_out_in_min=feature_timeout.get(feature),
+          time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
           test_feature=feature,
           test_name=name,
           network=V5_NETWORKS,
           subnetwork=V5E_SUBNETWORKS,
       ).run()
-      for feature, name in feature_name.items()
+      for feature, name in common.FEATURE_NAME.items()
   ]
 
   tf_keras_v5p_8 = [
@@ -106,13 +69,13 @@ with models.DAG(
           tpu_version=TpuVersion.V5P,
           tpu_cores=8,
           tpu_zone=Zone.US_EAST5_A.value,
-          time_out_in_min=feature_timeout.get(feature),
+          time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
           test_feature=feature,
           test_name=name,
           network=V5_NETWORKS,
           subnetwork=V5P_SUBNETWORKS,
       ).run()
-      for feature, name in feature_name.items()
+      for feature, name in common.FEATURE_NAME.items()
   ]
 
   # ResNet

--- a/dags/xlml/solutionsteam_tf_se_nightly_supported.py
+++ b/dags/xlml/solutionsteam_tf_se_nightly_supported.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run all supported ML models with the nightly TensorFlow version."""
+
+import datetime
+from airflow import models
+from configs import composer_env
+from configs.vm_resource import TpuVersion, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
+from configs.xlml.tensorflow import solutionsteam_tf_nightly_supported_config as tf_config
+from configs.xlml.tensorflow import common
+from airflow.operators.dummy import DummyOperator
+
+
+# Run once a day at 4 pm UTC (8 am PST)
+SCHEDULED_TIME = "0 16 * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="tf_se_nightly_supported",
+    schedule=SCHEDULED_TIME,
+    tags=["solutions_team", "tf", "se", "nightly", "supported", "xlml"],
+    start_date=datetime.datetime(2024, 1, 4),
+    catchup=False,
+) as dag:
+  # Keras - tests run in sequence order
+  tf_keras_v2_8 = [DummyOperator(task_id="tf_se_nightly_keras_v2-8")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        tpu_version=TpuVersion.V2,
+        tpu_cores=8,
+        tpu_zone=Zone.US_CENTRAL1_C.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        is_pjrt=False,
+        runtime_version=RuntimeVersion.TPU_VM_TF_2150_SE.value,
+    ).run()
+    tf_keras_v2_8[-1] >> test
+    tf_keras_v2_8.append(test)
+
+  # ResNet
+  tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL1_C.value,
+      time_out_in_min=60,
+      global_batch_size=1024,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_SE.value,
+  ).run()
+
+  tf_resnet_v2_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL1_A.value,
+      time_out_in_min=60,
+      global_batch_size=1024,
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_POD_SE.value,
+  ).run()
+
+  tf_resnet_v3_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V3,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST1_D.value,
+      time_out_in_min=60,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_SE.value,
+  ).run()
+
+  tf_resnet_v3_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V3,
+      tpu_cores=32,
+      tpu_zone=Zone.US_EAST1_D.value,
+      time_out_in_min=60,
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_POD_SE.value,
+  ).run()
+
+  tf_resnet_v4_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_SE.value,
+  ).run()
+
+  tf_resnet_v4_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_POD_SE.value,
+  ).run()
+
+  # Test dependencies
+  tf_keras_v2_8
+  tf_resnet_v2_8 >> tf_resnet_v2_32
+  tf_resnet_v3_8 >> tf_resnet_v3_32
+  tf_resnet_v4_8 >> tf_resnet_v4_32


### PR DESCRIPTION
# Description

Add TF SE nightly tests for Keras and ResNet:
* Add Keras for v2-8
* Add ResNet for v2-8, v2-32, v3-8, v3-32, v4-8, and v4-32
* Move commonly used variables to `common.py`

*Please note*: I put Keras tests in sequence order to mitigate the current capacity issue in new project. I will update the PJRT tests to be the same. Once we have enough capacity, I will change them to be parallel.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test: [link]()

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.