### PR TITLE
Add TF SE nightly DLRM test

### DIFF
--- a/configs/gcs_bucket.py
+++ b/configs/gcs_bucket.py
@@ -16,6 +16,7 @@
 
 # GCS bucket for training data
 # TODO(ranran): migrate data to `cloud-ml-auto-solutions` project
+CRITEO_DIR = "gs://xl-ml-test-us-central2/data/criteo/terabyte_processed_shuffled"
 IMAGENET_DIR = "gs://xl-ml-test-us-central2/data/imagenet"
 TFDS_DATA_DIR = "gs://xl-ml-test-us-central2/tfds-data"
 PAX_DIR = "gs://cloud-tpu-checkpoints/pax"

--- a/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/configs/xlml/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -19,6 +19,7 @@ from configs import gcs_bucket, test_owner
 from configs.xlml.tensorflow import common
 from airflow.models import Variable
 from configs.vm_resource import TpuVersion, Project, RuntimeVersion
+from typing import List
 
 
 def get_tf_keras_config(
@@ -142,6 +143,136 @@ def get_tf_resnet_config(
           " python3 official/vision/train.py"
           f" --tpu={tpu_name} --experiment=resnet_imagenet"
           " --mode=train_and_eval --model_dir=/tmp/output"
+          " --params_override='%s'" % str(params_override)
+      ),
+  )
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=runtime_version,
+          reserved=True,
+          network=network,
+          subnetwork=subnetwork,
+      ),
+      test_name=test_name,
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.CHANDRA_D,
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      tpu_name_env_var=is_pod,
+      all_workers=not is_pod,
+  )
+
+
+def get_tf_dlrm_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    bottom_mlp: List[int],
+    embedding_dim: int,
+    train_steps: int,
+    extraFlags: str = "",
+    project_name: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    runtime_version: str = RuntimeVersion.TPU_VM_TF_2150_PJRT.value,
+    is_pod: bool = False,
+    is_pjrt: bool = True,
+    criteo_dir: str = gcs_bucket.CRITEO_DIR,
+    network: str = "default",
+    subnetwork: str = "default",
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = common.set_up_google_tensorflow_models()
+  params_override = {
+      "runtime": {"distribution_strategy": "tpu"},
+      "task": {
+          "train_data": {
+              "input_path": criteo_dir + "/train/*",
+              "global_batch_size": 16384,
+          },
+          "validation_data": {
+              "input_path": criteo_dir + "/eval/*",
+              "global_batch_size": 16384,
+          },
+          "model": {
+              "interaction": "dot",
+              "num_dense_features": 13,
+              "bottom_mlp": bottom_mlp,
+              "embedding_dim": embedding_dim,
+              "top_mlp": [1024, 1024, 512, 256, 1],
+              "vocab_sizes": [
+                  39884406,
+                  39043,
+                  17289,
+                  7420,
+                  20263,
+                  3,
+                  7120,
+                  1543,
+                  63,
+                  38532951,
+                  2953546,
+                  403346,
+                  10,
+                  2208,
+                  11938,
+                  155,
+                  4,
+                  976,
+                  14,
+                  39979771,
+                  25641295,
+                  39664984,
+                  585935,
+                  12972,
+                  108,
+                  36,
+              ],
+          },
+      },
+      "trainer": {
+          "use_orbit": "true",
+          "validation_interval": 90000,
+          "checkpoint_interval": 270000,
+          "validation_steps": 5440,
+          "train_steps": train_steps,
+          "optimizer_config": {
+              "embedding_optimizer": "SGD",
+              "lr_config": {
+                  "decay_exp": 1.6,
+                  "decay_start_steps": 150000,
+                  "decay_steps": 136054,
+                  "learning_rate": 30,
+                  "warmup_steps": 8000,
+              },
+          },
+      },
+  }
+
+  test_name = "tf_dlrm_criteo"
+  benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
+  # Add default_var to pass DAG check
+  # TODO(ranran): replace Variable.get() to XCOM when it applies
+  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  env_variable = export_env_variable(is_pod, is_pjrt)
+  run_model_cmds = (
+      "sudo chmod -R 777 /tmp/",
+      (
+          f"cd /usr/share/tpu/models && {env_variable} &&"
+          " PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
+          f" --tpu={tpu_name} --model_dir=/tmp/output {extraFlags}"
           " --params_override='%s'" % str(params_override)
       ),
   )

--- a/dags/xlml/solutionsteam_tf_se_nightly_supported.py
+++ b/dags/xlml/solutionsteam_tf_se_nightly_supported.py
@@ -110,8 +110,65 @@ with models.DAG(
       runtime_version=RuntimeVersion.TPU_VM_TF_2150_POD_SE.value,
   ).run()
 
+  # DLRM
+  tf_dlrm_v2_8 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL1_C.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 16],
+      embedding_dim=16,
+      train_steps=10000,
+      extraFlags="--mode=train",
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_SE.value,
+  ).run()
+
+  tf_dlrm_v2_32 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL1_A.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 64],
+      embedding_dim=64,
+      train_steps=256054,
+      extraFlags="--mode=train_and_eval",
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_POD_SE.value,
+  ).run()
+
+  tf_dlrm_v4_8 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 64],
+      embedding_dim=64,
+      train_steps=10000,
+      extraFlags="--mode=train",
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_SE.value,
+  ).run()
+
+  tf_dlrm_v4_32 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 128],
+      embedding_dim=128,
+      train_steps=256054,
+      extraFlags="--mode=train_and_eval",
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.TPU_VM_TF_2150_POD_SE.value,
+  ).run()
+
   # Test dependencies
   tf_keras_v2_8
   tf_resnet_v2_8 >> tf_resnet_v2_32
   tf_resnet_v3_8 >> tf_resnet_v3_32
   tf_resnet_v4_8 >> tf_resnet_v4_32
+  tf_dlrm_v2_8 >> tf_dlrm_v2_32
+  tf_dlrm_v4_8 >> tf_dlrm_v4_32


### PR DESCRIPTION
# Description

Add TF SE nightly DLRM test for v2 and v4 [source code](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/master/tests/tensorflow/nightly-se/tf-dlrm-criteo.libsonnet#L120-L123). All tests in old infra were failing and same for most tests in new infra. I suggest we migrate first and then debug further.

In old infra: 
* v4-8 are failed due to the hang and timeout - [link](https://screenshot.googleplex.com/JdL9KbdjrnFDjNG)
* v2-32 failed due to  `NotFoundError: Exception encountered when calling layer 'ranking' (type Ranking)` error - [link](https://screenshot.googleplex.com/8pTeHiL54fJx6Xv)

In new infra:
* v2-8 - pass
* v2-32 - failed due to `PermissionDeniedError: /tmp/output/train; Permission denied` error. I am not sure why this happen on v2-32 only.
* v4-8 - hang and timeout, same as old infra.
* v4-32 - failed due to `RPC error information from remote target /job:worker/replica:0/task:0 while calling /tensorflow.eager.EagerService/Enqueue:`

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test: [link](https://screenshot.googleplex.com/AnZZa5qyUgmkwce)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.