### PR TITLE
Add conv tests for BART and BERT

### DIFF
--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -20,11 +20,13 @@ from apis import gcp_config, metric_config, task, test_config
 from configs import gcs_bucket, test_owner
 from configs.xlml.jax import common
 from configs.vm_resource import TpuVersion, Project, RuntimeVersion
+from datetime import datetime
 
 
 PROJECT_NAME = Project.CLOUD_ML_AUTO_SOLUTIONS.value
 RUNTIME_IMAGE = RuntimeVersion.TPU_UBUNTU2204_BASE.value
 IS_TPU_RESERVED = True
+RUN_DATE = datetime.now().strftime("%Y_%m_%d")
 
 
 def get_flax_resnet_config(
@@ -173,11 +175,9 @@ def get_flax_vit_conv_config(
 
   set_up_cmds = get_flax_vit_setup_cmds()
   tf_summary_location = (
-      "/tmp/transformers/vit-imagenette/events.out.tfevents.jax-vit.v2"
+      "/tmp/transformers/vit-imagenette/events.out.tfevents.flax-vit.v2"
   )
-  gcs_location = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/metric/events.out.tfevents.jax-vit.v2"
-  )
+  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/{RUN_DATE}/events.out.tfevents.flax-vit.v2"
   extra_run_cmds = (
       (
           "cp /tmp/transformers/vit-imagenette/events.out.tfevents.*"
@@ -346,12 +346,45 @@ def get_flax_sd_config(
       task_gcp_config=job_gcp_config,
   )
 
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
+  )
+
+
+def get_flax_bart_setup_cmds() -> Tuple[str]:
+  return common.set_up_hugging_face_transformers() + (
+      "pip install -r examples/flax/summarization/requirements.txt",
+      "pip install ml_dtypes==0.2.0",
+  )
+
+
+def get_flax_bart_run_model_cmds(
+    num_train_epochs: int,
+    extraFlags: str = "",
+    extra_run_cmds: Tuple[str] = ("echo",),
+) -> Tuple[str]:
+  return (
+      (
+          "cd /tmp/transformers/examples/flax/summarization &&"
+          " JAX_PLATFORM_NAME=TPU python3 run_summarization_flax.py"
+          " --model_name_or_path facebook/bart-base --tokenizer_name"
+          " facebook/bart-base --dataset_name wiki_summary --do_train"
+          " --do_eval --do_predict --predict_with_generate --learning_rate"
+          " 5e-5 --warmup_steps 0 --output_dir=/tmp/transformers/bart-base-wiki"
+          f" --overwrite_output_dir --num_train_epochs {num_train_epochs} --max_source_length"
+          f" 512 --max_target_length 64 {extraFlags}"
+      ),
+  ) + extra_run_cmds
+
 
 def get_flax_bart_config(
     tpu_version: TpuVersion,
     tpu_cores: int,
     tpu_zone: str,
     time_out_in_min: int,
+    num_train_epochs: int,
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
@@ -360,23 +393,8 @@ def get_flax_bart_config(
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
-  set_up_cmds = common.set_up_hugging_face_transformers() + (
-      "pip install -r examples/flax/summarization/requirements.txt",
-      "pip install ml_dtypes==0.2.0",
-  )
-
-  run_model_cmds = (
-      (
-          "cd /tmp/transformers/examples/flax/summarization &&"
-          " JAX_PLATFORM_NAME=TPU python3 run_summarization_flax.py"
-          " --model_name_or_path facebook/bart-base --tokenizer_name"
-          " facebook/bart-base --dataset_name wiki_summary --do_train"
-          " --do_eval --do_predict --predict_with_generate --learning_rate"
-          " 5e-5 --warmup_steps 0 --output_dir=./bart-base-wiki"
-          " --overwrite_output_dir --num_train_epochs 3 --max_source_length"
-          f" 512 --max_target_length 64 {extraFlags}"
-      ),
-  )
+  set_up_cmds = get_flax_bart_setup_cmds()
+  run_model_cmds = get_flax_bart_run_model_cmds(num_train_epochs, extraFlags)
 
   job_test_config = test_config.TpuVmTest(
       test_config.Tpu(
@@ -398,6 +416,84 @@ def get_flax_bart_config(
   )
 
 
+def get_flax_bart_conv_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    num_train_epochs: int,
+    extraFlags: str = "",
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=PROJECT_NAME,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = get_flax_bart_setup_cmds()
+  work_dir = "/tmp/transformers/bart-base-wiki"
+  tf_summary_location = f"{work_dir}/events.out.tfevents.flax-bart.v2"
+  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bart/{RUN_DATE}/events.out.tfevents.flax-bart.v2"
+  extra_run_cmds = (
+      f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
+      f"gsutil cp {tf_summary_location} {gcs_location} || exit 0",
+  )
+  run_model_cmds = get_flax_bart_run_model_cmds(
+      num_train_epochs, extraFlags, extra_run_cmds
+  )
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=RUNTIME_IMAGE,
+          reserved=IS_TPU_RESERVED,
+      ),
+      test_name="flax_bart_wiki_conv",
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.SHIVA_S,
+  )
+
+  job_metric_config = metric_config.MetricConfig(
+      tensorboard_summary=metric_config.SummaryConfig(
+          file_location=gcs_location,
+          aggregation_strategy=metric_config.AggregationStrategy.LAST,
+      )
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
+  )
+
+
+def get_flax_bert_setup_cmds() -> Tuple[str]:
+  return common.set_up_hugging_face_transformers() + (
+      "pip install -r examples/flax/text-classification/requirements.txt",
+      "pip install ml_dtypes==0.2.0",
+  )
+
+
+def get_flax_bert_run_model_cmds(
+    task_name: str,
+    num_train_epochs: int,
+    extraFlags: str = "",
+    extra_run_cmds: Tuple[str] = ("echo",),
+) -> Tuple[str]:
+  return (
+      (
+          "cd /tmp/transformers/examples/flax/text-classification &&"
+          " JAX_PLATFORM_NAME=TPU python3 run_flax_glue.py --output_dir"
+          " /tmp/transformers/bert-glue --model_name_or_path bert-base-cased"
+          f" --overwrite_output_dir --task_name {task_name} --num_train_epochs"
+          f" {num_train_epochs} --logging_dir ./bert-glue {extraFlags}"
+      ),
+  ) + extra_run_cmds
+
+
 def get_flax_bert_config(
     tpu_version: TpuVersion,
     tpu_cores: int,
@@ -413,20 +509,8 @@ def get_flax_bert_config(
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
-  set_up_cmds = common.set_up_hugging_face_transformers() + (
-      "pip install -r examples/flax/text-classification/requirements.txt",
-      "pip install ml_dtypes==0.2.0",
-  )
-
-  run_model_cmds = (
-      (
-          "cd /tmp/transformers/examples/flax/text-classification &&"
-          " JAX_PLATFORM_NAME=TPU python3 run_flax_glue.py --output_dir"
-          " ./bert-glue --model_name_or_path bert-base-cased"
-          f" --overwrite_output_dir --task_name {task_name} --num_train_epochs"
-          f" {num_train_epochs} --logging_dir ./bert-glue {extraFlags}"
-      ),
-  )
+  set_up_cmds = get_flax_bert_setup_cmds()
+  run_model_cmds = get_flax_bert_run_model_cmds(task_name, num_train_epochs, extraFlags)
 
   job_test_config = test_config.TpuVmTest(
       test_config.Tpu(
@@ -445,6 +529,61 @@ def get_flax_bert_config(
   return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
+  )
+
+
+def get_flax_bert_conv_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    task_name: str,
+    num_train_epochs: int = 1,
+    extraFlags: str = "",
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=PROJECT_NAME,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = get_flax_bert_setup_cmds()
+  work_dir = "/tmp/transformers/bert-glue"
+  tf_summary_location = f"{work_dir}/events.out.tfevents.flax-bert.v2"
+  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bert/{task_name}/{RUN_DATE}/events.out.tfevents.flax-bert.v2"
+  extra_run_cmds = (
+      f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
+      f"gsutil cp {tf_summary_location} {gcs_location} || exit 0",
+  )
+  run_model_cmds = get_flax_bert_run_model_cmds(
+      task_name, num_train_epochs, extraFlags, extra_run_cmds
+  )
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=RUNTIME_IMAGE,
+          reserved=IS_TPU_RESERVED,
+      ),
+      test_name=f"flax_bert_{task_name}_conv",
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.SHIVA_S,
+  )
+
+  job_metric_config = metric_config.MetricConfig(
+      tensorboard_summary=metric_config.SummaryConfig(
+          file_location=gcs_location,
+          aggregation_strategy=metric_config.AggregationStrategy.LAST,
+      )
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
   )
 
 

--- a/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
+++ b/configs/xlml/jax/solutionsteam_flax_latest_supported_config.py
@@ -25,7 +25,6 @@ from datetime import datetime
 
 PROJECT_NAME = Project.CLOUD_ML_AUTO_SOLUTIONS.value
 RUNTIME_IMAGE = RuntimeVersion.TPU_UBUNTU2204_BASE.value
-IS_TPU_RESERVED = True
 RUN_DATE = datetime.now().strftime("%Y_%m_%d")
 
 
@@ -384,6 +383,7 @@ def get_flax_bart_config(
     tpu_zone: str,
     time_out_in_min: int,
     num_train_epochs: int,
+    is_tpu_reserved: bool = True,
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
@@ -447,7 +447,7 @@ def get_flax_bart_conv_config(
           version=tpu_version,
           cores=tpu_cores,
           runtime_version=RUNTIME_IMAGE,
-          reserved=IS_TPU_RESERVED,
+          reserved=is_tpu_reserved,
       ),
       test_name="flax_bart_wiki_conv",
       set_up_cmds=set_up_cmds,
@@ -501,6 +501,7 @@ def get_flax_bert_config(
     time_out_in_min: int,
     task_name: str,
     num_train_epochs: int = 1,
+    is_tpu_reserved: bool = True,
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
@@ -539,6 +540,7 @@ def get_flax_bert_conv_config(
     time_out_in_min: int,
     task_name: str,
     num_train_epochs: int = 1,
+    is_tpu_reserved: bool = True,
     extraFlags: str = "",
 ) -> task.TpuQueuedResourceTask:
   job_gcp_config = gcp_config.GCPConfig(
@@ -564,7 +566,7 @@ def get_flax_bert_conv_config(
           version=tpu_version,
           cores=tpu_cores,
           runtime_version=RUNTIME_IMAGE,
-          reserved=IS_TPU_RESERVED,
+          reserved=is_tpu_reserved,
       ),
       test_name=f"flax_bert_{task_name}_conv",
       set_up_cmds=set_up_cmds,

--- a/dags/xlml/solutionsteam_flax_latest_supported.py
+++ b/dags/xlml/solutionsteam_flax_latest_supported.py
@@ -277,7 +277,7 @@ with models.DAG(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
-      time_out_in_min=60,
+      time_out_in_min=120,
       task_name="mnli",
       num_train_epochs=3,
       extraFlags=" ".join(jax_bert_v4_mnli_conv_extra_flags),

--- a/dags/xlml/solutionsteam_flax_latest_supported.py
+++ b/dags/xlml/solutionsteam_flax_latest_supported.py
@@ -135,7 +135,7 @@ with models.DAG(
   jax_vit_conv_extra_flags = jax_vit_func_extra_flags + [
       "--model_name_or_path google/vit-base-patch16-224-in21k",
   ]
-  jax_vit_v4_32 = flax_config.get_flax_vit_conv_config(
+  jax_vit_conv_v4_32 = flax_config.get_flax_vit_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
@@ -228,6 +228,7 @@ with models.DAG(
       tpu_cores=8,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
+      num_train_epochs=3,
       extraFlags=" ".join(jax_bart_v4_8_extra_flags),
   ).run()
 
@@ -235,23 +236,34 @@ with models.DAG(
       "--per_device_train_batch_size=32",
       "--per_device_eval_batch_size=32",
   ]
-  jax_bart_v4_32 = flax_config.get_flax_bart_config(
+  jax_bart_conv_v4_32 = flax_config.get_flax_bart_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
+      num_train_epochs=30,
       extraFlags=" ".join(jax_bart_v4_32_extra_flags),
   ).run()
 
   # BERT
+  jax_bert_v4_batch_size = [
+      "--per_device_train_batch_size=8",
+      "--per_device_eval_batch_size=8",
+  ]
+  jax_bert_conv_extra_flags = [
+      "--learning_rate 2e-5",
+      "--eval_steps 500",
+  ]
+
   jax_bert_mnli_extra_flags = [
       "--max_seq_length 512",
       "--eval_steps 1000",
   ]
-  jax_bert_v4_mnli_extra_flags = jax_bert_mnli_extra_flags + [
-      "--per_device_train_batch_size=8",
-      "--per_device_eval_batch_size=8",
-  ]
+  jax_bert_v4_mnli_extra_flags = jax_bert_mnli_extra_flags + jax_bert_v4_batch_size
+  jax_bert_v4_mnli_conv_extra_flags = (
+      jax_bert_mnli_extra_flags + jax_bert_v4_batch_size + jax_bert_conv_extra_flags
+  )
+
   jax_bert_mnli_v4_8 = flax_config.get_flax_bert_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=8,
@@ -261,23 +273,25 @@ with models.DAG(
       extraFlags=" ".join(jax_bert_v4_mnli_extra_flags),
   ).run()
 
-  jax_bert_mnli_v4_32 = flax_config.get_flax_bert_config(
+  jax_bert_mnli_conv_v4_32 = flax_config.get_flax_bert_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       task_name="mnli",
-      extraFlags=" ".join(jax_bert_v4_mnli_extra_flags),
+      num_train_epochs=3,
+      extraFlags=" ".join(jax_bert_v4_mnli_conv_extra_flags),
   ).run()
 
   jax_bert_mrpc_extra_flags = [
       "--max_seq_length 128",
       "--eval_steps 100",
   ]
-  jax_bert_v4_mrpc_extra_flags = jax_bert_mrpc_extra_flags + [
-      "--per_device_train_batch_size=8",
-      "--per_device_eval_batch_size=8",
-  ]
+  jax_bert_v4_mrpc_extra_flags = jax_bert_mrpc_extra_flags + jax_bert_v4_batch_size
+  jax_bert_v4_mrpc_conv_extra_flags = (
+      jax_bert_mrpc_extra_flags + jax_bert_v4_batch_size + jax_bert_conv_extra_flags
+  )
+
   jax_bert_mrpc_v4_8 = flax_config.get_flax_bert_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=8,
@@ -287,13 +301,14 @@ with models.DAG(
       extraFlags=" ".join(jax_bert_v4_mrpc_extra_flags),
   ).run()
 
-  jax_bert_mrpc_v4_32 = flax_config.get_flax_bert_config(
+  jax_bert_mrpc_conv_v4_32 = flax_config.get_flax_bert_conv_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       task_name="mrpc",
-      extraFlags=" ".join(jax_bert_v4_mrpc_extra_flags),
+      num_train_epochs=3,
+      extraFlags=" ".join(jax_bert_v4_mrpc_conv_extra_flags),
   ).run()
 
   # WMT
@@ -311,13 +326,13 @@ with models.DAG(
   jax_resnet_v4_8 >> jax_resnet_v4_32
   jax_resnet_v5e_4 >> jax_resnet_v5e_16
   jax_resnet_v5p_8 >> jax_resnet_v5p_32
-  jax_vit_v4_8 >> jax_vit_v4_32
+  jax_vit_v4_8 >> jax_vit_conv_v4_32
   jax_vit_v5e_4
   jax_gpt2_v4_8 >> jax_gpt2_v4_32
   jax_gpt2_v5e_4
   jax_sd_v4_8 >> jax_sd_v4_32
   jax_sd_v5e_4
-  jax_bart_v4_8 >> jax_bart_v4_32
-  jax_bert_mnli_v4_8 >> jax_bert_mnli_v4_32
-  jax_bert_mrpc_v4_8 >> jax_bert_mrpc_v4_32
+  jax_bart_v4_8 >> jax_bart_conv_v4_32
+  jax_bert_mnli_v4_8 >> jax_bert_mnli_conv_v4_32
+  jax_bert_mrpc_v4_8 >> jax_bert_mrpc_conv_v4_32
   jax_wmt_v4_8


### PR DESCRIPTION
# Description

Add conv tests for BART and BERT:
* Create helpers for commonly used commands
* Add helper config `get_flax_bart_conv_config` for BART conv tests - [source](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bart-wiki_summary.libsonnet)
* Add helper config `get_flax_bert_conv_config` for BERT conv tests - [source bert-mnli](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bert-glue_mnli.libsonnet), [source bert-mrpc](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bert-glue_mrpc.libsonnet)
* Other small changes, i.e. variable name change for ViT conv test

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
* BART Conv test on v4-32
  * Airflow test pass: [link](https://screenshot.googleplex.com/nMSVzi2zaToMCJ2)
  * Conv metric [train_loss](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bart-wiki_summary.libsonnet#L65) can be found in post_process result and the alarm will be set up [dashboard](http://go/ml-auto-solutions-dashboard) once changes are merged and data is in BigQuery

```
[2024-01-09, 03:19:15 UTC] {logging_mixin.py:150} INFO - Test run rows: [TestRun(job_history=JobHistoryRow(uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2
e6bd57e6f3f1118c', timestamp=datetime.datetime(2024, 1, 9, 3, 19, 12, 153977), owner='Shiva S.', 
job_name='flax_bart_wiki_conv-v4-32', job_status=0), metric_history=
[MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f11
18c', metric_key='train_time', metric_value=984.3043212890625), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='train_learning_rate', metric_value=1.8724799488722965e-08), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='train_loss', metric_value=0.9626200199127197), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_loss', metric_value=0.9807181358337402), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rouge1', metric_value=1.0702999830245972), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rouge2', metric_value=0.17020000517368317), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rougeL', metric_value=1.0693000555038452), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_rougeLsum', metric_value=1.065000057220459), 
MetricHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f111
8c', metric_key='eval_gen_len', metric_value=64.0)], metadata_history=
[MetadataHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3
f1118c', metadata_key='run_id', metadata_value='manual__2023-12-18T22:37:57.062465+00:00'), 
MetadataHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f
1118c', metadata_key='prev_start_date_success', metadata_value='2023-12-
14T00:18:08.979390+00:00'), 
MetadataHistoryRow(job_uuid='07f145ed31745093ee4bac590d4fe4b1ca1290354e5a9ea2e6bd57e6f3f
1118c', metadata_key='airflow_dag_run_link', 
metadata_value='https://7ef24502ca144d038c5754964af60450-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-12-
18T22%3A37%3A57.062465%2B00%3A00&task_id=flax_bart_wiki_conv-v4-
32.post_process.process_metrics')])]
```

* BERT - glue_mrpc conv test on v4-32
  * Airflow test pass: [link](https://screenshot.googleplex.com/Bh78R4H2EBKiALz)
  * Conv metric [eval_accuracy](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bert-glue_mrpc.libsonnet#L40) can be found in post_process result and the alarm will be set up [dashboard](http://go/ml-auto-solutions-dashboard)
  
```
[2024-01-09, 08:08:58 UTC] {logging_mixin.py:150} INFO - Test run rows: 
[TestRun(job_history=JobHistoryRow(uuid='8c7bb955cbdecbb7a9228370c9b17339a07ad4b76906fafc
dd446cab2dbce245', timestamp=datetime.datetime(2024, 1, 9, 8, 8, 57, 980901), owner='Shiva S.', 
job_name='flax_bert_mrpc_conv-v4-32', job_status=0), metric_history=
[MetricHistoryRow(job_uuid='8c7bb955cbdecbb7a9228370c9b17339a07ad4b76906fafcdd446cab2db
ce245', metric_key='eval_accuracy', metric_value=0.8504902124404907), 
MetricHistoryRow(job_uuid='8c7bb955cbdecbb7a9228370c9b17339a07ad4b76906fafcdd446cab2dbc
e245', metric_key='eval_f1', metric_value=0.8950086236000061)], metadata_history=
[MetadataHistoryRow(job_uuid='8c7bb955cbdecbb7a9228370c9b17339a07ad4b76906fafcdd446cab2
dbce245', metadata_key='run_id', metadata_value='manual__2023-12-18T22:37:57.062465+00:00'), 
MetadataHistoryRow(job_uuid='8c7bb955cbdecbb7a9228370c9b17339a07ad4b76906fafcdd446cab2
dbce245', metadata_key='prev_start_date_success', metadata_value='2023-12-
14T00:18:08.979390+00:00'), 
MetadataHistoryRow(job_uuid='8c7bb955cbdecbb7a9228370c9b17339a07ad4b76906fafcdd446cab2
dbce245', metadata_key='airflow_dag_run_link', 
metadata_value='https://7ef24502ca144d038c5754964af60450-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?
dag_run_id=manual__2023-12-
18T22%3A37%3A57.062465%2B00%3A00&task_id=flax_bert_mrpc_conv-v4-
32.post_process.process_metrics')])]
```

* BERT - glue_mnli conv test on v4-32
  * Airflow test pass: [link](https://screenshot.googleplex.com/83eVKBrWYugdSCg)
  * Conv metric [eval_accuracy](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/jax/latest/flax-bert-glue_mnli.libsonnet#L41) can be found in post_process result and the alarm will be set up [dashboard](http://go/ml-auto-solutions-dashboard)
  
```
[2024-01-09, 17:08:55 UTC] {logging_mixin.py:150} INFO - Test run rows: 
[TestRun(job_history=JobHistoryRow(uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989
ca3', timestamp=datetime.datetime(2024, 1, 9, 17, 8, 36, 191985), owner='Shiva S.', job_name='flax_bert_mnli_conv-v4-
32', job_status=0), metric_history=
[MetricHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metric_key='train_time', metric_value=56205.8671875), 
MetricHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metric_key='train_learning_rate', metric_value=1.7059205958958046e-07), 
MetricHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metric_key='train_loss', metric_value=0.32483866810798645), 
MetricHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metric_key='eval_accuracy', metric_value=0.8415690064430237)], metadata_history=
[MetadataHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metadata_key='run_id', metadata_value='manual__2023-12-18T22:37:57.062465+00:00'), 
MetadataHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metadata_key='prev_start_date_success', metadata_value='2023-12-14T00:18:08.979390+00:00'), 
MetadataHistoryRow(job_uuid='7753404226ad754653fc8a03e7ff43b676e46a03afdbb21caf562557b7989ca3', 
metadata_key='airflow_dag_run_link', metadata_value='https://7ef24502ca144d038c5754964af60450-dot-us-
central1.composer.googleusercontent.com/dags/flax_latest_supported/grid?dag_run_id=manual__2023-12-
18T22%3A37%3A57.062465%2B00%3A00&task_id=flax_bert_mnli_conv-v4-32.post_process.process_metrics')])]

```



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.
