### PR TITLE
Set TF 2.16 tests to run on-demand and fixed a bug in the setup script

### DIFF
--- a/dags/solutions_team/configs/tensorflow/common.py
+++ b/dags/solutions_team/configs/tensorflow/common.py
@@ -81,7 +81,7 @@ def install_tf_2_16() -> Tuple[str]:
   """Install tf 2.16 + libtpu."""
   return (
       "pip install tensorflow-text-nightly",
-      "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/2.16/2024-02-20/*.whl /tmp/ && pip install /tmp/tf*.whl --force",
+      "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/2.16/2024-02-20/t*.whl /tmp/ && pip install /tmp/t*.whl --force",
       "sudo gsutil -m cp gs://cloud-tpu-v2-images-dev-artifacts/libtpu/1.10.0/rc0/libtpu.so /lib/",
       CMD_PRINT_TF_VERSION,
   )

--- a/dags/solutions_team/solutionsteam_tf_2_16_se_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_2_16_se_supported.py
@@ -22,8 +22,8 @@ from dags.solutions_team.configs.tensorflow import solutionsteam_tf_2_16_support
 from dags.solutions_team.configs.tensorflow import common
 
 
-# Run once a day at 8 pm UTC (12 pm PST)
-SCHEDULED_TIME = "0 20 * * *" if composer_env.is_prod_env() else None
+# Release tests only need to run once, they can be run manually as needed
+SCHEDULED_TIME = None
 
 with models.DAG(
     dag_id="tf_2_16_se_nightly_supported",

--- a/dags/solutions_team/solutionsteam_tf_2_16_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_2_16_supported.py
@@ -22,8 +22,8 @@ from dags.solutions_team.configs.tensorflow import solutionsteam_tf_2_16_support
 from dags.solutions_team.configs.tensorflow import common
 
 
-# Run once a day at 6 pm UTC (10 am PST)
-SCHEDULED_TIME = "0 18 * * *" if composer_env.is_prod_env() else None
+# Release tests only need to run once, they can be run manually as needed
+SCHEDULED_TIME = None
 
 
 with models.DAG(


### PR DESCRIPTION
# Description

* Modifies the schedule of TF 2.16 release tests to only run on-demand
* Fixes a bug in the setup relating to the tf 2.16 pip install
* Note: another bug remains in the tf 2.16 resnet setup that I will fix in a future changeset

# Tests

Ran a sample tf-keras test: http://shortn/_kCMq0Dcs80

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.