### PR TITLE
MaxText convergence tests

### DIFF
--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -12,8 +12,8 @@ from dags.multipod.configs.common import SetupMode, Platform
 
 # bf16 and int8 convergence tests, each take ~5 hours to complete on a v4-128
 
-# Run once a week at Saturday 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "0 6 * * SAT" if composer_env.is_prod_env() else None
+# Run once a day at 6 am UTC (10 pm PST)
+SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(
@@ -23,42 +23,43 @@ with models.DAG(
     start_date=datetime.datetime(2024, 2, 27),
     catchup=False,
 ) as dag:
-    
-    current_time = datetime.datetime.now()
-    current_date = current_time.strftime("%Y-%m-%d")
-    base_output_directory = (
+  current_time = datetime.datetime.now()
+  current_date = current_time.strftime("%Y-%m-%d")
+  base_output_directory = (
       f"{gcs_bucket.XLML_OUTPUT_DIR}/maxtext/stable/automated/{current_date}"
-    )
-    dataset_path = "gs://max-datasets-rogue"
-    job_gcp_config = gcp_config.GCPConfig(
-        project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
-        zone=Zone.US_CENTRAL2_B.value,
-        dataset_name=metric_config.DatasetOption.XLML_DATASET
-    )
+  )
+  dataset_path = "gs://max-datasets-rogue"
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
+      zone=Zone.US_CENTRAL2_B.value,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
 
-    loss_threshold = 2.5
-    base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path} LOSS_THRESHOLD={loss_threshold}"
-    convergence_tests = {
-        "maxtext-convergence-bf16" : ((base_convergence_command),),
-        "maxtext-convergence-int8" : ((f"export M_QUANTIZATION=int8; {base_convergence_command}"),)
-    }
+  loss_threshold = 2.5
+  base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path} LOSS_THRESHOLD={loss_threshold}"
+  convergence_tests = {
+      "maxtext-convergence-bf16": ((base_convergence_command),),
+      "maxtext-convergence-int8": (
+          (f"export M_QUANTIZATION=int8; {base_convergence_command}"),
+      ),
+  }
 
-    for test_name, run_command in convergence_tests.items():
-        job_test_config = test_config.TpuGkeTest(
-            test_config.Tpu(
-                version=TpuVersion.V4,
-                cores=128,
-            ),
-            test_name=test_name,
-            cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-            docker_image=DockerImage.MAXTEXT_JAX_STABLE.value,
-            run_model_cmds=run_command,
-            set_up_cmds=None,
-            time_out_in_min=600,
-            task_owner=test_owner.MATT_D,
-            num_slices=1,
-        )
-        task.TpuXpkTask(
-            task_test_config=job_test_config,
-            task_gcp_config=job_gcp_config,
-        ).run()
+  for test_name, run_command in convergence_tests.items():
+    job_test_config = test_config.TpuGkeTest(
+        test_config.Tpu(
+            version=TpuVersion.V4,
+            cores=128,
+        ),
+        test_name=test_name,
+        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+        docker_image=DockerImage.MAXTEXT_JAX_STABLE.value,
+        run_model_cmds=run_command,
+        set_up_cmds=None,
+        time_out_in_min=600,
+        task_owner=test_owner.MATT_D,
+        num_slices=1,
+    )
+    task.TpuXpkTask(
+        task_test_config=job_test_config,
+        task_gcp_config=job_gcp_config,
+    ).run()

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -7,7 +7,7 @@ import datetime
 
 from airflow import models
 from dags import composer_env
-from dags.multipod.configs import maxtext_gke_config, common
+from dags.multipod.configs import common
 from dags.multipod.configs.common import SetupMode, Platform
 
 # bf16 and int8 convergence tests, each take ~5 hours to complete on a v4-128

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -1,0 +1,67 @@
+from xlml.apis import gcp_config, metric_config, task, test_config
+from dags import test_owner, gcs_bucket
+from dags.multipod.configs import common
+from dags.vm_resource import TpuVersion, Project, RuntimeVersion, Zone, ClusterName, DockerImage
+import datetime
+
+
+from airflow import models
+from dags import composer_env
+from dags.multipod.configs import maxtext_gke_config, common
+from dags.multipod.configs.common import SetupMode, Platform
+
+# bf16 convergence test, takes ~ 5 hours to complete on a 4v-128
+
+# Run once a day at 4 am UTC (8 pm PST)
+SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="maxtext_convergence",
+    schedule=SCHEDULED_TIME,
+    tags=["multipod_team", "maxtext", "stable"],
+    start_date=datetime.datetime(2024, 1, 19),
+    catchup=False,
+) as dag:
+
+    
+    base_output_directory = "gs://maxtext-experiments-multipod"
+    dataset_path = "gs://max-datasets-rogue"
+
+    test_name = "maxtext-convergence-bf16"
+    run_command = ((f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path}"),)
+
+    job_gcp_config = gcp_config.GCPConfig(
+        project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
+        zone=Zone.US_CENTRAL2_B.value,
+        dataset_name=dataset_path,
+    )
+
+    job_test_config = test_config.TpuGkeTest(
+        test_config.Tpu(
+            version=TpuVersion.V4,
+            cores=128,
+        ),
+        test_name=test_name,
+        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+        docker_image=DockerImage.MAXTEXT_JAX_STABLE.value,
+        run_model_cmds=run_command,
+        set_up_cmds=None,
+        time_out_in_min=600,
+        task_owner=test_owner.MATT_D,
+        num_slices=1,
+    )
+
+    print(f"{job_test_config=}")
+
+    t = task.TpuXpkTask(
+        task_test_config=job_test_config,
+        task_gcp_config=job_gcp_config,
+    )
+    print(f"{t=}")
+    t.run()
+
+    # task.TpuXpkTask(
+    #     task_test_config=job_test_config,
+    #     task_gcp_config=job_gcp_config,
+    # ).run()

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -10,58 +10,54 @@ from dags import composer_env
 from dags.multipod.configs import maxtext_gke_config, common
 from dags.multipod.configs.common import SetupMode, Platform
 
-# bf16 convergence test, takes ~ 5 hours to complete on a 4v-128
+# bf16 and int8 convergence tests, each take ~5 hours to complete on a v4-128
 
-# Run once a day at 4 am UTC (8 pm PST)
-SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+# Run once a week at Saturday 6 am UTC (10 pm PST)
+SCHEDULED_TIME = "0 6 * * SAT" if composer_env.is_prod_env() else None
 
 
 with models.DAG(
     dag_id="maxtext_convergence",
     schedule=SCHEDULED_TIME,
     tags=["multipod_team", "maxtext", "stable"],
-    start_date=datetime.datetime(2024, 1, 19),
+    start_date=datetime.datetime(2024, 2, 27),
     catchup=False,
 ) as dag:
-
     
-    base_output_directory = "gs://maxtext-experiments-multipod"
+    current_time = datetime.datetime.now()
+    current_date = current_time.strftime("%Y-%m-%d")
+    base_output_directory = (
+      f"{gcs_bucket.XLML_OUTPUT_DIR}/maxtext/stable/automated/{current_date}"
+    )
     dataset_path = "gs://max-datasets-rogue"
-
-    test_name = "maxtext-convergence-bf16"
-    run_command = ((f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path}"),)
-
     job_gcp_config = gcp_config.GCPConfig(
         project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
         zone=Zone.US_CENTRAL2_B.value,
         dataset_name=dataset_path,
     )
 
-    job_test_config = test_config.TpuGkeTest(
-        test_config.Tpu(
-            version=TpuVersion.V4,
-            cores=128,
-        ),
-        test_name=test_name,
-        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-        docker_image=DockerImage.MAXTEXT_JAX_STABLE.value,
-        run_model_cmds=run_command,
-        set_up_cmds=None,
-        time_out_in_min=600,
-        task_owner=test_owner.MATT_D,
-        num_slices=1,
-    )
+    base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path}"
+    convergence_tests = {
+        "maxtext-convergence-bf16" : ((base_convergence_command),),
+        "maxtext-convergence-int8" : ((f"export M_QUANTIZATION=int8; {base_convergence_command}"))
+    }
 
-    print(f"{job_test_config=}")
-
-    t = task.TpuXpkTask(
-        task_test_config=job_test_config,
-        task_gcp_config=job_gcp_config,
-    )
-    print(f"{t=}")
-    t.run()
-
-    # task.TpuXpkTask(
-    #     task_test_config=job_test_config,
-    #     task_gcp_config=job_gcp_config,
-    # ).run()
+    for test_name, run_command in convergence_tests.items:
+        job_test_config = test_config.TpuGkeTest(
+            test_config.Tpu(
+                version=TpuVersion.V4,
+                cores=128,
+            ),
+            test_name=test_name,
+            cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+            docker_image=DockerImage.MAXTEXT_JAX_STABLE.value,
+            run_model_cmds=run_command,
+            set_up_cmds=None,
+            time_out_in_min=600,
+            task_owner=test_owner.MATT_D,
+            num_slices=1,
+        )
+        task.TpuXpkTask(
+            task_test_config=job_test_config,
+            task_gcp_config=job_gcp_config,
+        ).run()

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -43,7 +43,7 @@ with models.DAG(
         "maxtext-convergence-int8" : ((f"export M_QUANTIZATION=int8; {base_convergence_command}"))
     }
 
-    for test_name, run_command in convergence_tests.items:
+    for test_name, run_command in convergence_tests.items():
         job_test_config = test_config.TpuGkeTest(
             test_config.Tpu(
                 version=TpuVersion.V4,

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -40,7 +40,7 @@ with models.DAG(
     base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path} LOSS_THRESHOLD={loss_threshold}"
     convergence_tests = {
         "maxtext-convergence-bf16" : ((base_convergence_command),),
-        "maxtext-convergence-int8" : ((f"export M_QUANTIZATION=int8; {base_convergence_command}"))
+        "maxtext-convergence-int8" : ((f"export M_QUANTIZATION=int8; {base_convergence_command}"),)
     }
 
     for test_name, run_command in convergence_tests.items():

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -33,7 +33,7 @@ with models.DAG(
     job_gcp_config = gcp_config.GCPConfig(
         project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
         zone=Zone.US_CENTRAL2_B.value,
-        dataset_name=dataset_path,
+        dataset_name=metric_config.DatasetOption.XLML_DATASET
     )
 
     base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path}"

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -36,7 +36,8 @@ with models.DAG(
         dataset_name=metric_config.DatasetOption.XLML_DATASET
     )
 
-    base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path}"
+    loss_threshold = 2.5
+    base_convergence_command = f"bash end_to_end/test_convergence_1b_params.sh OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path} LOSS_THRESHOLD={loss_threshold}"
     convergence_tests = {
         "maxtext-convergence-bf16" : ((base_convergence_command),),
         "maxtext-convergence-int8" : ((f"export M_QUANTIZATION=int8; {base_convergence_command}"))

--- a/dags/test_owner.py
+++ b/dags/test_owner.py
@@ -33,6 +33,7 @@ PEI_Z = "Pei Z."
 TONY_C = "Tony C."
 JON_B = "Jon B."
 RAYMOND_Z = "Raymond Z."
+MATT_D = "Matt D."
 
 # MLCompass
 ORTI_B = "Orti B."

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -106,3 +106,5 @@ class ClusterName(enum.Enum):
 class DockerImage(enum.Enum):
   XPK_JAX_TEST = "gcr.io/cloud-ml-auto-solutions/xpk_jax_test:latest"
   XPK_MAXTEXT_TEST = "gcr.io/tpu-prod-env-multipod/xpk_maxtext_test:latest"
+  MAXTEXT_JAX_STABLE = "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:latest"
+  MAXTEXT_JAX_NIGHTLY = "gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:latest"


### PR DESCRIPTION
# Description

MaxText convergence tests for bf16 and int8. These tests take 5 hours to run on a v4-128, so they will target an XPK cluster and run only once per week.

# Tests

Ran on local dev composer environment:
```
bucket_name=<your-bucket> # us-central1-mattdavidow-dev-53a5a345-bucket
bash scripts/upload-tests.sh gs://${bucket_name}/dags
```
Then ran dag in composer environment:

Dag result http://shortn/_qxsZCSmUrC


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.