### PR TITLE
Update CPU and memory for cluster

### DIFF
--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -138,10 +138,10 @@ resource "google_composer_environment" "example_environment" {
 
     workloads_config {
       scheduler {
-        cpu        = 2
-        memory_gb  = 8
+        cpu        = 4
+        memory_gb  = 13
         storage_gb = 10
-        count      = 4
+        count      = 2
       }
       web_server {
         cpu        = 2
@@ -149,8 +149,8 @@ resource "google_composer_environment" "example_environment" {
         storage_gb = 10
       }
       worker {
-        cpu        = 2
-        memory_gb  = 8
+        cpu        = 8
+        memory_gb  = 13
         storage_gb = 10
         min_count  = 1
         max_count  = 100


### PR DESCRIPTION
# Description

After the deployment of [change](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/101), I still noticed [tasks being killed](https://screenshot.googleplex.com/8Na9jzngtnLcDeH). 

Based on tutorial: `The most common reason for Zombie tasks is the shortage of CPU and memory resources in your environment's cluster. As a result, an Airflow worker might not be able to report the status of a task, or a sensor might be interrupted abruptly. In this case, the scheduler marks a given task as a Zombie task. To avoid Zombie tasks, assign more resources to your environment.`

* Update worker memory_gb from 8 to 13, and increase worker CPU from 2 to 8

For scheduler, I noticed this recommendation from [UI](https://screenshot.googleplex.com/7Lh9K3pqH8XES7f):
* reduce number of schedulers from 4 to 2
* update memory and CPU cores instead

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...
For past 12 hours - [link](https://screenshot.googleplex.com/9fPv8koNVcpACsa): 
* no zombie tasks are being killed
* no. of queued tasks are much smaller than running tasks
* no dag processing error

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.