### PR TITLE
[PT/XLA] Add `scikit-learn` to BERT test config

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/hf-bert.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/hf-bert.libsonnet
@@ -50,7 +50,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName+: '-pjrt',
     tpuSettings+: {
       tpuVmExtraSetup: |||
-        pip install tensorboardX google-cloud-storage transformers evaluate sacrebleu sacremoses
+        pip install tensorboardX google-cloud-storage transformers evaluate scikit-learn
       |||,
     },
   },


### PR DESCRIPTION
# Description

Fixes `ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['scikit-learn'] using 'pip install sklearn' for instance'`

# Tests

Tested locally on a TPU v4.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.