### PR TITLE
Update sync up algorithm

### DIFF
--- a/scripts/upload-tests.sh
+++ b/scripts/upload-tests.sh
@@ -22,7 +22,7 @@ FOLDERS_TO_UPLOAD=("dags" "xlml")
 # TODO(ranran): handle tests from Jsonnet
 for folder in "${FOLDERS_TO_UPLOAD[@]}"
 do
-  gsutil -m rsync -d -r "$folder" "$GCS_DAGS_FOLDER"/"$folder"
+  gsutil -m rsync -c -d -r "$folder" "$GCS_DAGS_FOLDER"/"$folder"
 done
 
 echo "Successfully uploaded tests."


### PR DESCRIPTION
# Description

Update sync up algorithm to use checksum, instead of mtime.

```
-c 

Causes the rsync command to compute and compare checksums (instead of comparing mtime)
 for files if the size of source and destination match. This option increases local disk I/O and run 
time if either src_url or dst_url are on the local file system.

```

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Test it in build.

**List links for your tests (use go/shortn-gen for any internal link):** ...
* 1st build: upload 29 files - [link](https://screenshot.googleplex.com/3mzQ9r8yMDLYRMj)
* 2nd build: upload 0 file - [link](https://screenshot.googleplex.com/AeAQLB4YDA3qhSm)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.