### PR TITLE
Add valid_until_duration to QR

### DIFF
--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -30,14 +30,20 @@ class Project(enum.Enum):
 
 
 class Zone(enum.Enum):
-  US_CENTRAL1_A = "us-central1-a"  # reservation for v2-32 in cloud-ml-auto-solutions
-  US_CENTRAL2_B = (  # reservation for v4-8 & v4-32 in cloud-ml-auto-solutions
-      "us-central2-b"
-  )
-  US_CENTRAL1_C = "us-central1-c"  # reservation for v2-8 in cloud-ml-auto-solutions
-  US_EAST1_C = "us-east1-c"  # reservation for v5e in tpu-prod-env-automated
-  US_EAST1_D = "us-east1-d"  # reservation for v3-8 & v3-32 in cloud-ml-auto-solutions
-  US_EAST5_A = "us-east5-a"  # reservation for v5p in tpu-prod-env-automated
+  # reserved/on-demand v2-32 in cloud-ml-auto-solutions
+  US_CENTRAL1_A = "us-central1-a"
+  # on-demand v3-8 in cloud-ml-auto-solutions
+  US_CENTRAL1_B = "us-central1-b"
+  # reserved v4-8 & v4-32 in cloud-ml-auto-solutions
+  US_CENTRAL2_B = "us-central2-b"
+  # reserved/on-demand v2-8 in cloud-ml-auto-solutions
+  US_CENTRAL1_C = "us-central1-c"
+  # reserved v5e in tpu-prod-env-automated
+  US_EAST1_C = "us-east1-c"
+  # reserved v3-8 & reserved/on-demand v3-32 in cloud-ml-auto-solutions
+  US_EAST1_D = "us-east1-d"
+  # reserved v5p in tpu-prod-env-automated
+  US_EAST5_A = "us-east5-a"
 
 
 class TpuVersion(enum.Enum):

--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -34,6 +34,7 @@ import google.longrunning.operations_pb2 as operations
 from xlml.utils import ssh
 import paramiko
 from airflow.models import Variable
+from google.protobuf.duration_pb2 import Duration
 
 
 @task
@@ -88,7 +89,6 @@ def create_queued_resource(
       )
 
     queued_resource = tpu_api.QueuedResource(
-        # TODO(wcromar): Implement `validUntilDuration` based on `timeout`
         # TODO(ranran): enable configuration via `AcceleratorConfig`
         tpu=tpu_api.QueuedResource.Tpu(
             node_spec=[
@@ -114,6 +114,9 @@ def create_queued_resource(
         ),
         guaranteed=tpu_api.QueuedResource.Guaranteed(
             reserved=accelerator.reserved,
+        ),
+        queueing_policy=tpu_api.QueuedResource.QueueingPolicy(
+            valid_until_duration=Duration(seconds=int(timeout.total_seconds())),
         ),
     )
 


### PR DESCRIPTION
# Description

* Add valid_until_duration feature to QR
* Add available on-demand zones for resources based on b/318440465, b/318446082 

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test

**List links for your tests (use go/shortn-gen for any internal link):** ...
* Changes in QR: [link](https://screenshot.googleplex.com/5gNznsXPqyJKNB6)
* QR failed at the time, which is expected: [link](https://screenshot.googleplex.com/8fTAa7wW4qaQru3)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.