### PR TITLE
fix clean_up_gcs attribute issue

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -82,7 +82,8 @@ def get_torchbench_tpu_config(
 
   set_up_cmds = set_up_torchbench_tpu(model_name)
   local_output_location = "~/xla/benchmarks/output/metric_report.jsonl"
-  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{tpu_version}/{int(datetime.datetime.now().timestamp())}/metric_report_tpu.jsonl"
+  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{tpu_version}/metric_report_tpu.jsonl"
+
   if not model_name or model_name.lower() == "all":
     run_filter = " "
   else:
@@ -118,7 +119,8 @@ def get_torchbench_tpu_config(
   job_metric_config = metric_config.MetricConfig(
       json_lines=metric_config.JSONLinesConfig(
           file_location=gcs_location,
-      )
+      ),
+      clean_up_gcs=True,
   )
 
   return task.TpuQueuedResourceTask(
@@ -221,7 +223,7 @@ def get_torchbench_gpu_config(
 
   set_up_cmds = set_up_torchbench_gpu(model_name, nvidia_driver_version)
   local_output_location = "/tmp/xla/benchmarks/output/metric_report.jsonl"
-  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{accelerator_type}/{int(datetime.datetime.now().timestamp())}/metric_report_gpu.jsonl"
+  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{accelerator_type}/metric_report_gpu.jsonl"
 
   if not model_name or model_name.lower() == "all":
     run_filter = " "
@@ -267,7 +269,8 @@ def get_torchbench_gpu_config(
   job_metric_config = metric_config.MetricConfig(
       json_lines=metric_config.JSONLinesConfig(
           file_location=gcs_location,
-      )
+      ),
+      clean_up_gcs=True,
   )
 
   return task.GpuCreateResourceTask(

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -92,8 +92,10 @@ class MetricConfig:
     json_lines: The config for JSON Lines input.
     tensorboard_summary: The config for TensorBoard summary input.
     profile: The config for profile input.
+    clean_up_gcs: Clean up the gcs bucket when finish metric processing.
   """
 
   json_lines: Optional[JSONLinesConfig] = None
   tensorboard_summary: Optional[SummaryConfig] = None
   profile: Optional[ProfileConfig] = None
+  clean_up_gcs: Optional[bool] = False

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -165,6 +165,23 @@ def download_object_from_gcs(source_location: str, destination_location: str) ->
   logging.info(f"Download JSON Lines file to: {destination_location}")
 
 
+def delete_object_from_gcs(source_location: str) -> None:
+  """Delete object from GCS bucket.
+
+  Args:
+    source_location: The full path of a file in GCS.
+  """
+
+  storage_client = storage.Client()
+  bucket_name = source_location.split("/")[2]
+  object_name = "/".join(source_location.split("/")[3:])
+
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(object_name)
+  blob.delete()
+  logging.info(f"Deleted bucket file: {source_location}")
+
+
 def process_json_lines(
     base_id: str,
     file_location: str,
@@ -680,3 +697,6 @@ def process_metrics(
 
   print("Test run rows:", test_run_rows)
   bigquery_metric.insert(test_run_rows)
+
+  if hasattr(task_metric_config, "clean_up_gcs") and task_metric_config.clean_up_gcs:
+    delete_object_from_gcs(task_metric_config.json_lines.file_location)


### PR DESCRIPTION
# Description

Fix the `clean_up_gcs` attribute not specified by the user in `task_metric_config`.

Add `if hasattr(task_metric_config, "clean_up_gcs")...` condition check in metric.py to avoid error out.

# Tests

See if other test can pass this time:

https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/maxtext_nightly/grid
