### PR TITLE
Example migration of Multipod XL ML test

### DIFF
--- a/dags/multipod/configs/legacy_unit_test.py
+++ b/dags/multipod/configs/legacy_unit_test.py
@@ -40,8 +40,9 @@ def get_legacy_unit_test_config(
 ) -> task.TpuXpkTask:
   """
   Run a legacy unit test script.
-  `script_to_copy` will be copied into the workload container, and `test_cmd`
-  will run in the same directory.
+  `script_to_copy` is a script in the `dags/multipod/legacy_tests` folder to be
+  copied into the workload container, and `test_cmd` will run with the script
+  in the working directory.
   """
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project_name,

--- a/dags/multipod/configs/legacy_unit_test.py
+++ b/dags/multipod/configs/legacy_unit_test.py
@@ -32,7 +32,6 @@ def get_legacy_unit_test_config(
     tpu_zone: str,
     time_out_in_min: int,
     test_name: str,
-    test_mode: common.SetupMode,
     test_owner: str,
     docker_image: str,
     num_slices: int = 1,

--- a/dags/multipod/configs/legacy_unit_test.py
+++ b/dags/multipod/configs/legacy_unit_test.py
@@ -48,7 +48,6 @@ def get_legacy_unit_test_config(
   )
 
   run_model_cmds = (
-      'set -xue',
       f'git clone https://github.com/GoogleCloudPlatform/ml-auto-solutions',
       'cd ml-auto-solutions/dags/multipod/legacy_tests',
       'export TPU_STDERR_LOG_LEVEL=0 TPU_MIN_LOG_LEVEL=0 JAX_USE_PJRT_C_API_ON_TPU=1 TF_CPP_MIN_LOG_LEVEL=0',

--- a/dags/multipod/configs/legacy_unit_test.py
+++ b/dags/multipod/configs/legacy_unit_test.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to run legacy tests from the old infrastructure."""
+
+import datetime
+import os
+from xlml.apis import gcp_config, metric_config, task, test_config
+from collections.abc import Iterable
+from dags import test_owner
+from dags.multipod.configs import common
+from dags.vm_resource import TpuVersion, Project, RuntimeVersion, ClusterName
+
+
+def get_legacy_unit_test_config(
+    test_cmd: Iterable[str],
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    time_out_in_min: int,
+    test_name: str,
+    test_mode: common.SetupMode,
+    test_owner: str,
+    docker_image: str,
+    num_slices: int = 1,
+    cluster_name: str = ClusterName.V4_8_MULTISLICE_CLUSTER.value,
+    project_name: str = Project.TPU_PROD_ENV_MULTIPOD.value,
+) -> task.TpuXpkTask:
+  """
+  Run a legacy unit test script.
+  test_cmd will be executed within the `dags/multipod/legacy_tests` directory.
+  """
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  run_model_cmds = (
+      'set -xue',
+      f'git clone https://github.com/GoogleCloudPlatform/ml-auto-solutions',
+      'cd ml-auto-solutions/dags/multipod/legacy_tests',
+      'export TPU_STDERR_LOG_LEVEL=0 TPU_MIN_LOG_LEVEL=0 JAX_USE_PJRT_C_API_ON_TPU=1 TF_CPP_MIN_LOG_LEVEL=0',
+      *test_cmd,
+  )
+
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+      ),
+      test_name=test_name,
+      run_model_cmds=run_model_cmds,
+      set_up_cmds=None,
+      time_out_in_min=time_out_in_min,
+      task_owner=test_owner,
+      num_slices=num_slices,
+      cluster_name=cluster_name,
+      docker_image=docker_image,
+  )
+
+  return task.TpuXpkTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+  )

--- a/dags/multipod/legacy.py
+++ b/dags/multipod/legacy.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run tests migrated from the legacy XL ML infrastructure"""
+
+import datetime
+from airflow import models
+from dags import composer_env, gcs_bucket, test_owner
+from dags.vm_resource import TpuVersion, Zone, Project, DockerImage, ClusterName
+from dags.multipod.configs import legacy_unit_test, gke_config
+from dags.multipod.configs.common import SetupMode, Platform
+
+# Run once a day at 9 am UTC (1 am PST)
+SCHEDULED_TIME = "0 9 * * *" if composer_env.is_prod_env() else None
+
+
+for test_mode in [SetupMode.NIGHTLY, SetupMode.STABLE]:
+  with models.DAG(
+      dag_id=f"multipod_legacy_xlml_{test_mode.value}",
+      schedule=SCHEDULED_TIME,
+      tags=["multipod_team", "xlml", "legacy", test_mode.value],
+      start_date=datetime.datetime(2024, 1, 10),
+      catchup=False,
+      concurrency=2,
+  ) as dag:
+    docker_image = (
+        DockerImage.MAXTEXT_JAX_NIGHTLY
+        if test_mode == SetupMode.NIGHTLY
+        else DockerImage.MAXTEXT_JAX_STABLE
+    )
+    current_time = datetime.datetime.now()
+    current_date = current_time.strftime("%Y-%m-%d")
+    base_output_directory = f"{gcs_bucket.XLML_OUTPUT_DIR}/legacy_unit_test/{test_mode.value}/{current_date}"
+
+    # Tests that require scripts from the `jax/unit_tests` folder should follow
+    # this pattern.
+    # TODO(jonbolin): Example for legacy unit test migration - evaluate whether
+    # to remove gpt1-like tests once test migration is complete.
+    for n_slice in [1, 2]:
+      legacy_unit_test.get_legacy_unit_test_config(
+          test_cmd=("python3 gpt1-like.py",),
+          tpu_version=TpuVersion.V4,
+          tpu_cores=16,
+          tpu_zone=Zone.US_CENTRAL2_B.value,
+          time_out_in_min=60,
+          test_name=f"gpt1-like",
+          test_mode=test_mode,
+          docker_image=docker_image.value,
+          test_owner=test_owner.JON_B,
+          num_slices=n_slice,
+          cluster_name=ClusterName.V4_16_MULTISLICE_CLUSTER.value,
+      ).run()
+
+    # Tests that run MaxText end_to_end tests should follow this pattern.
+    gke_config.get_gke_config(
+        tpu_version=TpuVersion.V4,
+        tpu_cores=8,
+        tpu_zone=Zone.US_CENTRAL2_B.value,
+        time_out_in_min=60,
+        test_name="maxtext-decode",
+        run_model_cmds=(
+            "bash end_to_end/test_decode.sh 10 gs://maxtext-xlml gs://maxtext-xlml/dataset xlml-decode-v4-8-1slice-stable",
+        ),
+        docker_image=docker_image.value,
+        test_owner=test_owner.JON_B,
+    ).run()

--- a/dags/multipod/legacy.py
+++ b/dags/multipod/legacy.py
@@ -39,10 +39,6 @@ for test_mode in [SetupMode.NIGHTLY, SetupMode.STABLE]:
         if test_mode == SetupMode.NIGHTLY
         else DockerImage.MAXTEXT_JAX_STABLE
     )
-    current_time = datetime.datetime.now()
-    current_date = current_time.strftime("%Y-%m-%d")
-    base_output_directory = f"{gcs_bucket.XLML_OUTPUT_DIR}/legacy_unit_test/{test_mode.value}/{current_date}"
-
     # Tests that require scripts from the `jax/unit_tests` folder should follow
     # this pattern.
     # TODO(jonbolin): Example for legacy unit test migration - evaluate whether

--- a/dags/multipod/legacy.py
+++ b/dags/multipod/legacy.py
@@ -51,7 +51,6 @@ with models.DAG(
           tpu_zone=Zone.US_CENTRAL2_B.value,
           time_out_in_min=60,
           test_name=f"gpt1-like-{test_mode.value}",
-          test_mode=test_mode,
           docker_image=DOCKER_IMAGE[test_mode].value,
           test_owner=test_owner.JON_B,
           num_slices=n_slice,

--- a/dags/multipod/legacy_tests/gpt1-like.py
+++ b/dags/multipod/legacy_tests/gpt1-like.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python3
+import jax
+from jax.experimental.pjit import pjit
+from jax._src.partition_spec import PartitionSpec
+import numpy as np
+from jax._src.mesh import Mesh
+import datetime
+import os
+
+# os.environ["TPU_STDERR_LOG_LEVEL"] = "0"
+# os.environ["TPU_MIN_LOG_LEVEL"] = "0"
+# os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+os.environ["JAX_USE_PJRT_C_API_ON_TPU"] = "1"
+
+
+def simple_timeit(f, tries=10, verbose=True):
+  outcomes = []
+  f()  # warm it up!
+  for i in range(tries):
+    s = datetime.datetime.now()
+    r = f()
+    e = datetime.datetime.now()
+    outcomes.append((e - s).total_seconds())
+  average_time = sum(outcomes) / len(outcomes)
+  if verbose:
+    print(f"average time: {average_time}, timings (seconds) {outcomes}")
+  return average_time
+
+
+# GPT1
+BATCH = len(jax.devices()) * 128
+SEQUENCE_LENGTH = 512
+D_MODEL = 768
+D_HIDDEN = 3072
+NUM_LAYERS = 12
+
+
+parameter_bytes = 2 * (4 * D_MODEL * D_HIDDEN * NUM_LAYERS)
+ACTIVATIONS_PER_LAYER = 2
+activation_bytes = (
+    2 * (BATCH * SEQUENCE_LENGTH * D_MODEL) * NUM_LAYERS * ACTIVATIONS_PER_LAYER
+)
+memory_bytes = parameter_bytes + activation_bytes
+
+print(
+    f"total {memory_bytes/10**9} GB, parameters {parameter_bytes/10**9} GB, all layers of activations {activation_bytes/10**9} GB",
+    flush=True,
+)
+
+
+def gen_layer(random_key):
+  keys = jax.random.split(random_key, num=4)
+  return {
+      "WQ": 1e-4
+      * jax.random.normal(
+          keys[0], (D_MODEL, D_HIDDEN), dtype=jax.numpy.bfloat16
+      ),
+      "WK": 1e-4
+      * jax.random.normal(
+          keys[1], (D_MODEL, D_HIDDEN), dtype=jax.numpy.bfloat16
+      ),
+      "WV": 1e-4
+      * jax.random.normal(
+          keys[2], (D_MODEL, D_HIDDEN), dtype=jax.numpy.bfloat16
+      ),
+      "FF": 1e-4
+      * jax.random.normal(
+          keys[3], (D_HIDDEN, D_MODEL), dtype=jax.numpy.bfloat16
+      ),
+  }
+
+
+def gen_layers(random_key):
+  layers = []
+  for _ in range(NUM_LAYERS):
+    random_key, sub_key = jax.random.split(random_key)
+    layers.append(gen_layer(sub_key))
+  return tuple(layers)
+
+
+def gen_data(random_key):
+  return jax.random.uniform(
+      random_key, (BATCH, SEQUENCE_LENGTH, D_MODEL), dtype=jax.numpy.bfloat16
+  )
+
+
+def multiply_layer(in_act, in_layer):
+  Q = (
+      in_act @ in_layer["WQ"]
+  )  # BATCH x SEQUENCE_LENGTH x D_HIDDEN, flops: 2* BATCH * SEQUENCE_LENGTH * D_MODEL * D_HIDDEN
+  K = (
+      in_act @ in_layer["WK"]
+  )  # BATCH x SEQUENCE_LENGTH x D_HIDDEN, flops: 2* BATCH * SEQUENCE_LENGTH * D_MODEL * D_HIDDEN
+  V = (
+      in_act @ in_layer["WV"]
+  )  # BATCH x SEQUENCE_LENGTH x D_HIDDEN, flops: 2* BATCH * SEQUENCE_LENGTH * D_MODEL * D_HIDDEN
+  A = jax.numpy.einsum(
+      "bsd,btd->bst", Q, K
+  )  # BATCH x SEQUENCE_LENGTH x SEQUENCE_LENGTH, flops : 2 * BATCH * SEQUENCE_LENGTH^2 * D_HIDDEN
+  A = jax.nn.relu(A)  # TODO(correct low arithmetic intensity manips)
+  post_attention = (
+      A @ V
+  )  # BATCH x SEQUENCE_LENGTH x D_HIDDEN, flops: 2 * BATCH * SEQUENCE_LENGTH^2 * D_HIDDEN
+
+  right_shape = (
+      post_attention @ in_layer["FF"]
+  )  # BATCH x SEQUENCE_LENGTH x D_MODEL, flops: 2 * BATCH * SEQUENCE_LENGTH * D_HIDDEN * D_MODEL
+  right_shape = jax.nn.relu(
+      right_shape
+  )  # TODO(correct low arithmetic intensity manips)
+  return right_shape + 1 + in_act
+
+
+def multiply_layers(in_act, in_layers):
+  x = in_act
+
+  for i in range(len(in_layers)):
+    x = multiply_layer(x, in_layers[i])
+
+  return x, in_layers
+
+
+def multiply_layers_with_loss(in_act, in_layers):
+  x, _ = multiply_layers(in_act, in_layers)
+  return jax.numpy.sum(x)
+
+
+def calculate_tflops(f, *args, **kwargs):
+  print(
+      "Not calculating TFLOPS since MXLA is enabled -- for now just have a stored value for this test"
+  )
+  return 50
+
+
+multiply_layers_and_grad = jax.value_and_grad(
+    multiply_layers_with_loss, argnums=[1]
+)
+
+
+def training_loop(in_act, in_layers):
+  _, grad_layers = multiply_layers_and_grad(in_act, in_layers)
+  out_layers = jax.tree_map(
+      lambda param, grad: param - 1e-4 * grad, in_layers, grad_layers[0]
+  )
+  return out_layers
+
+
+print(f"finished includes ", flush=True)
+
+
+# pjit NN
+devices = jax.devices()
+try:
+  num_slices = 1 + max([d.slice_index for d in devices])
+except:
+  num_slices = 1
+
+mesh_shape = [num_slices, len(jax.devices()) // num_slices]
+devices_array = np.asarray(jax.devices()).reshape(*mesh_shape)
+print(f"mesh shape {mesh_shape}", flush=True)
+print(f"device layout {devices_array}", flush=True)
+mesh = Mesh(devices_array, ("slices", "tpus"))
+
+
+pjit_func = pjit(
+    training_loop,
+    in_shardings=(PartitionSpec(("slices", "tpus")), PartitionSpec("tpus")),
+    out_shardings=PartitionSpec("tpus"),
+)
+
+pjit_gen_data = pjit(
+    gen_data, in_shardings=None, out_shardings=PartitionSpec(("slices", "tpus"))
+)
+
+pjit_gen_layers = pjit(
+    gen_layers, in_shardings=None, out_shardings=PartitionSpec("tpus")
+)
+
+print("compiles completed")
+
+with Mesh(mesh.devices, mesh.axis_names):
+  key = jax.random.PRNGKey(0)
+  presharded_X = jax.block_until_ready(pjit_gen_data(key))
+  presharded_layers = jax.block_until_ready(pjit_gen_layers(key))
+  TFLOPs = calculate_tflops(training_loop, presharded_X, presharded_layers)
+  with jax.profiler.trace("/tmp/tb12"):
+    time = simple_timeit(
+        lambda: jax.block_until_ready(
+            pjit_func(presharded_X, presharded_layers)
+        )
+    )
+  print(
+      f"time is {time} seconds, TFLOP is {TFLOPs}, memory usage is {memory_bytes/10**9} GB, TFLOP/s is {TFLOPs/time}",
+      flush=True,
+  )
+
+  assert (
+      TFLOPs / time > 275 / 2
+  ), "make sure that we're hitting the performance target, 50% peakflops"

--- a/dags/multipod/legacy_tests/gpt1-like.py
+++ b/dags/multipod/legacy_tests/gpt1-like.py
@@ -1,4 +1,18 @@
 #!/usr/bin/python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import jax
 from jax.experimental.pjit import pjit
 from jax._src.partition_spec import PartitionSpec

--- a/scripts/dag-check.sh
+++ b/scripts/dag-check.sh
@@ -14,5 +14,6 @@
 
 export PYTHONPATH=$PWD
 export XLMLTEST_CONFIGS=$PWD/dags/jsonnet/
+export XLMLTEST_MULTIPOD_LEGACY_TEST_DIR=dags/multipod/legacy_tests
 
-find dags -name '*.py' |  xargs -n 1 -t python
+find dags -name '*.py' -not -path "$XLMLTEST_MULTIPOD_LEGACY_TEST_DIR/*" |  xargs -n 1 -t python

--- a/scripts/local-airflow.sh
+++ b/scripts/local-airflow.sh
@@ -7,6 +7,7 @@ set -xue
 # TODO(wcromar): enable editable installs of `xlml` instead
 export PYTHONPATH=$PWD
 export XLMLTEST_CONFIGS=$PWD/dags/jsonnet
+export XLMLTEST_MULTIPOD_LEGACY_TEST_DIR=$PWD/dags/multipod/legacy_tests
 export XLMLTEST_SSH_EXTERNAL_IPS=1
 export XLMLTEST_LOCAL_AIRFLOW=1
 


### PR DESCRIPTION
# Description

The multipod team is migrating tests from the old XL ML test infrastructure. This change provides two example migrations:
- `gpt1-like` to demonstrate the process to migrate custom test scripts out of the old repository
- `maxtext-decode` to show how to migrate a MaxText end_to_end test.

The test scripts which were hosted in the old repository will be moved into the `dags/multipod/legacy_tests` folder.

These tests will run using XPK, and this change includes some minor related changes:
- Allow up to 20 hours for `wait_for_workload_completion`. Since XPK includes a scheduler through Kueue, we should allow tests to be queued up from Airflow and to run as capacity becomes available in the XPK cluster.
- Immediately terminate `wait_for_workload_completion` without retry if the workload pod fails.

# Tests

Ran the tests locally (process_metrics is broken locally): screen/63JfR5FWFhiuGcE
Ran the tests in a development Composer environment: https://fc137785b6c943a4af82d0671bf0ebe5-dot-us-central1.composer.googleusercontent.com/dags/multipod_legacy_xlml/grid?dag_run_id=manual__2024-03-14T22%3A57%3A06.860898%2B00%3A00&tab=logs&task_id=gpt1-like-stable-2xv4-16.run_model._run_workload

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.