### PR TITLE
[PT/XLA] Install expecttest in CI test script

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/ci.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/ci.libsonnet
@@ -17,6 +17,11 @@ local tpus = import 'templates/tpus.libsonnet';
         test/tpu/run_tests.sh
       |||,
     ],
+    tpuSettings+: {
+      tpuVmExtraSetup: |||
+        pip install expecttest==0.1.6
+      |||,
+    },
   },
   local pjrt = self.pjrt,
   pjrt:: common.PyTorchTpuVmMixin,


### PR DESCRIPTION
# Description

Fixes `ModuleNotFoundError: No module named 'expecttest'`