### PR TITLE
add compute instance admin role

### DIFF
--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -99,6 +99,14 @@ resource "google_project_iam_member" "monitoring_viewer_role" {
   role     = "roles/monitoring.viewer"
 }
 
+resource "google_project_iam_member" "compute_instance_admin_role" {
+  provider = google-beta
+  for_each = local.environment_config_dict
+  project  = var.project_config.project_name
+  member   = format("serviceAccount:%s", google_service_account.custom_service_account[each.key].email)
+  role     = "roles/compute.instanceAdmin.v1"
+}
+
 resource "google_service_account_iam_member" "custom_service_account" {
   provider           = google-beta
   for_each           = local.environment_config_dict


### PR DESCRIPTION
Add compute.instanceAdmin.v1 role to PROD and DEV environment. The role is for creating VM instance through gcp v1 api.