### PR TITLE
Fix a flaky wget issue.

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -141,8 +141,8 @@ local volumes = import 'templates/volumes.libsonnet';
         pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
 
         mkdir pytorch
-        wget https://github.com/pytorch/xla/archive/refs/heads/master.tar.gz -O - | tar xzf -
-        mv xla-master pytorch/xla
+        cd pytorch
+        git clone --depth=1 https://github.com/pytorch/xla.git
 
         %s
 

--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -143,6 +143,7 @@ local volumes = import 'templates/volumes.libsonnet';
         mkdir pytorch
         cd pytorch
         git clone --depth=1 https://github.com/pytorch/xla.git
+        cd -
 
         %s
 

--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -140,8 +140,8 @@ local volumes = import 'templates/volumes.libsonnet';
         pip3 uninstall -y torch torchvision
         pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
 
-        mkdir pytorch
-        git clone --depth=1 https://github.com/pytorch/xla.git pytorch
+        mkdir -p pytorch/xla
+        git clone --depth=1 https://github.com/pytorch/xla.git pytorch/xla
 
         %s
 

--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -141,9 +141,7 @@ local volumes = import 'templates/volumes.libsonnet';
         pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
 
         mkdir pytorch
-        cd pytorch
-        git clone --depth=1 https://github.com/pytorch/xla.git
-        cd -
+        git clone --depth=1 https://github.com/pytorch/xla.git pytorch
 
         %s
 


### PR DESCRIPTION
# Description

In b/329297378 and b/329295948, we have seen an error:
```
[2024-03-11, 14:06:30 UTC] {gke.py:116} INFO - pt-nightly-resnet50-mp-fake-v100-x2x2-9jhn2-1-6x5j8] --2024-03-11 14:06:30--  https://github.com/pytorch/xla/archive/refs/heads/master.tar.gz
[2024-03-11, 14:06:50 UTC] {gke.py:116} INFO - pt-nightly-resnet50-mp-fake-v100-x2x2-9jhn2-1-6x5j8] Resolving github.com (github.com)... failed: Temporary failure in name resolution.
[2024-03-11, 14:06:50 UTC] {gke.py:116} INFO - pt-nightly-resnet50-mp-fake-v100-x2x2-9jhn2-1-6x5j8] wget: unable to resolve host address ‘github.com’
[2024-03-11, 14:06:50 UTC] {gke.py:116} INFO - pt-nightly-resnet50-mp-fake-v100-x2x2-9jhn2-1-6x5j8] gzip: stdin: unexpected end of file
[2024-03-11, 14:06:50 UTC] {gke.py:116} INFO - pt-nightly-resnet50-mp-fake-v100-x2x2-9jhn2-1-6x5j8] tar: Child returned status 1
[2024-03-11, 14:06:50 UTC] {gke.py:116} INFO - pt-nightly-resnet50-mp-fake-v100-x2x2-9jhn2-1-6x5j8] tar: Error is not recoverable: exiting now
```
for 2 days (03/11 and 03/12). We didn't have seen it before and it recovered again on 03/13. I see 2 options:
- using wget: per this [so](https://unix.stackexchange.com/questions/168584/wget-is-unable-to-resolve-host-address-80-of-the-time), we can either retry on the failure of `wget` or do `wget --inet4-only`
- using `git clone` with `--depth 1` so we don't have to download the whole git history, which is the intention of using `wget` previously.

Option2 seems to be more stable, meanwhile not have to download the whole git history.
@will-cromar  please let me know what you think.

# Tests

Triggered the GPU multi-host tests

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** https://screenshot.googleplex.com/8uEm7p4TFjKgW49

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.