### PR TITLE
Add metric_aggregation_strategy to metadata

### DIFF
--- a/dags/multipod/configs/maxtext_sweep_gce_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gce_config.py
@@ -17,14 +17,14 @@
 from xlml.apis import gcp_config, metric_config, task, test_config
 from dags.vm_resource import TpuVersion
 import itertools
-from typing import List, Iterable
+from typing import List, Iterable, Dict, Any
 
 
 def get_maxtext_sweep_gce_config(
     test_owner: str,
     tpu_version: TpuVersion,
     num_slices: List[int],
-    sweep_params: {},
+    sweep_params: Dict[str, List[Any]],
     tpu_cores: int,
     tpu_zone: str,
     time_out_in_min: int,
@@ -38,6 +38,7 @@ def get_maxtext_sweep_gce_config(
     is_tpu_reserved: bool = True,
     network: str = "default",
     subnetwork: str = "default",
+    metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
 ) -> List[task.TpuQueuedResourceTask]:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project_name,
@@ -89,7 +90,7 @@ def get_maxtext_sweep_gce_config(
     job_metric_config = metric_config.MetricConfig(
         tensorboard_summary=metric_config.SummaryConfig(
             file_location=base_output_directory,
-            aggregation_strategy=metric_config.AggregationStrategy.MEDIAN,
+            aggregation_strategy=metric_aggregation_strategy,
             use_regex_file_location=True,
         ),
     )

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -17,14 +17,14 @@
 from xlml.apis import gcp_config, metric_config, task, test_config
 from dags.vm_resource import TpuVersion
 import itertools
-from typing import List, Iterable
+from typing import List, Iterable, Dict, Any
 
 
 def get_maxtext_sweep_gke_config(
     test_owner: str,
     tpu_version: TpuVersion,
     num_slices: List[int],
-    sweep_params: {},
+    sweep_params: Dict[str, List[Any]],
     tpu_cores: int,
     tpu_zone: str,
     time_out_in_min: int,
@@ -36,6 +36,7 @@ def get_maxtext_sweep_gke_config(
     base_run_model_cmds: Iterable[str],
     base_set_up_cmds: Iterable[str] = None,
     dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.BENCHMARK_DATASET,
+    metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
 ) -> List[task.TpuXpkTask]:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project_name,
@@ -85,7 +86,7 @@ def get_maxtext_sweep_gke_config(
     job_metric_config = metric_config.MetricConfig(
         tensorboard_summary=metric_config.SummaryConfig(
             file_location=base_output_directory,
-            aggregation_strategy=metric_config.AggregationStrategy.MEDIAN,
+            aggregation_strategy=metric_aggregation_strategy,
             use_regex_file_location=True,
         ),
     )

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -381,6 +381,7 @@ def add_test_config_metadata(
     base_id: str,
     task_test_config: test_config.TestConfig[test_config.Accelerator],
     task_gcp_config: gcp_config.GCPConfig,
+    task_metric_config: metric_config.MetricConfig,
     metadata: List[List[bigquery.MetricHistoryRow]],
 ) -> List[List[bigquery.MetricHistoryRow]]:
   for index in range(len(metadata)):
@@ -414,6 +415,14 @@ def add_test_config_metadata(
               job_uuid=uuid,
               metadata_key="multislice_topology",
               metadata_value=f"{task_test_config.num_slices}x{task_test_config.accelerator.name}",
+          )
+      )
+    if task_metric_config is not None and task_metric_config.tensorboard_summary:
+      test_config_meta.append(
+          bigquery.MetadataHistoryRow(
+              job_uuid=uuid,
+              metadata_key="metric_aggregation_strategy",
+              metadata_value=task_metric_config.tensorboard_summary.aggregation_strategy.name,
           )
       )
     metadata[index].extend(test_config_meta)
@@ -623,7 +632,11 @@ def process_metrics(
   )
 
   metadata_history_rows_list = add_test_config_metadata(
-      base_id, task_test_config, task_gcp_config, metadata_history_rows_list
+      base_id,
+      task_test_config,
+      task_gcp_config,
+      task_metric_config,
+      metadata_history_rows_list,
   )
 
   # append profile metrics to metric_history_rows_list if any

--- a/xlml/utils/metric_test.py
+++ b/xlml/utils/metric_test.py
@@ -353,10 +353,19 @@ class BenchmarkMetricTest(parameterized.TestCase, absltest.TestCase):
         composer_project="test_project",
     )
 
+    task_metric_config = metric_config.MetricConfig(
+        tensorboard_summary=metric_config.SummaryConfig(
+            file_location="test_file_location",
+            aggregation_strategy=metric_config.AggregationStrategy.MEDIAN,
+            use_regex_file_location=True,
+        ),
+    )
+
     actual_value = metric.add_test_config_metadata(
         base_id,
         task_test_config,
         task_gcp_config,
+        task_metric_config,
         raw_meta,
     )
     print("actual_value", actual_value)
@@ -389,6 +398,13 @@ class BenchmarkMetricTest(parameterized.TestCase, absltest.TestCase):
             job_uuid=uuid,
             metadata_key="topology",
             metadata_value="1xv4-8",
+        )
+    )
+    expected_value[0].append(
+        bigquery.MetadataHistoryRow(
+            job_uuid=uuid,
+            metadata_key="metric_aggregation_strategy",
+            metadata_value="MEDIAN",
         )
     )
     self.assert_metric_and_dimension_equal([], [], actual_value, expected_value)


### PR DESCRIPTION
# Description

* Add `metric_aggregation_strategy` to metadata during metrics post processing
* Allow aggregation strategy to be configured from DAG in `maxtext_sweep_gce_config` and `maxtext_sweep_gke_config`
* Add type annotation for `sweep_params`

# Tests

* Ran `maxtext_sweep_gke_example_dag` in local dev composer environment http://shortn/_0gmUFPCfcH

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.