### PR TITLE
Adding new DAGs for TF 2.16 release tests

### DIFF
--- a/dags/solutions_team/configs/tensorflow/common.py
+++ b/dags/solutions_team/configs/tensorflow/common.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,6 +54,10 @@ FEATURE_TIMEOUT = {
 }
 
 
+CMD_PRINT_TF_VERSION = "python3 -c \"import tensorflow; print('Running using TensorFlow Version: ' + tensorflow.__version__)\""
+CMD_INSTALL_KERAS_NIGHTLY = "pip install --upgrade --force-reinstall tf-keras-nightly"
+
+
 def set_up_se_nightly() -> Tuple[str]:
   """Adjust grpc_tpu_worker for SE tests"""
   return (
@@ -69,13 +73,33 @@ def install_tf_nightly() -> Tuple[str]:
       "pip install tensorflow-text-nightly",
       "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/tf-nightly/latest/*.whl /tmp/ && pip install /tmp/tf*.whl --force",
       "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/libtpu/latest/libtpu.so /lib/",
+      CMD_PRINT_TF_VERSION,
+  )
+
+
+def install_tf_2_16() -> Tuple[str]:
+  """Install tf 2.16 + libtpu."""
+  return (
+      "pip install tensorflow-text-nightly",
+      "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/2.16/2024-02-20/*.whl /tmp/ && pip install /tmp/tf*.whl --force",
+      "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/libtpu/1.10.0/rc0/libtpu.so /lib/",
+      CMD_PRINT_TF_VERSION,
   )
 
 
 def set_up_tensorflow_keras() -> Tuple[str]:
   """Common set up for tensorflow Keras tests."""
   return (
-      "pip install --upgrade --force-reinstall tf-keras-nightly",
+      CMD_INSTALL_KERAS_NIGHTLY,
+      "export PATH=$PATH:/root/google-cloud-sdk/bin && cd /tmp && sudo gcloud source repos clone tf2-api-tests --project=cloud-ml-auto-solutions",
+      "cd /tmp/tf2-api-tests && pip install behave matplotlib",
+  )
+
+
+def set_up_tensorflow_2_16_keras() -> Tuple[str]:
+  """Common set up for tensorflow Keras 2.16 tests."""
+  return (
+      "pip install --upgrade --force-reinstall tf-keras==2.16.0rc0",
       "export PATH=$PATH:/root/google-cloud-sdk/bin && cd /tmp && sudo gcloud source repos clone tf2-api-tests --project=cloud-ml-auto-solutions",
       "cd /tmp/tf2-api-tests && pip install behave matplotlib",
   )
@@ -87,5 +111,15 @@ def set_up_google_tensorflow_models() -> Tuple[str]:
       "sudo mkdir -p /usr/share/tpu && cd /usr/share/tpu && git clone https://github.com/tensorflow/models.git",
       "pip install -r /usr/share/tpu/models/official/requirements.txt",
       "pip install tensorflow-recommenders --no-deps",
-      "pip install --upgrade --force-reinstall tf-keras-nightly",
+      CMD_INSTALL_KERAS_NIGHTLY,
+  )
+
+
+def set_up_google_tensorflow_2_16_models() -> Tuple[str]:
+  """Common set up for tensorflow models."""
+  return (
+      "sudo mkdir -p /usr/share/tpu && cd /usr/share/tpu && git clone -b r2.16.0 https://github.com/tensorflow/models.git",
+      "pip install -r /usr/share/tpu/models/official/requirements.txt",
+      "pip install tensorflow-recommenders --no-deps",
+      "pip install --upgrade --force-reinstall tf-keras==2.16.0rc0",
   )

--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_2_16_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_2_16_supported_config.py
@@ -1,0 +1,320 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to construct configs for solutionsteam_tf_nightly_supported DAG."""
+
+from xlml.apis import gcp_config, metric_config, task, test_config
+from dags import gcs_bucket, test_owner
+from dags.solutions_team.configs.tensorflow import common
+from airflow.models import Variable
+from dags.vm_resource import TpuVersion, Project, RuntimeVersion
+from typing import List
+
+
+def get_tf_keras_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    test_feature: str,
+    test_name: str,
+    runtime_version: str,
+    project_name: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    is_pod: bool = False,
+    is_pjrt: bool = True,
+    network: str = "default",
+    subnetwork: str = "default",
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = common.install_tf_2_16() + common.set_up_tensorflow_2_16_keras()
+  if not is_pjrt and is_pod:
+    set_up_cmds += common.set_up_se_nightly()
+  keras_test_name = f"tf_2_16_keras_api_{test_name}"
+  benchmark_id = f"{keras_test_name}-v{tpu_version.value}-{tpu_cores}"
+  # Add default_var to pass DAG check
+  # TODO(ranran): replace Variable.get() to XCOM when it applies
+  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  env_variable = export_env_variable(is_pod, is_pjrt)
+  skipped_tag = "--tags=-failspod" if is_pod else ""
+  run_model_cmds = (
+      "sudo chmod -R 777 /tmp/",
+      (
+          "export PATH=$PATH:/home/ml-auto-solutions/.local/bin &&"
+          f" export TPU_NAME={tpu_name} && {env_variable} &&"
+          " cd /tmp/tf2-api-tests && TF_USE_LEGACY_KERAS=1"
+          " behave -e ipynb_checkpoints"
+          f" --tags=-fails {skipped_tag} -i {test_feature}"
+      ),
+  )
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=runtime_version,
+          reserved=True,
+          network=network,
+          subnetwork=subnetwork,
+      ),
+      test_name=keras_test_name,
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.ERIC_L,
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      tpu_name_env_var=is_pod,
+      all_workers=not is_pod,
+  )
+
+
+def get_tf_resnet_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    runtime_version: str,
+    project_name: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    network: str = "default",
+    subnetwork: str = "default",
+    is_pod: bool = False,
+    is_pjrt: bool = True,
+    imagenet_dir: str = gcs_bucket.IMAGENET_DIR,
+    tfds_data_dir: str = gcs_bucket.TFDS_DATA_DIR,
+    global_batch_size: int = 4096,
+    train_steps: int = 320,
+    validation_interval: int = 320,
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = common.install_tf_2_16() + common.set_up_google_tensorflow_models()
+  if not is_pjrt and is_pod:
+    set_up_cmds += common.set_up_se_nightly()
+
+  params_override = {
+      "runtime": {"distribution_strategy": "tpu"},
+      "task": {
+          "train_data": {
+              "input_path": imagenet_dir + "/train*",
+              "tfds_data_dir": tfds_data_dir,
+              "global_batch_size": global_batch_size,
+          },
+          "validation_data": {
+              "input_path": imagenet_dir + "/valid*",
+              "tfds_data_dir": tfds_data_dir,
+              "global_batch_size": global_batch_size,
+          },
+      },
+      "trainer": {
+          "train_steps": train_steps,
+          "validation_interval": validation_interval,
+      },
+  }
+
+  test_name = "tf_2_16_resnet_imagenet"
+  benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
+  # Add default_var to pass DAG check
+  # TODO(ranran): replace Variable.get() to XCOM when it applies
+  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  env_variable = export_env_variable(is_pod, is_pjrt)
+  run_model_cmds = (
+      "sudo chmod -R 777 /tmp/",
+      (
+          f"cd /usr/share/tpu/models && {env_variable} &&"
+          " PYTHONPATH='.' TF_USE_LEGACY_KERAS=1"
+          " python3 official/vision/train.py"
+          f" --tpu={tpu_name} --experiment=resnet_imagenet"
+          " --mode=train_and_eval --model_dir=/tmp/"
+          " --params_override='%s'" % str(params_override)
+      ),
+  )
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=runtime_version,
+          reserved=True,
+          network=network,
+          subnetwork=subnetwork,
+      ),
+      test_name=test_name,
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.CHANDRA_D,
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      tpu_name_env_var=is_pod,
+      all_workers=not is_pod,
+  )
+
+
+def get_tf_dlrm_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    bottom_mlp: List[int],
+    embedding_dim: int,
+    train_steps: int,
+    runtime_version: str,
+    extraFlags: str = "",
+    project_name: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    is_pod: bool = False,
+    is_pjrt: bool = True,
+    criteo_dir: str = gcs_bucket.CRITEO_DIR,
+    network: str = "default",
+    subnetwork: str = "default",
+) -> task.TpuQueuedResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  set_up_cmds = common.install_tf_2_16() + common.set_up_google_tensorflow_models()
+  if not is_pjrt and is_pod:
+    set_up_cmds += common.set_up_se_nightly()
+
+  params_override = {
+      "runtime": {"distribution_strategy": "tpu"},
+      "task": {
+          "train_data": {
+              "input_path": criteo_dir + "/train/*",
+              "global_batch_size": 16384,
+          },
+          "validation_data": {
+              "input_path": criteo_dir + "/eval/*",
+              "global_batch_size": 16384,
+          },
+          "model": {
+              "interaction": "dot",
+              "num_dense_features": 13,
+              "bottom_mlp": bottom_mlp,
+              "embedding_dim": embedding_dim,
+              "top_mlp": [1024, 1024, 512, 256, 1],
+              "vocab_sizes": [
+                  39884406,
+                  39043,
+                  17289,
+                  7420,
+                  20263,
+                  3,
+                  7120,
+                  1543,
+                  63,
+                  38532951,
+                  2953546,
+                  403346,
+                  10,
+                  2208,
+                  11938,
+                  155,
+                  4,
+                  976,
+                  14,
+                  39979771,
+                  25641295,
+                  39664984,
+                  585935,
+                  12972,
+                  108,
+                  36,
+              ],
+          },
+      },
+      "trainer": {
+          "use_orbit": "true",
+          "validation_interval": 90000,
+          "checkpoint_interval": 270000,
+          "validation_steps": 5440,
+          "train_steps": train_steps,
+          "optimizer_config": {
+              "embedding_optimizer": "SGD",
+              "lr_config": {
+                  "decay_exp": 1.6,
+                  "decay_start_steps": 150000,
+                  "decay_steps": 136054,
+                  "learning_rate": 30,
+                  "warmup_steps": 8000,
+              },
+          },
+      },
+  }
+
+  test_name = "tf_2_16_dlrm_criteo"
+  benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
+  # Add default_var to pass DAG check
+  # TODO(ranran): replace Variable.get() to XCOM when it applies
+  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  env_variable = export_env_variable(is_pod, is_pjrt)
+  run_model_cmds = (
+      "sudo chmod -R 777 /tmp/",
+      (
+          f"cd /usr/share/tpu/models && {env_variable} &&"
+          " TF_USE_LEGACY_KERAS=1 PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
+          f" --tpu={tpu_name} --model_dir=/tmp/output {extraFlags}"
+          " --params_override='%s'" % str(params_override)
+      ),
+  )
+
+  job_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=runtime_version,
+          reserved=True,
+          network=network,
+          subnetwork=subnetwork,
+      ),
+      test_name=test_name,
+      set_up_cmds=set_up_cmds,
+      run_model_cmds=run_model_cmds,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner.CHANDRA_D,
+  )
+
+  return task.TpuQueuedResourceTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      tpu_name_env_var=is_pod,
+      all_workers=not is_pod,
+  )
+
+
+def export_env_variable(is_pod: bool, is_pjrt: bool) -> str:
+  """Export environment variables for training if any."""
+  if is_pod:
+    return "export TPU_LOAD_LIBRARY=0"
+  elif is_pjrt:
+    return "export NEXT_PLUGGABLE_DEVICE_USE_C_API=true && export TF_PLUGGABLE_DEVICE_LIBRARY_PATH=/lib/libtpu.so"
+  else:
+    # dummy command
+    return "echo"

--- a/dags/solutions_team/solutionsteam_tf_2_16_se_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_2_16_se_supported.py
@@ -1,0 +1,171 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run all supported ML models with the nightly TensorFlow version."""
+
+import datetime
+from airflow import models
+from dags import composer_env
+from dags.vm_resource import TpuVersion, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
+from dags.solutions_team.configs.tensorflow import solutionsteam_tf_2_16_supported_config as tf_config
+from dags.solutions_team.configs.tensorflow import common
+from airflow.operators.dummy import DummyOperator
+
+
+# Run once a day at 8 pm UTC (12 pm PST)
+SCHEDULED_TIME = "0 20 * * *" if composer_env.is_prod_env() else None
+
+with models.DAG(
+    dag_id="tf_se_nightly_supported",
+    schedule=SCHEDULED_TIME,
+    tags=["solutions_team", "tf", "se", "2.16", "supported", "xlml"],
+    start_date=datetime.datetime(2024, 1, 4),
+    catchup=False,
+) as dag:
+  # Keras - tests run in sequence order
+  tf_keras_v2_8 = [DummyOperator(task_id="tf_se_nightly_keras_v2-8")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        tpu_version=TpuVersion.V2,
+        tpu_cores=8,
+        tpu_zone=Zone.US_CENTRAL1_C.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        is_pjrt=False,
+        runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+    ).run()
+    tf_keras_v2_8[-1] >> test
+    tf_keras_v2_8.append(test)
+
+  # ResNet
+  tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL1_C.value,
+      time_out_in_min=60,
+      global_batch_size=1024,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v2_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL1_A.value,
+      time_out_in_min=60,
+      global_batch_size=1024,
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v3_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V3,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST1_D.value,
+      time_out_in_min=60,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v3_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V3,
+      tpu_cores=32,
+      tpu_zone=Zone.US_EAST1_D.value,
+      time_out_in_min=60,
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v4_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+  tf_resnet_v4_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+  # DLRM
+  tf_dlrm_v2_8 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL1_C.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 16],
+      embedding_dim=16,
+      train_steps=10000,
+      extraFlags="--mode=train",
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_dlrm_v2_32 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL1_A.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 64],
+      embedding_dim=64,
+      train_steps=256054,
+      extraFlags="--mode=train_and_eval",
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_dlrm_v4_8 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 64],
+      embedding_dim=64,
+      train_steps=10000,
+      extraFlags="--mode=train",
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_dlrm_v4_32 = tf_config.get_tf_dlrm_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, 128],
+      embedding_dim=128,
+      train_steps=256054,
+      extraFlags="--mode=train_and_eval",
+      is_pod=True,
+      is_pjrt=False,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  # Test dependencies
+  tf_keras_v2_8
+  tf_resnet_v2_8 >> tf_resnet_v2_32
+  tf_resnet_v3_8 >> tf_resnet_v3_32
+  tf_resnet_v4_8 >> tf_resnet_v4_32
+  tf_dlrm_v2_8 >> tf_dlrm_v2_32
+  tf_dlrm_v4_8 >> tf_dlrm_v4_32

--- a/dags/solutions_team/solutionsteam_tf_2_16_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_2_16_supported.py
@@ -1,0 +1,177 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run all supported ML models with the nightly TensorFlow version."""
+
+import datetime
+from airflow import models
+from dags import composer_env
+from dags.vm_resource import TpuVersion, Project, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
+from dags.solutions_team.configs.tensorflow import solutionsteam_tf_2_16_supported_config as tf_config
+from dags.solutions_team.configs.tensorflow import common
+from airflow.operators.dummy import DummyOperator
+
+
+# Run once a day at 6 pm UTC (10 am PST)
+SCHEDULED_TIME = "0 18 * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="tf_nightly_supported",
+    schedule=SCHEDULED_TIME,
+    tags=["solutions_team", "tf", "2.16", "supported", "xlml"],
+    start_date=datetime.datetime(2023, 8, 16),
+    catchup=False,
+) as dag:
+  # Keras - tests run in sequence order
+  tf_keras_v2_8 = [DummyOperator(task_id="tf_nightly_keras_v2-8")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        tpu_version=TpuVersion.V2,
+        tpu_cores=8,
+        tpu_zone=Zone.US_CENTRAL1_C.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+    ).run()
+    tf_keras_v2_8[-1] >> test
+    tf_keras_v2_8.append(test)
+
+  tf_keras_v5e_4 = [DummyOperator(task_id="tf_nightly_keras_v5litepod-4")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+        tpu_version=TpuVersion.V5E,
+        tpu_cores=4,
+        tpu_zone=Zone.US_EAST1_C.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        network=V5_NETWORKS,
+        subnetwork=V5E_SUBNETWORKS,
+        runtime_version=RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
+    ).run()
+    tf_keras_v5e_4[-1] >> test
+    tf_keras_v5e_4.append(test)
+
+  tf_keras_v5p_8 = [DummyOperator(task_id="tf_nightly_keras_v5p-8")]
+  for feature, name in common.FEATURE_NAME.items():
+    test = tf_config.get_tf_keras_config(
+        project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+        tpu_version=TpuVersion.V5P,
+        tpu_cores=8,
+        tpu_zone=Zone.US_EAST5_A.value,
+        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
+        test_feature=feature,
+        test_name=name,
+        network=V5_NETWORKS,
+        subnetwork=V5P_SUBNETWORKS,
+        runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+    ).run()
+    tf_keras_v5p_8[-1] >> test
+    tf_keras_v5p_8.append(test)
+
+  # ResNet
+  tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V2,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL1_C.value,
+      time_out_in_min=60,
+      global_batch_size=1024,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v3_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V3,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST1_D.value,
+      time_out_in_min=60,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v4_8 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=8,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v4_32 = tf_config.get_tf_resnet_config(
+      tpu_version=TpuVersion.V4,
+      tpu_cores=32,
+      tpu_zone=Zone.US_CENTRAL2_B.value,
+      time_out_in_min=60,
+      is_pod=True,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v5e_4 = tf_config.get_tf_resnet_config(
+      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+      tpu_version=TpuVersion.V5E,
+      tpu_cores=4,
+      tpu_zone=Zone.US_EAST1_C.value,
+      time_out_in_min=60,
+      global_batch_size=2048,
+      network=V5_NETWORKS,
+      subnetwork=V5E_SUBNETWORKS,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
+  ).run()
+
+  tf_resnet_v5e_16 = tf_config.get_tf_resnet_config(
+      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+      tpu_version=TpuVersion.V5E,
+      tpu_cores=16,
+      tpu_zone=Zone.US_EAST1_C.value,
+      time_out_in_min=60,
+      global_batch_size=2048,
+      network=V5_NETWORKS,
+      subnetwork=V5E_SUBNETWORKS,
+      is_pod=True,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5_LITE.value,
+  ).run()
+
+  tf_resnet_v5p_8 = tf_config.get_tf_resnet_config(
+      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+      tpu_version=TpuVersion.V5P,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST5_A.value,
+      time_out_in_min=60,
+      network=V5_NETWORKS,
+      subnetwork=V5P_SUBNETWORKS,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  tf_resnet_v5p_32 = tf_config.get_tf_resnet_config(
+      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+      tpu_version=TpuVersion.V5P,
+      tpu_cores=32,
+      tpu_zone=Zone.US_EAST5_A.value,
+      time_out_in_min=60,
+      network=V5_NETWORKS,
+      subnetwork=V5P_SUBNETWORKS,
+      is_pod=True,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  # Test dependencies
+  tf_keras_v2_8
+  tf_keras_v5e_4
+  tf_keras_v5p_8
+  tf_resnet_v2_8
+  tf_resnet_v3_8
+  tf_resnet_v4_8 >> tf_resnet_v4_32
+  tf_resnet_v5e_4 >> tf_resnet_v5e_16
+  tf_resnet_v5p_8 >> tf_resnet_v5p_32

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,10 +83,10 @@ class GpuVersion(enum.Enum):
 class RuntimeVersion(enum.Enum):
   TPU_VM_TF_NIGHTLY = "tpu-vm-tf-nightly"
   TPU_VM_TF_NIGHTLY_POD = "tpu-vm-tf-nightly-pod"
-  TPU_VM_TF_2150_SE = "tpu-vm-tf-2.15.0-se"
-  TPU_VM_TF_2150_POD_SE = "tpu-vm-tf-2.15.0-pod-se"
-  TPU_VM_TF_2150_PJRT = "tpu-vm-tf-2.15.0-pjrt"
-  TPU_VM_TF_2150_POD_PJRT = "tpu-vm-tf-2.15.0-pod-pjrt"
+  TPU_VM_TF_STABLE_SE = "tpu-vm-tf-2.16.0-se"
+  TPU_VM_TF_STABLE_POD_SE = "tpu-vm-tf-2.16.0-pod-se"
+  TPU_VM_TF_STABLE_PJRT = "tpu-vm-tf-2.16.0-pjrt"
+  TPU_VM_TF_STABLE_POD_PJRT = "tpu-vm-tf-2.16.0-pod-pjrt"
   TPU_UBUNTU2204_BASE = "tpu-ubuntu2204-base"
   TPU_VM_V4_BASE = "tpu-vm-v4-base"
   V2_ALPHA_TPUV5_LITE = "v2-alpha-tpuv5-lite"


### PR DESCRIPTION
# Description

Adds two new DAGs to test TF against the 2.16 release candidate.

# Tests

Tests still pending, getting the code change in PR in the meantime and will test before merging.

**Instruction and/or command lines to reproduce your tests:** TK

**List links for your tests (use go/shortn-gen for any internal link):** TK

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.