### PR TITLE
Increase size of schedulers

### DIFF
--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -147,10 +147,10 @@ resource "google_composer_environment" "example_environment" {
 
     workloads_config {
       scheduler {
-        cpu        = 4
-        memory_gb  = 13
+        cpu        = 8
+        memory_gb  = 26
         storage_gb = 10
-        count      = 2
+        count      = 8
       }
       web_server {
         cpu        = 2

--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -147,10 +147,10 @@ resource "google_composer_environment" "example_environment" {
 
     workloads_config {
       scheduler {
-        cpu        = 8
-        memory_gb  = 26
+        cpu        = 28
+        memory_gb  = 80
         storage_gb = 10
-        count      = 8
+        count      = 2
       }
       web_server {
         cpu        = 2


### PR DESCRIPTION
# Description

With larger tests, schedulers are near the maximum utilization:

![image](https://github.com/GoogleCloudPlatform/ml-auto-solutions/assets/15197278/17f22a31-a14d-43cf-875e-436d05a1ff33)

This may be causing an increase in zombies and interrupted tasks:

![image](https://github.com/GoogleCloudPlatform/ml-auto-solutions/assets/15197278/387e8837-912a-4b1b-9356-cd370389b19f)

See https://cloud.google.com/composer/docs/how-to/using/troubleshooting-dags#zombie-tasks

# Tests

n/a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.