### PR TITLE
Add MaxText tests for Llama2, Mistral, and Gamma

### DIFF
--- a/dags/multipod/configs/common.py
+++ b/dags/multipod/configs/common.py
@@ -15,13 +15,24 @@
 """Utilities to construct common configs."""
 
 from typing import Tuple
+import enum
 
 UPGRADE_PIP = "pip install --upgrade pip"
 
 
+class SetupMode(enum.Enum):
+  STABLE = "stable"
+  NIGHTLY = "nightly"
+
+
 def download_maxtext() -> Tuple[str]:
-  """Common set up for flax repo."""
+  """Download MaxText repo."""
   return (
       UPGRADE_PIP,
       "git clone https://github.com/google/maxtext.git /tmp/maxtext",
   )
+
+
+def setup_maxtext(mode: SetupMode) -> Tuple[str]:
+  """Common set up for MaxText repo."""
+  return download_maxtext() + (f"cd /tmp/maxtext && bash setup.sh MODE={mode.value}",)

--- a/dags/multipod/configs/maxtext_gce_config.py
+++ b/dags/multipod/configs/maxtext_gce_config.py
@@ -73,7 +73,54 @@ def get_maxtext_nightly_config(
       set_up_cmds=set_up_cmds,
       run_model_cmds=run_model_cmds,
       time_out_in_min=time_out_in_min,
-      task_owner=test_owner.Tony_C,
+      task_owner=test_owner.TONY_C,
+      num_slices=num_slices,
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+  )
+
+
+def get_maxtext_end_to_end_test_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    test_name: str,
+    test_script: str,
+    test_mode: common.SetupMode,
+    project_name: str = PROJECT_NAME,
+    runtime_version: str = RUNTIME_IMAGE,
+    network: str = "default",
+    subnetwork: str = "default",
+    is_tpu_reserved: bool = True,
+    num_slices: int = 1,
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = common.setup_maxtext(test_mode)
+  run_model_cmds = (f"cd /tmp/maxtext && bash end_to_end/{test_script}.sh",)
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=runtime_version,
+          reserved=is_tpu_reserved,
+          network=network,
+          subnetwork=subnetwork,
+      ),
+      test_name=test_name,
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.JON_B,
       num_slices=num_slices,
   )
 

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run end-to-end MaxText tests."""
+
+
+import datetime
+from airflow import models
+from dags import composer_env
+from dags.vm_resource import TpuVersion, Zone
+from dags.multipod.configs import maxtext_gce_config
+from dags.multipod.configs.common import SetupMode
+
+
+# Run once a day at 4 am UTC (8 pm PST)
+SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="maxtext_end_to_end",
+    schedule=SCHEDULED_TIME,
+    tags=["multipod_team", "maxtext", "stable", "nightly"],
+    start_date=datetime.datetime(2024, 1, 19),
+    catchup=False,
+) as dag:
+  test_name_prefix = "maxtext"
+  test_models = ["llama2", "mistral", "gamma"]
+  test_modes = [SetupMode.STABLE, SetupMode.NIGHTLY]
+
+  for model in test_models:
+    for mode in test_modes:
+      maxtext_gce_config.get_maxtext_end_to_end_test_config(
+          tpu_version=TpuVersion.V4,
+          tpu_cores=8,
+          tpu_zone=Zone.US_CENTRAL2_B.value,
+          time_out_in_min=60,
+          is_tpu_reserved=False,
+          test_name=f"{test_name_prefix}-{mode.value}-{model}",
+          test_script=f"test_{model}",
+          test_mode=mode,
+      ).run()

--- a/dags/multipod/maxtext_nightly.py
+++ b/dags/multipod/maxtext_nightly.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A DAG to run all supported ML models with the latest JAX/FLAX version."""
+"""A DAG to run MaxText tests with nightly version."""
 
 import datetime
 from airflow import models
@@ -28,7 +28,7 @@ SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="maxtext_test",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext"],
+    tags=["multipod_team", "maxtext", "nightly"],
     start_date=datetime.datetime(2024, 1, 10),
     catchup=False,
 ) as dag:

--- a/dags/test_owner.py
+++ b/dags/test_owner.py
@@ -30,4 +30,5 @@ RAN_R = "Ran R."
 PEI_Z = "Pei Z."
 
 # Maxtext
-Tony_C = "Tony C."
+TONY_C = "Tony C."
+JON_B = "Jon B."


### PR DESCRIPTION
# Description

Add decode test for Llama2, Mistral, and Gamma
* Reuse the end-to-end bash scripts in MaxText repo
* This PR needs to be done along with another PR in MaxText repo - [PR](https://github.com/google/maxtext/pull/379)

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow, and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
* Successful run for three models on both stable and nightly on Airflow: [link](https://screenshot.googleplex.com/3DBMBFEaMgXyz2A)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.