### PR TITLE
Switch ResNet50 SPMD test to use fake data

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -241,7 +241,7 @@ local tpus = import 'templates/tpus.libsonnet';
     resnet50 + convergence + v4_32 + timeouts.Hours(24) + pjrt,
     resnet50 + fake_data + v5litepod_4 + timeouts.Hours(2) + pjrt,
     // SPMD
-    resnet50 + functional + v4_8 + timeouts.Hours(2) + pjrt + spmd(['batch']),
-    resnet50 + functional + v4_8 + timeouts.Hours(2) + pjrt + spmd(['spatial']),
+    resnet50 + fake_data + v4_8 + timeouts.Hours(2) + pjrt + spmd(['batch']),
+    resnet50 + fake_data + v4_8 + timeouts.Hours(2) + pjrt + spmd(['spatial']),
   ],
 }

--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -77,8 +77,8 @@ def torchvision():
       for test in (
           "pt-nightly-resnet50-pjrt-fake-v4-8-1vm",
           "pt-nightly-resnet50-pjrt-ddp-fake-v4-8-1vm",
-          "pt-nightly-resnet50-spmd-batch-func-v4-8-1vm",
-          "pt-nightly-resnet50-spmd-spatial-func-v4-8-1vm",
+          "pt-nightly-resnet50-spmd-batch-fake-v4-8-1vm",
+          "pt-nightly-resnet50-spmd-spatial-fake-v4-8-1vm",
       )
   ]
   resnet_v4_32 = task.TpuQueuedResourceTask(


### PR DESCRIPTION
# Description

Use fake data for ResNet50 SPMD test. `imagenet-mini` is not available in the test environment.

# Tests

n/a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.