### PR TITLE
support env to runner to dynamic change run command

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -82,7 +82,7 @@ def get_torchbench_tpu_config(
 
   set_up_cmds = set_up_torchbench_tpu(model_name)
   local_output_location = "~/xla/benchmarks/output/metric_report.jsonl"
-  # The gcs location can be overwrite if we use run_with_gcs_name_generatioin().
+  # The gcs location can be overwritten if we use run_with_gcs_name_generatioin().
   gcs_location = (
       f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/metric_report_tpu.jsonl"
   )
@@ -224,7 +224,7 @@ def get_torchbench_gpu_config(
 
   set_up_cmds = set_up_torchbench_gpu(model_name, nvidia_driver_version)
   local_output_location = "/tmp/xla/benchmarks/output/metric_report.jsonl"
-  # The gcs location can be overwrite if we use run_with_gcs_name_generatioin().
+  # The gcs location can be overwritten if we use run_with_gcs_name_generatioin().
   gcs_location = (
       f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/metric_report_gpu.jsonl"
   )

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -95,7 +95,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} ${metric_config.MetricPath.GCS_OUTPUT.value}",
+      f"gsutil cp {local_output_location} ${metric_config.SshEnvVars.GCS_OUTPUT.value}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -240,7 +240,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl ${metric_config.MetricPath.GCS_OUTPUT.value}",
+      f"gsutil cp metric_report.jsonl ${metric_config.SshEnvVars.GCS_OUTPUT.value}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -98,7 +98,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} $gcs_location",
+      f"gsutil cp {local_output_location} $OUTPUT_DIR",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -251,7 +251,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl $gcs_location",
+      f"gsutil cp metric_report.jsonl $OUTPUT_DIR",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -82,7 +82,10 @@ def get_torchbench_tpu_config(
 
   set_up_cmds = set_up_torchbench_tpu(model_name)
   local_output_location = "~/xla/benchmarks/output/metric_report.jsonl"
-  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{tpu_version}/{int(datetime.datetime.now().timestamp())}/metric_report_tpu.jsonl"
+  # The gcs location can be overwrite if we use run_with_gcs_name_generatioin().
+  gcs_location = (
+      f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/metric_report_tpu.jsonl"
+  )
   if not model_name or model_name.lower() == "all":
     run_filter = " "
   else:
@@ -95,7 +98,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} {gcs_location}",
+      f"gsutil cp {local_output_location} ${{gcs_location}}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -221,7 +224,10 @@ def get_torchbench_gpu_config(
 
   set_up_cmds = set_up_torchbench_gpu(model_name, nvidia_driver_version)
   local_output_location = "/tmp/xla/benchmarks/output/metric_report.jsonl"
-  gcs_location = f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/{accelerator_type}/{int(datetime.datetime.now().timestamp())}/metric_report_gpu.jsonl"
+  # The gcs location can be overwrite if we use run_with_gcs_name_generatioin().
+  gcs_location = (
+      f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/metric_report_gpu.jsonl"
+  )
 
   if not model_name or model_name.lower() == "all":
     run_filter = " "
@@ -245,7 +251,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl {gcs_location}",
+      f"gsutil cp metric_report.jsonl ${{gcs_location}}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -82,10 +82,7 @@ def get_torchbench_tpu_config(
 
   set_up_cmds = set_up_torchbench_tpu(model_name)
   local_output_location = "~/xla/benchmarks/output/metric_report.jsonl"
-  # The gcs location can be overwritten if we use run_with_gcs_name_generatioin().
-  gcs_location = (
-      f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/metric_report_tpu.jsonl"
-  )
+
   if not model_name or model_name.lower() == "all":
     run_filter = " "
   else:
@@ -98,7 +95,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} $OUTPUT_DIR",
+      f"gsutil cp {local_output_location} ${metric_config.MetricPath.GCS_OUTPUT}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -118,11 +115,7 @@ def get_torchbench_tpu_config(
       task_owner=test_owner.PEI_Z,
   )
 
-  job_metric_config = metric_config.MetricConfig(
-      json_lines=metric_config.JSONLinesConfig(
-          file_location=gcs_location,
-      )
-  )
+  job_metric_config = metric_config.MetricConfig()
 
   return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
@@ -224,10 +217,6 @@ def get_torchbench_gpu_config(
 
   set_up_cmds = set_up_torchbench_gpu(model_name, nvidia_driver_version)
   local_output_location = "/tmp/xla/benchmarks/output/metric_report.jsonl"
-  # The gcs location can be overwritten if we use run_with_gcs_name_generatioin().
-  gcs_location = (
-      f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/torchbench_config/metric_report_gpu.jsonl"
-  )
 
   if not model_name or model_name.lower() == "all":
     run_filter = " "
@@ -251,7 +240,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl $OUTPUT_DIR",
+      f"gsutil cp metric_report.jsonl ${metric_config.MetricPath.GCS_OUTPUT}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -270,11 +259,7 @@ def get_torchbench_gpu_config(
       task_owner=test_owner.PEI_Z,
   )
 
-  job_metric_config = metric_config.MetricConfig(
-      json_lines=metric_config.JSONLinesConfig(
-          file_location=gcs_location,
-      )
-  )
+  job_metric_config = metric_config.MetricConfig()
 
   return task.GpuCreateResourceTask(
       image_project.value,

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -98,7 +98,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} ${{gcs_location}}",
+      f"gsutil cp {local_output_location} $gcs_location",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -251,7 +251,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl ${{gcs_location}}",
+      f"gsutil cp metric_report.jsonl $gcs_location",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -95,7 +95,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} ${metric_config.MetricPath.GCS_OUTPUT}",
+      f"gsutil cp {local_output_location} ${metric_config.MetricPath.GCS_OUTPUT.value}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -115,7 +115,7 @@ def get_torchbench_tpu_config(
       task_owner=test_owner.PEI_Z,
   )
 
-  job_metric_config = metric_config.MetricConfig()
+  job_metric_config = metric_config.MetricConfig(use_runtime_generated_filename=True)
 
   return task.TpuQueuedResourceTask(
       task_test_config=job_test_config,
@@ -240,7 +240,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl ${metric_config.MetricPath.GCS_OUTPUT}",
+      f"gsutil cp metric_report.jsonl ${metric_config.MetricPath.GCS_OUTPUT.value}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -259,7 +259,7 @@ def get_torchbench_gpu_config(
       task_owner=test_owner.PEI_Z,
   )
 
-  job_metric_config = metric_config.MetricConfig()
+  job_metric_config = metric_config.MetricConfig(use_runtime_generated_filename=True)
 
   return task.GpuCreateResourceTask(
       image_project.value,

--- a/dags/pytorch_xla/pytorchxla_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla_torchbench.py
@@ -43,7 +43,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()
 
   # Running on V5P
   config.get_torchbench_tpu_config(
@@ -57,7 +57,7 @@ with models.DAG(
       time_out_in_min=700,
       model_name=model,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()
 
   # Running on V5E
   config.get_torchbench_tpu_config(
@@ -71,7 +71,7 @@ with models.DAG(
       time_out_in_min=1600,
       model_name=model,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()
 
   # Running on V100 GPU
   config.get_torchbench_gpu_config(
@@ -84,7 +84,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()
 
   # Running on A100 GPU
   config.get_torchbench_gpu_config(
@@ -97,7 +97,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()
 
   # Running on H100 GPU
   # Note: H100 must use ssd.
@@ -112,7 +112,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()
 
   # Running on L4 GPU
   config.get_torchbench_gpu_config(
@@ -125,4 +125,4 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run()
+  ).run_with_gcs_name_generatioin()

--- a/dags/pytorch_xla/pytorchxla_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla_torchbench.py
@@ -43,7 +43,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()
 
   # Running on V5P
   config.get_torchbench_tpu_config(
@@ -57,7 +57,7 @@ with models.DAG(
       time_out_in_min=700,
       model_name=model,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()
 
   # Running on V5E
   config.get_torchbench_tpu_config(
@@ -71,7 +71,7 @@ with models.DAG(
       time_out_in_min=1600,
       model_name=model,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()
 
   # Running on V100 GPU
   config.get_torchbench_gpu_config(
@@ -84,7 +84,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()
 
   # Running on A100 GPU
   config.get_torchbench_gpu_config(
@@ -97,7 +97,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()
 
   # Running on H100 GPU
   # Note: H100 must use ssd.
@@ -112,7 +112,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()
 
   # Running on L4 GPU
   config.get_torchbench_gpu_config(
@@ -125,4 +125,4 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generatioin()
+  ).run_with_gcs_name_generation()

--- a/dags/pytorch_xla/pytorchxla_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla_torchbench.py
@@ -31,7 +31,7 @@ with models.DAG(
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,
 ) as dag:
-  model = "all"
+  model = "BERT_pytorch"
   torchbench_extra_flags = [f"--filter={model}"]
   # Running on V4-8:
   config.get_torchbench_tpu_config(
@@ -43,7 +43,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()
 
   # Running on V5P
   config.get_torchbench_tpu_config(
@@ -57,7 +57,7 @@ with models.DAG(
       time_out_in_min=700,
       model_name=model,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()
 
   # Running on V5E
   config.get_torchbench_tpu_config(
@@ -71,7 +71,7 @@ with models.DAG(
       time_out_in_min=1600,
       model_name=model,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()
 
   # Running on V100 GPU
   config.get_torchbench_gpu_config(
@@ -84,7 +84,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()
 
   # Running on A100 GPU
   config.get_torchbench_gpu_config(
@@ -97,7 +97,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()
 
   # Running on H100 GPU
   # Note: H100 must use ssd.
@@ -112,7 +112,7 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()
 
   # Running on L4 GPU
   config.get_torchbench_gpu_config(
@@ -125,4 +125,4 @@ with models.DAG(
       model_name=model,
       time_out_in_min=1600,
       extraFlags=" ".join(torchbench_extra_flags),
-  ).run_with_gcs_name_generation()
+  ).run()

--- a/dags/pytorch_xla/pytorchxla_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla_torchbench.py
@@ -31,7 +31,7 @@ with models.DAG(
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,
 ) as dag:
-  model = "BERT_pytorch"
+  model = "all"
   torchbench_extra_flags = [f"--filter={model}"]
   # Running on V4-8:
   config.get_torchbench_tpu_config(

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -37,7 +37,7 @@ class AggregationStrategy(enum.Enum):
   MEDIAN = enum.auto()
 
 
-class MetricPath(enum.Enum):
+class SshEnvVars(enum.Enum):
   GCS_OUTPUT = "GCS_OUTPUT"
 
 

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -101,3 +101,4 @@ class MetricConfig:
   json_lines: Optional[JSONLinesConfig] = None
   tensorboard_summary: Optional[SummaryConfig] = None
   profile: Optional[ProfileConfig] = None
+  use_runtime_generated_filename: bool = False

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -37,6 +37,10 @@ class AggregationStrategy(enum.Enum):
   MEDIAN = enum.auto()
 
 
+class MetricPath(enum.Enum):
+  GCS_OUTPUT = "GCS_OUTPUT"
+
+
 @dataclasses.dataclass
 class JSONLinesConfig:
   """This is a class to set up JSON Lines config.

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -271,8 +271,8 @@ class TpuQueuedResourceTask(BaseTask):
           self.task_test_config,
           self.task_metric_config,
           self.task_gcp_config,
-          use_startup_script,
-          file_location,
+          use_startup_script=use_startup_script,
+          file_location=file_location,
       )
       return group
 
@@ -379,7 +379,7 @@ class TpuXpkTask(BaseTask):
       workload_id >> run_workload >> wait_for_workload_completion
       return group
 
-  def post_process(self, file_location: str = None) -> DAGNode:
+  def post_process(self) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
     Returns:
@@ -392,7 +392,6 @@ class TpuXpkTask(BaseTask):
           self.task_test_config,
           self.task_metric_config,
           self.task_gcp_config,
-          file_location=file_location,
       )
 
       return group

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -88,7 +88,7 @@ class TpuQueuedResourceTask(BaseTask):
       run_model = self.run_model(
           queued_resource, ssh_keys, {"gcs_location": gcs_location}
       )
-      post_process = self.post_process()
+      post_process = self.post_process(gcs_location)
       clean_up = self.clean_up(queued_resource)
 
       gcs_location >> provision >> run_model >> post_process >> clean_up
@@ -430,7 +430,7 @@ class GpuCreateResourceTask(BaseTask):
       provision >> run_model >> post_process >> clean_up
     return group
 
-  def run_with_gcs_name_generatioin(self) -> DAGNode:
+  def run_with_gcs_name_generation(self) -> DAGNode:
     with TaskGroup(
         group_id=self.task_test_config.benchmark_id, prefix_group_id=True
     ) as group:

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -88,7 +88,7 @@ class TpuQueuedResourceTask(BaseTask):
       run_model = self.run_model(
           queued_resource, ssh_keys, {"gcs_location": gcs_location}
       )
-      post_process = self.post_process(gcs_location)
+      post_process = self.post_process(file_location=gcs_location)
       clean_up = self.clean_up(queued_resource)
 
       gcs_location >> provision >> run_model >> post_process >> clean_up
@@ -256,7 +256,9 @@ class TpuQueuedResourceTask(BaseTask):
         env,
     )
 
-  def post_process(self, use_startup_script: bool = False) -> DAGNode:
+  def post_process(
+      self, use_startup_script: bool = False, file_location: str = None
+  ) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
     Returns:
@@ -270,6 +272,7 @@ class TpuQueuedResourceTask(BaseTask):
           self.task_metric_config,
           self.task_gcp_config,
           use_startup_script,
+          file_location,
       )
       return group
 
@@ -376,7 +379,7 @@ class TpuXpkTask(BaseTask):
       workload_id >> run_workload >> wait_for_workload_completion
       return group
 
-  def post_process(self) -> DAGNode:
+  def post_process(self, file_location: str = None) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
     Returns:
@@ -389,6 +392,7 @@ class TpuXpkTask(BaseTask):
           self.task_test_config,
           self.task_metric_config,
           self.task_gcp_config,
+          file_location=file_location,
       )
 
       return group

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -257,7 +257,7 @@ class TpuQueuedResourceTask(BaseTask):
     )
 
   def post_process(
-      self, use_startup_script: bool = False, file_location: str = None
+      self, use_startup_script: bool = False, file_location: Optional[str] = None
   ) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
@@ -516,7 +516,7 @@ class GpuCreateResourceTask(BaseTask):
         env,
     )
 
-  def post_process(self, result_file_location: airflow.XComArg = None) -> DAGNode:
+  def post_process(self, result_file_location: Optional[airflow.XComArg] = None) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
     Returns:

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -86,7 +86,7 @@ class TpuQueuedResourceTask(BaseTask):
       )
       provision, queued_resource, ssh_keys = self.provision()
       run_model = self.run_model(
-          queued_resource, ssh_keys, {"gcs_location": gcs_location}
+          queued_resource, ssh_keys, {"OUTPUT_DIR": gcs_location}
       )
       post_process = self.post_process(file_location=gcs_location)
       clean_up = self.clean_up(queued_resource)
@@ -441,7 +441,7 @@ class GpuCreateResourceTask(BaseTask):
           self.task_test_config.benchmark_id
       )
       provision, ip_address, instance_name, ssh_keys = self.provision()
-      run_model = self.run_model(ip_address, ssh_keys, {"gcs_location": gcs_location})
+      run_model = self.run_model(ip_address, ssh_keys, {"OUTPUT_DIR": gcs_location})
       post_process = self.post_process(gcs_location)
       clean_up = self.clean_up(
           instance_name, self.task_gcp_config.project_name, self.task_gcp_config.zone

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -77,7 +77,7 @@ class TpuQueuedResourceTask(BaseTask):
 
     return group
 
-  def run_with_gcs_name_generatioin(self) -> DAGNode:
+  def run_with_gcs_name_generation(self) -> DAGNode:
     with TaskGroup(
         group_id=self.task_test_config.benchmark_id, prefix_group_id=True
     ) as group:

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -450,7 +450,7 @@ class GpuCreateResourceTask(BaseTask):
 
   def provision(
       self,
-  ) -> Tuple[DAGNode, airflow.XComArg, airflow.XComArg, airflow.XComArg, airflow.XComArt]:
+  ) -> Tuple[DAGNode, airflow.XComArg, airflow.XComArg, airflow.XComArg, airflow.XComArg]:
     """Provision a GPU accelerator via a resource creation.
 
     Generates a random GPU name and SSH keys, creates a VM Resource, and

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -77,7 +77,7 @@ class TpuQueuedResourceTask(BaseTask):
           self.task_metric_config
           and self.task_metric_config.use_runtime_generated_filename
       ):
-        env_variable = {f"{metric_config.MetricPath.GCS_OUTPUT.value}": gcs_location}
+        env_variable = {f"{metric_config.SshEnvVars.GCS_OUTPUT.value}": gcs_location}
       else:
         env_variable = None
       run_model = self.run_model(queued_resource, ssh_keys, env_variable)
@@ -427,7 +427,7 @@ class GpuCreateResourceTask(BaseTask):
           self.task_metric_config
           and self.task_metric_config.use_runtime_generated_filename
       ):
-        env_variable = {f"{metric_config.MetricPath.GCS_OUTPUT.value}": gcs_location}
+        env_variable = {f"{metric_config.SshEnvVars.GCS_OUTPUT.value}": gcs_location}
       else:
         env_variable = None
       run_model = self.run_model(ip_address, ssh_keys, env_variable)

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -89,7 +89,7 @@ class TpuQueuedResourceTask(BaseTask):
       post_process = self.post_process(file_location=gcs_location)
       clean_up = self.clean_up(queued_resource)
 
-      gcs_location >> provision >> run_model >> post_process >> clean_up
+      provision >> run_model >> post_process >> clean_up
 
     return group
 
@@ -182,7 +182,7 @@ class TpuQueuedResourceTask(BaseTask):
           self.tpu_create_timeout,
           self.task_test_config,
       )
-      queued_resource_op >> tpu.ssh_tpu.override(task_id="setup")(
+      output_location >> queued_resource_op >> tpu.ssh_tpu.override(task_id="setup")(
           queued_resource_name,
           # TODO(wcromar): remove split
           self.task_test_config.setup_script,
@@ -444,7 +444,7 @@ class GpuCreateResourceTask(BaseTask):
           instance_name, self.task_gcp_config.project_name, self.task_gcp_config.zone
       )
 
-      gcs_location >> provision >> run_model >> post_process >> clean_up
+      provision >> run_model >> post_process >> clean_up
 
     return group
 
@@ -482,11 +482,13 @@ class GpuCreateResourceTask(BaseTask):
           ssh_keys,
       )
 
-      gpu.ssh_host.override(task_id="setup")(
+      create_resource = gpu.ssh_host.override(task_id="setup")(
           ip_address,
           self.task_test_config.setup_script,
           ssh_keys,
       )
+
+      output_location >> ip_address >> create_resource
     return group, ip_address, gpu_name, ssh_keys, output_location
 
   def run_model(

--- a/xlml/utils/gpu.py
+++ b/xlml/utils/gpu.py
@@ -354,7 +354,7 @@ def ssh_host(
     ip_address: str,
     cmds: Iterable[str],
     ssh_keys: ssh.SshKeys,
-    env: dict[str, str] = None,
+    env: Dict[str, str] = None,
 ) -> None:
   """SSH GPU and run commands in multi process.
 

--- a/xlml/utils/gpu.py
+++ b/xlml/utils/gpu.py
@@ -350,13 +350,19 @@ def create_resource(
 
 
 @task
-def ssh_host(ip_address: str, cmds: Iterable[str], ssh_keys: ssh.SshKeys) -> None:
+def ssh_host(
+    ip_address: str,
+    cmds: Iterable[str],
+    ssh_keys: ssh.SshKeys,
+    env: dict[str, str] = None,
+) -> None:
   """SSH GPU and run commands in multi process.
 
   Args:
    ip_address: The ip address of the vm resource.
    cmds: The commands to run on a GPU.
    ssh_keys: The SSH key pair to use for authentication.
+   env: environment variables to be pass to the ssh runner session using dict.
   """
   pkey = paramiko.RSAKey.from_private_key(io.StringIO(ssh_keys.private))
   logging.info(f"Connecting to IP addresses {ip_address}")
@@ -370,7 +376,7 @@ def ssh_host(ip_address: str, cmds: Iterable[str], ssh_keys: ssh.SshKeys) -> Non
           )
       },
   )
-  ssh_group.run(cmds)
+  ssh_group.run(cmds, env=env)
 
 
 # TODO(piz): Check why sometime GPU instance doesn't get deleted.

--- a/xlml/utils/gpu.py
+++ b/xlml/utils/gpu.py
@@ -26,7 +26,7 @@ from google.cloud import compute_v1
 import io
 import paramiko
 import re
-from typing import Iterable, Any
+from typing import Any, Dict, Iterable
 import uuid
 from xlml.apis import gcp_config, test_config
 from xlml.utils import ssh
@@ -268,7 +268,7 @@ def wait_for_extended_operation(
   return result
 
 
-def create_metadata(key_val: dict[str, str]) -> compute_v1.Metadata:
+def create_metadata(key_val: Dict[str, str]) -> compute_v1.Metadata:
   metadata = compute_v1.Metadata()
   metadata.items = [{"key": key, "value": val} for key, val in key_val.items()]
   return metadata

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -162,7 +162,9 @@ def download_object_from_gcs(source_location: str, destination_location: str) ->
   bucket = storage_client.bucket(bucket_name)
   blob = bucket.blob(object_name)
   blob.download_to_filename(destination_location)
-  logging.info(f"Download JSON Lines file to: {destination_location}")
+  logging.info(
+      f"Download JSON Lines file from {source_location} to {destination_location}"
+  )
 
 
 def process_json_lines(

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -600,7 +600,7 @@ def process_metrics(
     task_metric_config: metric_config.MetricConfig,
     task_gcp_config: gcp_config.GCPConfig,
     use_startup_script: bool = False,
-    file_location: str = None,
+    file_location: Optional[str] = None,
 ) -> None:
   benchmark_id = task_test_config.benchmark_id
   current_time = datetime.datetime.now()

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -610,29 +610,27 @@ def process_metrics(
   profile_history_rows_list = []
 
   # process metrics, metadata, and profile
-  if file_location is not None:
-    if task_metric_config.json_lines:
-      metric_history_rows_list, metadata_history_rows_list = process_json_lines(
-          base_id, file_location
+  if task_metric_config.json_lines:
+    metric_history_rows_list, metadata_history_rows_list = process_json_lines(
+        base_id, task_metric_config.json_lines.file_location
+    )
+  elif  file_location:
+    metric_history_rows_list, metadata_history_rows_list = process_json_lines(
+        base_id, file_location
+    ) 
+  if task_metric_config.tensorboard_summary:
+    (
+        metric_history_rows_list,
+        metadata_history_rows_list,
+    ) = process_tensorboard_summary(base_id, task_metric_config.tensorboard_summary)
+  if task_metric_config.profile:
+    has_profile = True
+    num_profiles = len(task_metric_config.profile.file_locations)
+    for index in range(num_profiles):
+      profile_history_rows = process_profile(
+          base_id, task_metric_config.profile.file_locations[index]
       )
-  elif task_metric_config is not None:
-    if task_metric_config.json_lines:
-      metric_history_rows_list, metadata_history_rows_list = process_json_lines(
-          base_id, task_metric_config.json_lines.file_location
-      )
-    if task_metric_config.tensorboard_summary:
-      (
-          metric_history_rows_list,
-          metadata_history_rows_list,
-      ) = process_tensorboard_summary(base_id, task_metric_config.tensorboard_summary)
-    if task_metric_config.profile:
-      has_profile = True
-      num_profiles = len(task_metric_config.profile.file_locations)
-      for index in range(num_profiles):
-        profile_history_rows = process_profile(
-            base_id, task_metric_config.profile.file_locations[index]
-        )
-        profile_history_rows_list.append(profile_history_rows)
+      profile_history_rows_list.append(profile_history_rows)
 
   # add default airflow metadata
   metadata_history_rows_list = add_airflow_metadata(

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -598,6 +598,7 @@ def process_metrics(
     task_metric_config: metric_config.MetricConfig,
     task_gcp_config: gcp_config.GCPConfig,
     use_startup_script: bool = False,
+    file_location: str = None,
 ) -> None:
   benchmark_id = task_test_config.benchmark_id
   current_time = datetime.datetime.now()
@@ -607,7 +608,12 @@ def process_metrics(
   profile_history_rows_list = []
 
   # process metrics, metadata, and profile
-  if task_metric_config is not None:
+  if file_location is not None:
+    if task_metric_config.json_lines:
+      metric_history_rows_list, metadata_history_rows_list = process_json_lines(
+          base_id, file_location
+      )
+  elif task_metric_config is not None:
     if task_metric_config.json_lines:
       metric_history_rows_list, metadata_history_rows_list = process_json_lines(
           base_id, task_metric_config.json_lines.file_location

--- a/xlml/utils/name_format.py
+++ b/xlml/utils/name_format.py
@@ -15,6 +15,7 @@
 import datetime
 import os
 from airflow.decorators import task
+from dags import gcs_bucket
 
 
 @task
@@ -39,3 +40,17 @@ def generate_tb_file_location(run_name: str, base_output_directory: str) -> str:
   return os.path.join(
       base_output_directory, run_name, "tensorboard", "events.out.tfevents.*"
   )
+
+
+@task
+def generate_gcs_file_location(benchmark_id) -> str:
+  """Generates result file location in GCS.
+
+  Args:
+    benchmark_id: Benchmark id of the test
+
+  Returns:
+    gsc file name with location
+  """
+  current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+  return f"{gcs_bucket.BENCHMARK_OUTPUT_DIR}/{benchmark_id}-{current_datetime}/metric_report.jsonl"

--- a/xlml/utils/name_format.py
+++ b/xlml/utils/name_format.py
@@ -19,7 +19,7 @@ from dags import gcs_bucket
 
 
 @task
-def generate_run_name(benchmark_id) -> str:
+def generate_run_name(benchmark_id: str) -> str:
   """Generates a unique run name by appending the current datetime to benchmark_id.
 
   Args:
@@ -43,7 +43,7 @@ def generate_tb_file_location(run_name: str, base_output_directory: str) -> str:
 
 
 @task
-def generate_gcs_file_location(benchmark_id) -> str:
+def generate_gcs_file_location(benchmark_id: str) -> str:
   """Generates result file location in GCS.
 
   Args:

--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -292,6 +292,7 @@ def ssh_tpu(
     cmds: Iterable[str],
     ssh_keys: ssh.SshKeys,
     all_workers: bool,
+    env: dict[str, str] = None,
 ) -> None:
   """SSH TPU and run commands in multi process.
 
@@ -301,6 +302,7 @@ def ssh_tpu(
    ssh_keys: The SSH key pair to use for authentication.
    all_workers: The flag to define if run commands on all workers or worker 0
      only.
+   env: environment variables to be pass to the ssh runner session using dict.
   """
   creds, _ = google.auth.default()
   client = tpu_api.TpuClient(credentials=creds)
@@ -343,4 +345,4 @@ def ssh_tpu(
     ssh_group.run(';'.join(kill_process_cmds))
 
   # run provided commands
-  ssh_group.run(cmds)
+  ssh_group.run(cmds, env=env)

--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -18,7 +18,7 @@ import datetime
 import io
 import itertools
 import os
-from typing import Iterable, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 import uuid
 
 from absl import logging
@@ -292,7 +292,7 @@ def ssh_tpu(
     cmds: Iterable[str],
     ssh_keys: ssh.SshKeys,
     all_workers: bool,
-    env: dict[str, str] = None,
+    env: Dict[str, str] = None,
 ) -> None:
   """SSH TPU and run commands in multi process.
 


### PR DESCRIPTION
# Description

1. Support env to runner to dynamic change run command
2. Support passing gs file location to `run_model` and `post_process` function
3. update `provision` phase to generate gcs file based on current timestamp.

Note:
You need to to set `MetricConfig.use_runtime_generated_filename=True` to tell post_process to use process generated filename.

# Tests

torchbench: [run](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-torchbench/grid)
Other's test like maxtext: [run](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/maxtext_nightly/grid?dag_run_id=manual__2024-02-22T03%3A03%3A45.831358%2B00%3A00)
Flax [run](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/flax_latest_supported/grid)