### PR TITLE
Use fake token to bypass torchbench HF init check

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -88,6 +88,7 @@ def get_torchbench_tpu_config(
   else:
     run_filter = f" --filter={model_name} "
   run_script_cmds = (
+      "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
       (
           "export PJRT_DEVICE=TPU && cd ~/xla/benchmarks && python experiment_runner.py"
           " --suite-name=torchbench --xla=PJRT --accelerator=tpu --progress-bar"
@@ -230,6 +231,7 @@ def get_torchbench_gpu_config(
   cmd_list = (
       "export PJRT_DEVICE=CUDA",
       f"export GPU_NUM_DEVICES={count}",
+      "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
       "cd /tmp/xla/benchmarks",
       f"python experiment_runner.py  --suite-name=torchbench --accelerator=cuda --progress-bar --xla=PJRT --xla=None {run_filter}",
       "rm -rf /tmp/xla/benchmarks/output/metric_report.jsonl",


### PR DESCRIPTION
# Description

Torchbench always check the token if we import models from hugging face: https://github.com/pytorch/benchmark/blob/8ffe57ecb5df6af5c458684f1834fbe78adfda00/torchbenchmark/util/framework/huggingface/model_factory.py#L191-L195. The token is not a must for public models. We use fake token to bypass torchbench HF init check.

Details: https://b.corp.google.com/issues/324078896#comment6.
