### PR TITLE
[PT/XLA] Remove task group prefix from PyTorch nightly test groups.

### DIFF
--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -47,7 +47,7 @@ US_EAST1_C = gcp_config.GCPConfig(
 )
 
 
-@task_group
+@task_group(prefix_group_id=False)
 def torchvision():
   mnist_v2_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch("pt-nightly-mnist-pjrt-func-v2-8-1vm"),
@@ -134,7 +134,7 @@ def torchvision():
   resnet_v100_2x1_plugin >> resnet_v100_2x2_plugin
 
 
-@task_group
+@task_group(prefix_group_id=False)
 def huggingface():
   accelerate_v2_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch("pt-nightly-accelerate-smoke-v2-8-1vm"),
@@ -162,7 +162,7 @@ def huggingface():
   ).run()
 
 
-@task_group
+@task_group(prefix_group_id=False)
 def llama():
   llama_inference_v4_8 = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(


### PR DESCRIPTION
# Description

The name prefix breaks post process, e.g.

```
File "/home/airflow/gcs/dags/xlml/utils/metric.py", line 671, in process_metrics
    test_job_status = get_gce_job_status(task_test_config, use_startup_script)
...
airflow.exceptions.TaskNotFound: Task pt-nightly-llama2-pjrt-infer-func-v4-8-1vm-1vm.provision.create_queued_resource.wait_for_ready_queued_resource not found
```

The prefix isn't useful. We just want to group tests by topic in the Airflow UI.

# Tests

n/a, reverts tests to old IDs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.