### PR TITLE
Scale up the env

### DIFF
--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -113,10 +113,12 @@ resource "google_composer_environment" "example_environment" {
   name     = each.value.environment_name
 
   config {
+    environment_size = "ENVIRONMENT_SIZE_MEDIUM"
     software_config {
       image_version = "composer-2.4.6-airflow-2.6.3"
       airflow_config_overrides = {
         core-allowed_deserialization_classes = ".*"
+        scheduler-min_file_process_interval = "120"
       }
       # Note: keep this in sync with .github/requirements.txt
       pypi_packages = {
@@ -139,7 +141,7 @@ resource "google_composer_environment" "example_environment" {
         cpu        = 2
         memory_gb  = 8
         storage_gb = 10
-        count      = 2
+        count      = 4
       }
       web_server {
         cpu        = 2
@@ -151,7 +153,7 @@ resource "google_composer_environment" "example_environment" {
         memory_gb  = 8
         storage_gb = 10
         min_count  = 1
-        max_count  = 3
+        max_count  = 100
       }
     }
 


### PR DESCRIPTION
# Description

Scale up the env, as more tests are onboarding (noticed a few tasked being killed and waiting in queue):
* change env size from small to medium, so it allows more total dags and running tasks - [ref](https://screenshot.googleplex.com/BpCfDLtfzNk3Q9X)
* increase the max number of workers from 3 to 100, so the env can automatically scale up when needed
* increase `scheduler-min_file_process_interval` from default 30s to 120s, and increase the scheduler to 4 to address [long duration of parse time of dags](https://screenshot.googleplex.com/7MTYTizxRk45b5y). In tutorial it mentioned `The default DAG parsing frequency in Airflow is 30 seconds; if DAG parsing time exceeds this threshold, parsing cycles start to overlap, which then exhausts scheduler's capacity.` 

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test it on Airflow:
* parse time drops: [link](https://screenshot.googleplex.com/7MTYTizxRk45b5y)
* killed tasks and queued tasks seem fine, but will need to keep monitoring: [link](https://screenshot.googleplex.com/7tSD8m7fRam4QBZ)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.