### PR TITLE
Add `ENABLE_PJRT_COMPATIBILITY=true` and rename `maxtext_nightly`

### DIFF
--- a/dags/multipod/configs/maxtext_gce_config.py
+++ b/dags/multipod/configs/maxtext_gce_config.py
@@ -62,6 +62,7 @@ def get_maxtext_nightly_config(
       (
           "cd /tmp/maxtext &&"
           " JAX_PLATFORM_NAME=TPU XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/'"
+          " ENABLE_PJRT_COMPATIBILITY=true"
           f" python3 MaxText/train.py MaxText/configs/base.yml run_name={run_name}"
           f" base_output_directory={base_output_directory}"
           " dataset_path=gs://max-datasets-rogue dataset_type=synthetic"

--- a/dags/multipod/mxla_maxtext_nightly.py
+++ b/dags/multipod/mxla_maxtext_nightly.py
@@ -26,13 +26,13 @@ SCHEDULED_TIME = "0 9 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(
-    dag_id="maxtext_nightly",
+    dag_id="mxla_maxtext_nightly",
     schedule=SCHEDULED_TIME,
     tags=["multipod_team", "maxtext", "nightly"],
     start_date=datetime.datetime(2024, 1, 10),
     catchup=False,
 ) as dag:
-  default_test_name = "maxtext-nightly"
+  default_test_name = "mxla-maxtext-nightly"
   test_mode = SetupMode.NIGHTLY
 
   # v4 Maxtext test


### PR DESCRIPTION
# Description
1. Add `ENABLE_PJRT_COMPATIBILITY=true` to relax the libtpu/jaxlib version check for nightly test.
2. Also rename the test name from `maxtext_nightly` to `mxla_maxtext_nightly`.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Tested on Airflow.

**List links for your tests (use go/shortn-gen for any internal link):** ...
https://screenshot.googleplex.com/7fwW6T5DiUz5LeQ

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.