### PR TITLE
Update keras test order

### DIFF
--- a/dags/xlml/solutionsteam_tf_nightly_supported.py
+++ b/dags/xlml/solutionsteam_tf_nightly_supported.py
@@ -20,63 +20,65 @@ from configs import composer_env
 from configs.vm_resource import TpuVersion, Project, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
 from configs.xlml.tensorflow import solutionsteam_tf_nightly_supported_config as tf_config
 from configs.xlml.tensorflow import common
+from airflow.operators.dummy import DummyOperator
 
 
 # Run once a day at 6 am UTC (10 pm PST)
 SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
 
 
-# TODO(ranran): remove concurrency param when we have enough v2-8 capacity for Keras
 with models.DAG(
     dag_id="tf_nightly_supported",
     schedule=SCHEDULED_TIME,
     tags=["solutions_team", "tf", "nightly", "supported", "xlml"],
     start_date=datetime.datetime(2023, 8, 16),
-    concurrency=6,
     catchup=False,
 ) as dag:
-  # Keras
-  tf_keras_v2_8 = [
-      tf_config.get_tf_keras_config(
-          tpu_version=TpuVersion.V2,
-          tpu_cores=8,
-          tpu_zone=Zone.US_CENTRAL1_C.value,
-          time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-          test_feature=feature,
-          test_name=name,
-      ).run()
-      for feature, name in common.FEATURE_NAME.items()
-  ]
+  # Keras - tests run in sequence order
+  tf_keras_v2_8 = [DummyOperator(task_id="tf_nightly_keras_v2-8")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        tpu_version=TpuVersion.V2,
+        tpu_cores=8,
+        tpu_zone=Zone.US_CENTRAL1_C.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+    ).run()
+    tf_keras_v2_8[-1] >> test
+    tf_keras_v2_8.append(test)
 
-  tf_keras_v5e_4 = [
-      tf_config.get_tf_keras_config(
-          project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
-          tpu_version=TpuVersion.V5E,
-          tpu_cores=4,
-          tpu_zone=Zone.US_EAST1_C.value,
-          time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-          test_feature=feature,
-          test_name=name,
-          network=V5_NETWORKS,
-          subnetwork=V5E_SUBNETWORKS,
-      ).run()
-      for feature, name in common.FEATURE_NAME.items()
-  ]
+  tf_keras_v5e_4 = [DummyOperator(task_id="tf_nightly_keras_v5litepod-4")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+        tpu_version=TpuVersion.V5E,
+        tpu_cores=4,
+        tpu_zone=Zone.US_EAST1_C.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        network=V5_NETWORKS,
+        subnetwork=V5E_SUBNETWORKS,
+    ).run()
+    tf_keras_v5e_4[-1] >> test
+    tf_keras_v5e_4.append(test)
 
-  tf_keras_v5p_8 = [
-      tf_config.get_tf_keras_config(
-          project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
-          tpu_version=TpuVersion.V5P,
-          tpu_cores=8,
-          tpu_zone=Zone.US_EAST5_A.value,
-          time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-          test_feature=feature,
-          test_name=name,
-          network=V5_NETWORKS,
-          subnetwork=V5P_SUBNETWORKS,
-      ).run()
-      for feature, name in common.FEATURE_NAME.items()
-  ]
+  tf_keras_v5p_8 = [DummyOperator(task_id="tf_nightly_keras_v5p-8")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+        tpu_version=TpuVersion.V5P,
+        tpu_cores=8,
+        tpu_zone=Zone.US_EAST5_A.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        network=V5_NETWORKS,
+        subnetwork=V5P_SUBNETWORKS,
+    ).run()
+    tf_keras_v5p_8[-1] >> test
+    tf_keras_v5p_8.append(test)
 
   # ResNet
   tf_resnet_v2_8 = tf_config.get_tf_resnet_config(


### PR DESCRIPTION
# Description

Currently, due to capacity issues, Keras tests are [failing](https://screenshot.googleplex.com/agB5vB3Q9ufFBJi) when running in parallel. Update keras test to run in sequential order in short-term fix. Will move it back when capacity is ready in projects (i.e. b/318440465 for v2, b/318855898 for v5e).

This change has been applied to [TF SE nightly Keras tests](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/66).


# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow, and check graph view.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Graph view is expected: [link](https://screenshot.googleplex.com/3iLfQVM3vhA4BVC).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.