### PR TITLE
fix filename using timstamp changing issue and allow user to delete g…

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -14,7 +14,6 @@
 
 """Utilities to construct configs for pytorchxla_torchbench DAG."""
 
-from absl import logging
 import datetime
 from typing import Tuple
 from xlml.apis import gcp_config, metric_config, task, test_config

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -14,6 +14,7 @@
 
 """Utilities to construct configs for pytorchxla_torchbench DAG."""
 
+from absl import logging
 import datetime
 from typing import Tuple
 from xlml.apis import gcp_config, metric_config, task, test_config
@@ -82,7 +83,8 @@ def get_torchbench_tpu_config(
 
   set_up_cmds = set_up_torchbench_tpu(model_name)
   local_output_location = "~/xla/benchmarks/output/metric_report.jsonl"
-  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{tpu_version}/{int(datetime.datetime.now().timestamp())}/metric_report_tpu.jsonl"
+  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{tpu_version}/metric_report_tpu.jsonl"
+
   if not model_name or model_name.lower() == "all":
     run_filter = " "
   else:
@@ -118,7 +120,8 @@ def get_torchbench_tpu_config(
   job_metric_config = metric_config.MetricConfig(
       json_lines=metric_config.JSONLinesConfig(
           file_location=gcs_location,
-      )
+      ),
+      clean_up_gcs=True
   )
 
   return task.TpuQueuedResourceTask(
@@ -219,7 +222,7 @@ def get_torchbench_gpu_config(
 
   set_up_cmds = set_up_torchbench_gpu(model_name, nvidia_driver_version)
   local_output_location = "/tmp/xla/benchmarks/output/metric_report.jsonl"
-  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{accelerator_type}/{int(datetime.datetime.now().timestamp())}/metric_report_gpu.jsonl"
+  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{accelerator_type}/metric_report_gpu.jsonl"
 
   if not model_name or model_name.lower() == "all":
     run_filter = " "
@@ -265,7 +268,8 @@ def get_torchbench_gpu_config(
   job_metric_config = metric_config.MetricConfig(
       json_lines=metric_config.JSONLinesConfig(
           file_location=gcs_location,
-      )
+      ),
+      clean_up_gcs=True
   )
 
   return task.GpuCreateResourceTask(

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -121,7 +121,7 @@ def get_torchbench_tpu_config(
       json_lines=metric_config.JSONLinesConfig(
           file_location=gcs_location,
       ),
-      clean_up_gcs=True
+      clean_up_gcs=True,
   )
 
   return task.TpuQueuedResourceTask(
@@ -269,7 +269,7 @@ def get_torchbench_gpu_config(
       json_lines=metric_config.JSONLinesConfig(
           file_location=gcs_location,
       ),
-      clean_up_gcs=True
+      clean_up_gcs=True,
   )
 
   return task.GpuCreateResourceTask(

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -92,8 +92,10 @@ class MetricConfig:
     json_lines: The config for JSON Lines input.
     tensorboard_summary: The config for TensorBoard summary input.
     profile: The config for profile input.
+    clean_up_gcs: Clean up the gcs bucket when finish metric processing.
   """
 
   json_lines: Optional[JSONLinesConfig] = None
   tensorboard_summary: Optional[SummaryConfig] = None
   profile: Optional[ProfileConfig] = None
+  clean_up_gcs: Optional[bool] = False

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -165,6 +165,23 @@ def download_object_from_gcs(source_location: str, destination_location: str) ->
   logging.info(f"Download JSON Lines file to: {destination_location}")
 
 
+def delete_object_from_gcs(source_location: str) -> None:
+  """Delete object from GCS bucket.
+
+  Args:
+    source_location: The full path of a file in GCS.
+  """ 
+
+  storage_client = storage.Client()
+  bucket_name = source_location.split("/")[2]
+  object_name = "/".join(source_location.split("/")[3:])
+
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(object_name)
+  blob.delete(source_location)
+  logging.info(f"Deleted bucket file: {source_location}") 
+
+
 def process_json_lines(
     base_id: str,
     file_location: str,
@@ -680,3 +697,6 @@ def process_metrics(
 
   print("Test run rows:", test_run_rows)
   bigquery_metric.insert(test_run_rows)
+
+  if task_metric_config.clean_up_gcs:
+    delete_object_from_gcs(task_metric_config.json_lines.file_location)

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -178,7 +178,7 @@ def delete_object_from_gcs(source_location: str) -> None:
 
   bucket = storage_client.bucket(bucket_name)
   blob = bucket.blob(object_name)
-  blob.delete(source_location)
+  blob.delete()
   logging.info(f"Deleted bucket file: {source_location}")
 
 

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -170,7 +170,7 @@ def delete_object_from_gcs(source_location: str) -> None:
 
   Args:
     source_location: The full path of a file in GCS.
-  """ 
+  """
 
   storage_client = storage.Client()
   bucket_name = source_location.split("/")[2]
@@ -179,7 +179,7 @@ def delete_object_from_gcs(source_location: str) -> None:
   bucket = storage_client.bucket(bucket_name)
   blob = bucket.blob(object_name)
   blob.delete(source_location)
-  logging.info(f"Deleted bucket file: {source_location}") 
+  logging.info(f"Deleted bucket file: {source_location}")
 
 
 def process_json_lines(


### PR DESCRIPTION
fix filename using timstamp changing issue and allow user to delete gcs file.

# Description

The issue is that post_process currently read the same gcs file every run. This will cause trouble when the gcs file failed to generate but post_process will still try to read the outdated file.

I am trying to avoid passing the file name and modify the task.py. A simple solution is to allow user to delete the gcs file after post_process.

# Tests
https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-torchbench/grid?dag_run_id=manual__2024-02-17T00%3A06%3A25.080243%2B00%3A00&task_id=torchbench_BERT_pytorch-v4-8.post_process.process_metrics&tab=logs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.