### PR TITLE
Add TPU cleanup DAG

### DIFF
--- a/dags/infra/clean_up.py
+++ b/dags/infra/clean_up.py
@@ -1,0 +1,43 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to clean up idle accelerator resources."""
+
+import datetime
+from airflow import models
+from dags import composer_env
+from dags.vm_resource import Project, Zone
+from xlml.utils import tpu
+
+
+# Run every 10min
+SCHEDULED_TIME = "*/10 * * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="clean_up",
+    schedule=SCHEDULED_TIME,
+    tags=["solutions_team", "clean_up"],
+    start_date=datetime.datetime(2024, 2, 22),
+    catchup=False,
+) as dag:
+  # List tpu zones for project cloud_ml_auto_solutions to avoid permission issue
+  tpu_zones = [
+      Zone.US_CENTRAL1_A,
+      Zone.US_CENTRAL1_B,
+      Zone.US_CENTRAL2_B,
+      Zone.US_CENTRAL1_C,
+      Zone.US_EAST1_D,
+  ]
+  tpu.clean_up_idle_queued_resources(Project.CLOUD_ML_AUTO_SOLUTIONS.value, tpu_zones)


### PR DESCRIPTION
# Description

Noticed the QR quota is fully occupied - [here](https://screenshot.googleplex.com/3cPzChSmv7EmXj4). This is caused by manually clear tasks in dev env (or occasionally the QR is not deleted).

Add cleanup DAG:
* Add QR clean up, and run every 10min
* Will continue to add/refactor task to clean up idle TPUs in coming PR

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...
Upload to Airflow and test:
- Successfully deletion - [link](https://screenshot.googleplex.com/BpJiHkhRtuX3jHi)
- All clean-up - [link](https://screenshot.googleplex.com/6nATQLfLsHwa8Yz)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.