### PR TITLE
Add MaxText parameter sweep configs/dags on GCE and GKE

### DIFF
--- a/dags/examples/maxtext_sweep_gce_example_dag.py
+++ b/dags/examples/maxtext_sweep_gce_example_dag.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+An example DAG to launch a sweep of MaxText GCE QueuedResource jobs
+sweeping over a range of per_device_batch_size values for a 1B
+model on 1xv4-8.
+"""
+import datetime
+from airflow import models
+from dags import test_owner
+from dags.vm_resource import TpuVersion, Zone, Project, RuntimeVersion
+from dags.multipod.configs import maxtext_sweep_gce_config
+from dags.multipod.configs import common
+
+
+with models.DAG(
+    dag_id="maxtext_sweep_gce_example_dag",
+    schedule=None,
+    tags=["multipod_team", "maxtext"],
+    start_date=datetime.datetime(2024, 1, 10),
+    catchup=False,
+    concurrency=2,
+) as dag:
+  # MaxText set up and run commands
+  base_set_up_cmds = common.download_maxtext()
+  base_run_model_cmds = [
+      "cd /tmp/maxtext",
+      "bash setup.sh MODE=stable",
+      "python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=gs://maxtext-experiments-multipod/ dataset_path=gs://max-datasets-rogue enable_checkpointing=false global_parameter_scale=1 steps=10",
+  ]
+
+  # Get list of MaxText GCE QueuedResource jobs
+  maxtext_sweep_gce_test = maxtext_sweep_gce_config.get_maxtext_sweep_gce_config(
+      test_owner=test_owner.RAYMOND_Z,
+      project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      is_tpu_reserved=False,
+      tpu_version=TpuVersion.V4,
+      tpu_cores=8,
+      runtime_version=RuntimeVersion.TPU_UBUNTU2204_BASE.value,
+      num_slices=[1],
+      run_name_prefix="maxtext-1b",
+      base_set_up_cmds=base_set_up_cmds,
+      base_run_model_cmds=base_run_model_cmds,
+      sweep_params={"M_PER_DEVICE_BATCH_SIZE": [1, 2, 4]},
+  )
+
+  # Run jobs
+  for test in maxtext_sweep_gce_test:
+    test.run()

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+An example DAG to launch a sweep of MaxText GKE XPK workloads
+sweeping over a range of per_device_batch_size values for a 16B model
+on 1xv4-128.
+"""
+
+import datetime
+from airflow import models
+from dags import test_owner
+from dags.vm_resource import TpuVersion, Zone, Project, ClusterName, DockerImage
+from dags.multipod.configs import maxtext_sweep_gke_config
+
+
+with models.DAG(
+    dag_id="maxtext_sweep_gke_example_dag",
+    schedule=None,
+    tags=["multipod_team", "maxtext"],
+    start_date=datetime.datetime(2024, 1, 10),
+    catchup=False,
+    concurrency=2,
+) as dag:
+  # MaxText set up and run commands
+  base_run_model_cmds = [
+      "python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=gs://maxtext-experiments-multipod/ dataset_path=gs://max-datasets-rogue enable_checkpointing=false global_parameter_scale=16 steps=10",
+  ]
+
+  # Get list of MaxText GKE XPK jobs
+  maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+      test_owner=test_owner.RAYMOND_Z,
+      project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
+      cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      tpu_version=TpuVersion.V4,
+      tpu_cores=128,
+      num_slices=[1],
+      docker_image=DockerImage.XPK_MAXTEXT_TEST.value,
+      run_name_prefix="maxtext-16b",
+      base_run_model_cmds=base_run_model_cmds,
+      sweep_params={"M_PER_DEVICE_BATCH_SIZE": [2, 4, 8]},
+  )
+
+  # Run jobs
+  for test in maxtext_sweep_gke_test:
+    test.run()

--- a/dags/multipod/configs/maxtext_gce_config.py
+++ b/dags/multipod/configs/maxtext_gce_config.py
@@ -41,6 +41,8 @@ def get_maxtext_nightly_config(
       project_name=project_name,
       zone=tpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
+      dataset_project=project_name,
+      composer_project=project_name,
   )
   current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
   run_name = (

--- a/dags/multipod/configs/maxtext_sweep_gce_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gce_config.py
@@ -1,0 +1,98 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to construct job sweep GCE configs for maxtext DAG."""
+
+from xlml.apis import gcp_config, metric_config, task, test_config
+from dags.vm_resource import TpuVersion
+import datetime
+import itertools
+from typing import List, Iterable
+
+
+def get_maxtext_sweep_gce_config(
+    test_owner: str,
+    tpu_version: TpuVersion,
+    num_slices: List[int],
+    sweep_params: {},
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    run_name_prefix: str,
+    project_name: str,
+    runtime_version: str,
+    base_set_up_cmds: Iterable[str],
+    base_run_model_cmds: Iterable[str],
+    is_tpu_reserved: bool = True,
+    network: str = "default",
+    subnetwork: str = "default",
+) -> List[task.TpuQueuedResourceTask]:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+      dataset_project=project_name,
+      composer_project=project_name,
+  )
+
+  # Add num_slices as a sweep param
+  sweep_params["NUM_SLICES"] = num_slices
+
+  # Convert sweep_params to a list of lists to generate sweep param combinations
+  sweep_params_list = []
+  for param, values in sweep_params.items():
+    sweep_params_list.append([(param, val) for val in values])
+
+  # Generate all combinations of sweep param configurations and create a TpuQueuedResourceTask for each one
+  qr_task_list = []
+  current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+  for idx, config in enumerate(itertools.product(*sweep_params_list)):
+    config_dict = {key: value for (key, value) in config}
+
+    # Remove num_slices as a sweep param after combinations have been generated
+    curr_num_slices = config_dict["NUM_SLICES"]
+    del config_dict["NUM_SLICES"]
+
+    # Add MaxText run_name
+    run_name = f"{run_name_prefix}-{curr_num_slices}x{tpu_version.value}-{tpu_cores}-{current_datetime}-{idx}"
+    config_dict["M_RUN_NAME"] = run_name
+
+    # Export sweep params as env variables for MaxText to read
+    run_model_cmds = [f"export {key}={value}" for (key, value) in config_dict.items()]
+    for cmd in base_run_model_cmds:
+      run_model_cmds.append(cmd)
+
+    job_test_config = test_config.TpuVmTest(
+        test_config.Tpu(
+            version=tpu_version,
+            cores=tpu_cores,
+            runtime_version=runtime_version,
+            reserved=is_tpu_reserved,
+            network=network,
+            subnetwork=subnetwork,
+        ),
+        test_name=f"{run_name_prefix}-{idx}",
+        set_up_cmds=base_set_up_cmds,
+        run_model_cmds=run_model_cmds,
+        time_out_in_min=time_out_in_min,
+        task_owner=test_owner,
+        num_slices=curr_num_slices,
+    )
+    qr_task = task.TpuQueuedResourceTask(
+        task_test_config=job_test_config,
+        task_gcp_config=job_gcp_config,
+    )
+    qr_task_list.append(qr_task)
+
+  return qr_task_list

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to construct job sweep GKE configs for maxtext DAG."""
+
+from xlml.apis import gcp_config, metric_config, task, test_config
+from dags.vm_resource import TpuVersion
+import datetime
+import itertools
+from typing import List, Iterable
+
+
+def get_maxtext_sweep_gke_config(
+    test_owner: str,
+    tpu_version: TpuVersion,
+    num_slices: List[int],
+    sweep_params: {},
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    run_name_prefix: str,
+    project_name: str,
+    cluster_name: str,
+    docker_image: str,
+    base_run_model_cmds: Iterable[str],
+    base_set_up_cmds: Iterable[str] = None,
+) -> List[task.TpuXpkTask]:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+      dataset_project=project_name,
+      composer_project=project_name,
+  )
+
+  # Add num_slices as a sweep param
+  sweep_params["NUM_SLICES"] = num_slices
+
+  # Convert sweep_params to a list of lists to generate sweep param combinations
+  sweep_params_list = []
+  for param, values in sweep_params.items():
+    sweep_params_list.append([(param, val) for val in values])
+
+  # Generate all combinations of sweep param configurations and create a TpuXpkTask for each one
+  xpk_task_list = []
+  current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+  for idx, config in enumerate(itertools.product(*sweep_params_list)):
+    config_dict = {key: value for (key, value) in config}
+
+    # Remove num_slices as a sweep param after combinations have been generated
+    curr_num_slices = config_dict["NUM_SLICES"]
+    del config_dict["NUM_SLICES"]
+
+    # Add MaxText run_name
+    run_name = f"{run_name_prefix}-{curr_num_slices}x{tpu_version.value}-{tpu_cores}-{current_datetime}-{idx}"
+    config_dict["M_RUN_NAME"] = run_name
+
+    # Export sweep params as env variables for MaxText to read
+    run_model_cmds = [f"export {key}={value}" for (key, value) in config_dict.items()]
+    for cmd in base_run_model_cmds:
+      run_model_cmds.append(cmd)
+
+    job_test_config = test_config.TpuGkeTest(
+        test_config.Tpu(
+            version=tpu_version,
+            cores=tpu_cores,
+        ),
+        test_name=f"{run_name_prefix}-{idx}",
+        set_up_cmds=base_set_up_cmds,
+        run_model_cmds=run_model_cmds,
+        time_out_in_min=time_out_in_min,
+        task_owner=test_owner,
+        num_slices=curr_num_slices,
+        cluster_name=cluster_name,
+        docker_image=docker_image,
+    )
+    xpk_task = task.TpuXpkTask(
+        task_test_config=job_test_config,
+        task_gcp_config=job_gcp_config,
+    )
+    xpk_task_list.append(xpk_task)
+
+  return xpk_task_list

--- a/dags/multipod/maxtext_nightly.py
+++ b/dags/multipod/maxtext_nightly.py
@@ -26,7 +26,7 @@ SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(
-    dag_id="maxtext_test",
+    dag_id="maxtext_nightly",
     schedule=SCHEDULED_TIME,
     tags=["multipod_team", "maxtext"],
     start_date=datetime.datetime(2024, 1, 10),

--- a/dags/test_owner.py
+++ b/dags/test_owner.py
@@ -29,5 +29,6 @@ RAN_R = "Ran R."
 # PYTORCH
 PEI_Z = "Pei Z."
 
-# Maxtext
+# MaxText
 Tony_C = "Tony C."
+RAYMOND_Z = "Raymond Z."

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -73,3 +73,4 @@ class ClusterName(enum.Enum):
 
 class DockerImage(enum.Enum):
   XPK_JAX_TEST = "gcr.io/cloud-ml-auto-solutions/xpk_jax_test:latest"
+  XPK_MAXTEXT_TEST = "gcr.io/tpu-prod-env-multipod/xpk_maxtext_test:latest"

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -220,7 +220,7 @@ class TpuXpkTask(BaseTask):
           workload_id=workload_id,
           docker_image=self.task_test_config.docker_image,
           accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.run_model_cmds,
+          run_cmds=self.task_test_config.test_script,
           task_owner=self.task_test_config.task_owner,
           startup_timeout=self.task_test_config.startup_time_out_in_sec,
           num_slices=self.task_test_config.num_slices,

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -62,6 +62,9 @@ def run_workload(
       f"gcloud config set compute/zone {zone}",
       "git clone https://github.com/google/xpk.git /tmp/xpk",
       "cd /tmp/xpk",
+      "apt-get update && apt-get install -y google-cloud-sdk",
+      "apt-get install -y kubectl",
+      "apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin",
       (
           "python3 xpk.py workload create"
           f" --cluster={cluster_name} --workload={workload_id} --command='{run_cmds}'"


### PR DESCRIPTION
# Description

Add configs/dags for launching parameter job sweeps with MaxText on GCE and GKE.
* `maxtext_sweep_gce_config` and `maxtext_sweep_gke_config` will take in test settings (project_name, tpu_type, num_slices, etc.) and maxtext sweep parameters (per_device_batch_size, remat_policy, ici_tensor_parallelism, etc.), generate all combinations of sweep parameter configurations, and then launch QR jobs or XPK workloads for all configurations
* `maxtext_sweep_gke_example_dag` and `maxtext_sweep_gce_example_dag` are example dags for using these configs

# Tests
* Successfully ran `maxtext_sweep_gce_example_dag` which launched 3 MaxText QR jobs on 1xv4-8 varying the per_device_batch_size
* Successfully ran `maxtext_sweep_gke_example_dag` which launched 3 MaxText GKE/XPK workloads on 1xv4-128 varying the per_device_batch_size
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.