### PR TITLE
Allow running xpk workloads with standalone Airflow

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -8,4 +8,5 @@ google-cloud-tpu>=1.16.0
 jsonlines
 tensorflow-cpu
 apache-airflow-providers-cncf-kubernetes
+apache-airflow-providers-docker
 kubernetes

--- a/dags/examples/xpk_example_dag.py
+++ b/dags/examples/xpk_example_dag.py
@@ -51,5 +51,5 @@ with models.DAG(
       cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
       docker_image=DockerImage.XPK_JAX_TEST.value,
       time_out_in_min=60,
-      num_slices=4,
+      num_slices=2,
   ).run()

--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -133,6 +133,7 @@ resource "google_composer_environment" "example_environment" {
       # Note: keep this in sync with .github/requirements.txt
       pypi_packages = {
         apache-airflow-providers-sendgrid = ""
+	apache-airflow-providers-docker   = ""
         fabric                            = ""
         google-cloud-tpu                  = ">=1.16.0"
         jsonlines                         = ""

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,12 +58,7 @@ for this purpose.
 
 To run a dag file in a temporary local environment, use `local-airflow.sh`. The script will symlink just the DAG provided to speed up parsing times.
 
-This requires Airflow to be installed locally. Ensure you have the appropriate Airflow version installed as defined in [cloud_composer_template.tf](/deployment/cloud_composer_template.tf#L126). For version 2.6.3:
-
-```
-VERSION=2.6.3
-pip install apache-airflow==$VERSION --constraint 'https://raw.githubusercontent.com/apache/airflow/constraints-${VERSION}/constraints-3.10.txt'
-```
+This requires Airflow to be installed locally. You can configure your local environment by running `pip install -r .github/requirements.txt`.
 
 To run the local environment, use the following commands:
 
@@ -80,6 +75,6 @@ If you're running a JSonnet-based test, run this each time any time the test cha
 scripts/gen-configs.sh
 ```
 
-Airflow will print a link to a local instance as well as a temporary admin password. From the UI, find your dag and run it manually.
+Airflow will print a link to a local instance. From the UI, find your dag and run it manually.
 
 This functionality is extremely experimental, and not all DAGs are expected to work with a local standalone server. Only the Airflow server runs locally. Tests will still run in the project defined in each DAG, so use this option with caution.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,6 +58,15 @@ for this purpose.
 
 To run a dag file in a temporary local environment, use `local-airflow.sh`. The script will symlink just the DAG provided to speed up parsing times.
 
+This requires Airflow to be installed locally. Ensure you have the appropriate Airflow version installed as defined in [cloud_composer_template.tf](/deployment/cloud_composer_template.tf#L126). For version 2.6.3:
+
+```
+VERSION=2.6.3
+pip install apache-airflow==$VERSION --constraint 'https://raw.githubusercontent.com/apache/airflow/constraints-${VERSION}/constraints-3.10.txt'
+```
+
+To run the local environment, use the following commands:
+
 ```
 gcloud auth login --update-adc
 scripts/local-airflow.sh path/to/dag_file.py

--- a/scripts/local-airflow.sh
+++ b/scripts/local-airflow.sh
@@ -8,6 +8,7 @@ set -xue
 export PYTHONPATH=$PWD
 export XLMLTEST_CONFIGS=$PWD/dags/jsonnet
 export XLMLTEST_SSH_EXTERNAL_IPS=1
+export XLMLTEST_LOCAL_AIRFLOW=1
 
 export AIRFLOW_HOME=$(mktemp -d)
 
@@ -16,5 +17,11 @@ ln -s $PWD/$target_dag $AIRFLOW_HOME/dags/
 
 cd $AIRFLOW_HOME
 
+# Disable auth login
+echo "AUTH_ROLE_PUBLIC = 'Admin'" > webserver_config.py
+
 export AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES_REGEXP='.*'
+export AIRFLOW__CORE__LOAD_EXAMPLES=False
+export AIRFLOW__WEBSERVER__WEB_SERVER_HOST=localhost
+export AIRFLOW__API__AUTH_BACKENDS=airflow.api.auth.backend.default
 airflow standalone

--- a/scripts/local-airflow.sh
+++ b/scripts/local-airflow.sh
@@ -20,6 +20,7 @@ cd $AIRFLOW_HOME
 # Disable auth login
 echo "AUTH_ROLE_PUBLIC = 'Admin'" > webserver_config.py
 
+# Configs from https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html
 export AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES_REGEXP='.*'
 export AIRFLOW__CORE__LOAD_EXAMPLES=False
 export AIRFLOW__WEBSERVER__WEB_SERVER_HOST=localhost

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -384,8 +384,6 @@ class TpuXpkTask(BaseTask):
           docker_image=self.task_test_config.docker_image,
           accelerator_type=self.task_test_config.accelerator.name,
           run_cmds=self.task_test_config.test_script,
-          task_owner=self.task_test_config.task_owner,
-          startup_timeout=self.task_test_config.startup_time_out_in_sec,
           num_slices=self.task_test_config.num_slices,
       )
       wait_for_workload_completion = xpk.wait_for_workload_completion.override(

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -374,7 +374,7 @@ class TpuXpkTask(BaseTask):
     """
     with TaskGroup(group_id="run_model") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      run_workload = xpk.run_workload(
+      run_workload = xpk.run_workload.override(owner=self.task_test_config.task_owner)(
           task_id="run_workload",
           cluster_project=self.task_gcp_config.project_name,
           zone=self.task_gcp_config.zone,

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -374,7 +374,9 @@ class TpuXpkTask(BaseTask):
     """
     with TaskGroup(group_id="run_model") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      run_workload = xpk.run_workload.override(owner=self.task_test_config.task_owner)(
+      run_workload = xpk.run_workload.override(
+          owner=self.task_test_config.task_owner
+      )(
           task_id="run_workload",
           cluster_project=self.task_gcp_config.project_name,
           zone=self.task_gcp_config.zone,

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -15,9 +15,9 @@
 """Utilities to run workloads with xpk (https://github.com/google/xpk)."""
 
 import uuid
+import os
 from absl import logging
 from airflow.decorators import task
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from kubernetes import client as k8s_client
 from kubernetes.client import models as k8s_models
 from xlml.utils import gke
@@ -30,7 +30,7 @@ def generate_workload_id(benchmark_id: str) -> str:
   return f"{benchmark_id}-{short_id}"
 
 
-def run_workload(
+def _run_workload(
     task_id: str,
     cluster_project: str,
     zone: str,
@@ -43,15 +43,9 @@ def run_workload(
     task_owner: str,
     startup_timeout: int,
     num_slices: int = 1,
-) -> KubernetesPodOperator:
-  """Run workload through xpk tool.
-
-  The reason to use KubernetesPodOperator instead of BashOperator is that
-  xpk must run with Python 3.10 or greater; however, the latest version in
-  Composer is Python 3.8, and it's non-trivial to upgrade it as the  Composer
-  uses docker images that bundle Airflow releases with Python and other
-  libraries.
-  """
+):
+  """Run workload through xpk tool."""
+  import subprocess
 
   cmds = (
       "set -xue",
@@ -79,17 +73,20 @@ def run_workload(
       ),
   )
 
-  return KubernetesPodOperator(
-      task_id=task_id,
-      name=benchmark_id,
-      cmds=["/bin/bash", "-c"],
-      arguments=[";".join(cmds)],
+  subprocess.run(["bash", "-c", ";".join(cmds)], check=True)
+
+
+# To support local execution using `scripts/local-airflow.sh`, run using
+# task.docker in local environments. Otherwise, task.kubernetes should be used.
+if "XLMLTEST_LOCAL_AIRFLOW" in os.environ:
+  run_workload = task.docker(_run_workload, image="python:3.10")
+else:
+  run_workload = task.kubernetes(
+      _run_workload,
       namespace="composer-user-workloads",
       image="python:3.10",
       config_file="/home/airflow/composer_kube_config",
       kubernetes_conn_id="kubernetes_default",
-      startup_timeout_seconds=startup_timeout,
-      owner=task_owner,
       container_resources=k8s_models.V1ResourceRequirements(
           limits={"ephemeral-storage": "10G"},
       ),

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -40,8 +40,6 @@ def _run_workload(
     docker_image: str,
     accelerator_type: str,
     run_cmds: str,
-    task_owner: str,
-    startup_timeout: int,
     num_slices: int = 1,
 ):
   """Run workload through xpk tool."""


### PR DESCRIPTION
# Description

Enable running XPK using a local Airflow environment, and integrate the `run_workload` using Taskflow. The task type should be conditionally determined by the execution environment: local Airflow tasks should use `task.docker`, and in the Composer environment `task.kubernetes` should be used.

*Note that the VM hosting the standalone Airflow server must have sufficient permissions to create workloads in the target GKE cluster.*

This change also adds a couple of ease-of-use enhancements for standalone runs:

- Disable login for the local server, and run on localhost
- Remove example DAGs to only show the desired one.

# Tests

- Ran example_gke_dag locally (1-slice failed due to VM permission issues, 2-slice started): http://screen/Aj5fJLtzuiCi9Dk
- Ran example_gke_dag in a Composer environment (manually killed the 4-slice run): http://shortn/_j9QVWlXXX1

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.