### PR TITLE
Adding TF_USE_LEGACY_KERAS flag to DLRM runs

### DIFF
--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -279,7 +279,7 @@ def get_tf_dlrm_config(
       "sudo chmod -R 777 /tmp/",
       (
           f"cd /usr/share/tpu/models && {env_variable} &&"
-          " PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
+          " TF_USE_LEGACY_KERAS=1 PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
           f" --tpu={tpu_name} --model_dir=/tmp/output {extraFlags}"
           " --params_override='%s'" % str(params_override)
       ),


### PR DESCRIPTION
# Description

DLRM nightly tests are failing due to an unrecognized keras optimizer. Setting the legacy keras flag (already present on the [other tests](https://github.com/GoogleCloudPlatform/ml-auto-solutions/blob/62a169c4ce3ebc4bd297cd3f0ea2f91d5f70c274/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py#L60))

# Tests

I ran the DLRM test locally with the flag and it passed as expected. Changing nothing except unsetting that flag resulted in the same failure that they nightly tests are seeing.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.