### PR TITLE
Add conv tests for BART and SD

### DIFF
--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -20,11 +20,13 @@ from apis import gcp_config, metric_config, task, test_config
 from configs import gcs_bucket, test_owner
 from configs.xlml.jax import common
 from configs.vm_resource import TpuVersion, Project, RuntimeVersion
+from datetime import datetime
 
 
 PROJECT_NAME = Project.CLOUD_ML_AUTO_SOLUTIONS.value
 RUNTIME_IMAGE = RuntimeVersion.TPU_UBUNTU2204_BASE.value
 IS_TPU_RESERVED = True
+RUN_DATE = datetime.now().strftime("%Y_%m_%d")
 
 
 def get_flax_resnet_config(
@@ -176,7 +178,7 @@ def get_flax_vit_conv_config(
       "/tmp/transformers/vit-imagenette/events.out.tfevents.jax-vit.v2"
   )
   gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/metric/events.out.tfevents.jax-vit.v2"
+      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/{RUN_DATE}/events.out.tfevents.jax-vit.v2"
   )
   extra_run_cmds = (
       (
@@ -385,7 +387,7 @@ def get_flax_sd_conv_config(
   work_dir = generate_unique_dir("/tmp/diffusers/sd-pokemon-model")
   tf_summary_location = f"{work_dir}/events.out.tfevents.jax-sd.v2"
   gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/sd/metric/events.out.tfevents.jax-sd.v2"
+      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/sd/{RUN_DATE}/events.out.tfevents.jax-sd.v2"
   )
   extra_run_cmds = (
       f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
@@ -506,7 +508,7 @@ def get_flax_bart_conv_config(
   work_dir = "/tmp/transformers/bart-base-wiki"
   tf_summary_location = f"{work_dir}/events.out.tfevents.jax-bart.v2"
   gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bart/metric/events.out.tfevents.jax-bart.v2"
+      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bart/{RUN_DATE}/events.out.tfevents.jax-bart.v2"
   )
   extra_run_cmds = (
       f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",

--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -309,7 +309,7 @@ def get_flax_sd_run_model_cmds(
           f" --dataset_name='lambdalabs/pokemon-blip-captions' --resolution={resolution}"
           " --center_crop --random_flip --train_batch_size=8"
           f" --num_train_epochs={num_train_epochs} --learning_rate=1e-05"
-          f" --max_grad_norm=1 --output_dir=/tmp/diffusers/{work_dir} --cache_dir /tmp"
+          f" --max_grad_norm=1 --output_dir={work_dir} --cache_dir /tmp"
           f" {extraFlags}"
       ),
   ) + extra_run_cmds

--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -177,9 +177,7 @@ def get_flax_vit_conv_config(
   tf_summary_location = (
       "/tmp/transformers/vit-imagenette/events.out.tfevents.jax-vit.v2"
   )
-  gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/{RUN_DATE}/events.out.tfevents.jax-vit.v2"
-  )
+  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/{RUN_DATE}/events.out.tfevents.flax-vit.v2"
   extra_run_cmds = (
       (
           "cp /tmp/transformers/vit-imagenette/events.out.tfevents.*"
@@ -387,7 +385,7 @@ def get_flax_sd_conv_config(
   work_dir = generate_unique_dir("/tmp/diffusers/sd-pokemon-model")
   tf_summary_location = f"{work_dir}/events.out.tfevents.jax-sd.v2"
   gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/sd/{RUN_DATE}/events.out.tfevents.jax-sd.v2"
+      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/sd/{RUN_DATE}/events.out.tfevents.flax-sd.v2"
   )
   extra_run_cmds = (
       f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
@@ -507,9 +505,7 @@ def get_flax_bart_conv_config(
   set_up_cmds = get_flax_bart_setup_cmds()
   work_dir = "/tmp/transformers/bart-base-wiki"
   tf_summary_location = f"{work_dir}/events.out.tfevents.jax-bart.v2"
-  gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bart/{RUN_DATE}/events.out.tfevents.jax-bart.v2"
-  )
+  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bart/{RUN_DATE}/events.out.tfevents.flax-bart.v2"
   extra_run_cmds = (
       f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
       f"gsutil cp {tf_summary_location} {gcs_location} || exit 0",

--- a/dags/xlml/solutionsteam_flax_latest_supported.py
+++ b/dags/xlml/solutionsteam_flax_latest_supported.py
@@ -197,12 +197,12 @@ with models.DAG(
       num_train_epochs=1,
   ).run()
 
-  jax_sd_conv_v4_32 = flax_config.get_flax_sd_conv_config(
+  jax_sd_v4_32 = flax_config.get_flax_sd_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      num_train_epochs=10,
+      num_train_epochs=1,
   ).run()
 
   jax_sd_v5e_4 = flax_config.get_flax_sd_config(
@@ -246,14 +246,24 @@ with models.DAG(
   ).run()
 
   # BERT
+  jax_bert_v4_batch_size = [
+      "--per_device_train_batch_size=8",
+      "--per_device_eval_batch_size=8",
+  ]
+  jax_bert_conv_extra_flags = [
+      "--learning_rate 2e-5",
+      "--eval_steps 500",
+  ]
+
   jax_bert_mnli_extra_flags = [
       "--max_seq_length 512",
       "--eval_steps 1000",
   ]
-  jax_bert_v4_mnli_extra_flags = jax_bert_mnli_extra_flags + [
-      "--per_device_train_batch_size=8",
-      "--per_device_eval_batch_size=8",
-  ]
+  jax_bert_v4_mnli_extra_flags = jax_bert_mnli_extra_flags + jax_bert_v4_batch_size
+  jax_bert_v4_mnli_conv_extra_flags = (
+      jax_bert_mnli_extra_flags + jax_bert_v4_batch_size + jax_bert_conv_extra_flags
+  )
+
   jax_bert_mnli_v4_8 = flax_config.get_flax_bert_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=8,
@@ -263,23 +273,25 @@ with models.DAG(
       extraFlags=" ".join(jax_bert_v4_mnli_extra_flags),
   ).run()
 
-  jax_bert_mnli_v4_32 = flax_config.get_flax_bert_config(
+  jax_bert_mnli_conv_v4_32 = flax_config.get_flax_bert_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       task_name="mnli",
-      extraFlags=" ".join(jax_bert_v4_mnli_extra_flags),
+      num_train_epochs=3,
+      extraFlags=" ".join(jax_bert_v4_mnli_conv_extra_flags),
   ).run()
 
   jax_bert_mrpc_extra_flags = [
       "--max_seq_length 128",
       "--eval_steps 100",
   ]
-  jax_bert_v4_mrpc_extra_flags = jax_bert_mrpc_extra_flags + [
-      "--per_device_train_batch_size=8",
-      "--per_device_eval_batch_size=8",
-  ]
+  jax_bert_v4_mrpc_extra_flags = jax_bert_mrpc_extra_flags + jax_bert_v4_batch_size
+  jax_bert_v4_mrpc_conv_extra_flags = (
+      jax_bert_mrpc_extra_flags + jax_bert_v4_batch_size + jax_bert_conv_extra_flags
+  )
+
   jax_bert_mrpc_v4_8 = flax_config.get_flax_bert_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=8,
@@ -289,13 +301,14 @@ with models.DAG(
       extraFlags=" ".join(jax_bert_v4_mrpc_extra_flags),
   ).run()
 
-  jax_bert_mrpc_v4_32 = flax_config.get_flax_bert_config(
+  jax_bert_mrpc_conv_v4_32 = flax_config.get_flax_bert_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       task_name="mrpc",
-      extraFlags=" ".join(jax_bert_v4_mrpc_extra_flags),
+      num_train_epochs=3,
+      extraFlags=" ".join(jax_bert_v4_mrpc_conv_extra_flags),
   ).run()
 
   # WMT
@@ -317,9 +330,9 @@ with models.DAG(
   jax_vit_v5e_4
   jax_gpt2_v4_8 >> jax_gpt2_v4_32
   jax_gpt2_v5e_4
-  jax_sd_v4_8 >> jax_sd_conv_v4_32
+  jax_sd_v4_8 >> jax_sd_v4_32
   jax_sd_v5e_4
   jax_bart_v4_8 >> jax_bart_conv_v4_32
-  jax_bert_mnli_v4_8 >> jax_bert_mnli_v4_32
-  jax_bert_mrpc_v4_8 >> jax_bert_mrpc_v4_32
+  jax_bert_mnli_v4_8 >> jax_bert_mnli_conv_v4_32
+  jax_bert_mrpc_v4_8 >> jax_bert_mrpc_conv_v4_32
   jax_wmt_v4_8

--- a/dags/xlml/solutionsteam_flax_latest_supported.py
+++ b/dags/xlml/solutionsteam_flax_latest_supported.py
@@ -135,7 +135,7 @@ with models.DAG(
   jax_vit_conv_extra_flags = jax_vit_func_extra_flags + [
       "--model_name_or_path google/vit-base-patch16-224-in21k",
   ]
-  jax_vit_v4_32 = flax_config.get_flax_vit_conv_config(
+  jax_vit_conv_v4_32 = flax_config.get_flax_vit_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
@@ -197,12 +197,12 @@ with models.DAG(
       num_train_epochs=1,
   ).run()
 
-  jax_sd_v4_32 = flax_config.get_flax_sd_config(
+  jax_sd_conv_v4_32 = flax_config.get_flax_sd_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      num_train_epochs=1,
+      num_train_epochs=10,
   ).run()
 
   jax_sd_v5e_4 = flax_config.get_flax_sd_config(
@@ -228,6 +228,7 @@ with models.DAG(
       tpu_cores=8,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
+      num_train_epochs=3,
       extraFlags=" ".join(jax_bart_v4_8_extra_flags),
   ).run()
 
@@ -235,11 +236,12 @@ with models.DAG(
       "--per_device_train_batch_size=32",
       "--per_device_eval_batch_size=32",
   ]
-  jax_bart_v4_32 = flax_config.get_flax_bart_config(
+  jax_bart_conv_v4_32 = flax_config.get_flax_bart_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
+      num_train_epochs=30,
       extraFlags=" ".join(jax_bart_v4_32_extra_flags),
   ).run()
 
@@ -311,13 +313,13 @@ with models.DAG(
   jax_resnet_v4_8 >> jax_resnet_v4_32
   jax_resnet_v5e_4 >> jax_resnet_v5e_16
   jax_resnet_v5p_8 >> jax_resnet_v5p_32
-  jax_vit_v4_8 >> jax_vit_v4_32
+  jax_vit_v4_8 >> jax_vit_conv_v4_32
   jax_vit_v5e_4
   jax_gpt2_v4_8 >> jax_gpt2_v4_32
   jax_gpt2_v5e_4
-  jax_sd_v4_8 >> jax_sd_v4_32
+  jax_sd_v4_8 >> jax_sd_conv_v4_32
   jax_sd_v5e_4
-  jax_bart_v4_8 >> jax_bart_v4_32
+  jax_bart_v4_8 >> jax_bart_conv_v4_32
   jax_bert_mnli_v4_8 >> jax_bert_mnli_v4_32
   jax_bert_mrpc_v4_8 >> jax_bert_mrpc_v4_32
   jax_wmt_v4_8


### PR DESCRIPTION
# Description

Add conv tests for BART and SD:
* Create helpers for commonly used commands
* Add helper config `get_flax_sd_conv_config` for stable diffusion conv tests
* Add helper config `get_flax_bart_conv_config` for BART conv tests
* Other small changes, i.e. variable name change for ViT conv test

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
* BART Conv test on v4-32
  * Airflow test pass: [link](https://screenshot.googleplex.com/nMSVzi2zaToMCJ2)
  * Conv metric [train_loss](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bart-wiki_summary.libsonnet#L65) can be found in post_process result and the alarm will be set up [dashboard](http://go/ml-auto-solutions-dashboard) once changes are merged and data is in BigQuery

```
[2024-01-09, 03:19:15 UTC] {logging_mixin.py:150} INFO - Test run rows: [TestRun(job_history=JobHistoryRow(uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2
e6bd57e6f3f1118c', timestamp=datetime.datetime(2024, 1, 9, 3, 19, 12, 153977), owner='Shiva S.', 
job_name='flax_bart_wiki_conv-v4-32', job_status=0), metric_history=
[MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f11
18c', metric_key='train_time', metric_value=984.3043212890625), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='train_learning_rate', metric_value=1.8724799488722965e-08), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='train_loss', metric_value=0.9626200199127197), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_loss', metric_value=0.9807181358337402), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rouge1', metric_value=1.0702999830245972), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rouge2', metric_value=0.17020000517368317), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rougeL', metric_value=1.0693000555038452), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rougeLsum', metric_value=1.065000057220459), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_gen_len', metric_value=64.0)], metadata_history=
[MetadataHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3
f1118c', metadata_key='run_id', metadata_value='manual__2023-12-18T22:37:57.062465+00:00'), 
MetadataHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f
1118c', metadata_key='prev_start_date_success', metadata_value='2023-12-
14T00:18:08.979390+00:00'), 
MetadataHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f
1118c', metadata_key='airflow_dag_run_link', 
metadata_value='https://7ef24502ca144d038c5754964af60450-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-12-
18T22%3A37%3A57.062465%2B00%3A00&task_id=flax_bart_wiki_conv-v4-
32.post_process.process_metrics')])]
```

* SD Conv test on v4-32
  * Airflow test pass: [link]()
  * Conv metric [eval_accuracy](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-sd-pokemon.libsonnet#L61) can be found in post_process result and the alarm will be set up [dashboard](http://go/ml-auto-solutions-dashboard)
  
```
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.