### PR TITLE
Adds missing WRAPT_DISABLE_EXTENSIONS=true flag

### DIFF
--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_2_16_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_2_16_supported_config.py
@@ -57,7 +57,7 @@ def get_tf_keras_config(
       (
           "export PATH=$PATH:/home/ml-auto-solutions/.local/bin &&"
           f" export TPU_NAME={tpu_name} && {env_variable} &&"
-          " cd /tmp/tf2-api-tests && TF_USE_LEGACY_KERAS=1"
+          " cd /tmp/tf2-api-tests &&"
           " behave -e ipynb_checkpoints"
           f" --tags=-fails {skipped_tag} -i {test_feature}"
       ),
@@ -144,7 +144,7 @@ def get_tf_resnet_config(
       "sudo chmod -R 777 /tmp/",
       (
           f"cd /usr/share/tpu/models && {env_variable} &&"
-          " PYTHONPATH='.' TF_USE_LEGACY_KERAS=1"
+          " PYTHONPATH='.'"
           " python3 official/vision/train.py"
           f" --tpu={tpu_name} --experiment=resnet_imagenet"
           " --mode=train_and_eval --model_dir=/tmp/"
@@ -279,7 +279,7 @@ def get_tf_dlrm_config(
       "sudo chmod -R 777 /tmp/",
       (
           f"cd /usr/share/tpu/models && {env_variable} &&"
-          " TF_USE_LEGACY_KERAS=1 PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
+          " PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
           f" --tpu={tpu_name} --model_dir=/tmp/output {extraFlags}"
           " --params_override='%s'" % str(params_override)
       ),
@@ -311,10 +311,11 @@ def get_tf_dlrm_config(
 
 def export_env_variable(is_pod: bool, is_pjrt: bool) -> str:
   """Export environment variables for training if any."""
+  stmts = ["export WRAPT_DISABLE_EXTENSIONS=true", "export TF_USE_LEGACY_KERAS=1"]
   if is_pod:
-    return "export TPU_LOAD_LIBRARY=0"
+    stmts.append("export TPU_LOAD_LIBRARY=0")
   elif is_pjrt:
-    return "export NEXT_PLUGGABLE_DEVICE_USE_C_API=true && export TF_PLUGGABLE_DEVICE_LIBRARY_PATH=/lib/libtpu.so"
-  else:
-    # dummy command
-    return "echo"
+    stmts.append("export NEXT_PLUGGABLE_DEVICE_USE_C_API=true")
+    stmts.append("export TF_PLUGGABLE_DEVICE_LIBRARY_PATH=/lib/libtpu.so")
+
+  return " && ".join(stmts)


### PR DESCRIPTION
# Description

Adds a missing WRAPT_DISABLE_EXTENSIONS=true environment flag.
Consolidates TF_USE_LEGACY_KERAS=1 into a single location.

# Tests

Ran 2.16 tests on Resnet and DLRM which were previously failing and are now passing.
Ran 2.16 test on tf-keras which remains passing.

**List links for your tests (use go/shortn-gen for any internal link):**/
[tf-keras](http://shortn/_qsMrqm5hQr)
[Resnet](http://shortn/_Uu4K6ZCxbt)
[DLRM](http://shortn/_nGYQPWVVus)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.