### PR TITLE
Add metric collection to maxtext convergence test

### DIFF
--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -36,6 +36,8 @@ def get_gke_config(
     dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    base_output_directory: str = None,
+    metric_aggregation_strategy: metric_config.AggregationStrategy = None,
 ) -> task.TpuXpkTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project_name,
@@ -60,9 +62,22 @@ def get_gke_config(
       docker_image=docker_image,
   )
 
+  job_metric_config = (
+      metric_config.MetricConfig(
+          tensorboard_summary=metric_config.SummaryConfig(
+              file_location=base_output_directory,
+              aggregation_strategy=metric_aggregation_strategy,
+              use_regex_file_location=True,
+          ),
+      )
+      if base_output_directory and metric_aggregation_strategy
+      else None
+  )
+
   return task.TpuXpkTask(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
   )
 
 

--- a/dags/multipod/configs/maxtext_sweep_gce_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gce_config.py
@@ -39,13 +39,20 @@ def get_maxtext_sweep_gce_config(
     network: str = "default",
     subnetwork: str = "default",
     metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
+    dataset_project: str = None,
+    composer_project: str = None,
 ) -> List[task.TpuQueuedResourceTask]:
+  if not dataset_project:
+    dataset_project = project_name
+  if not composer_project:
+    composer_project = project_name
+
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project_name,
       zone=tpu_zone,
       dataset_name=dataset_name,
-      dataset_project=project_name,
-      composer_project=project_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
   )
 
   # Add num_slices as a sweep param

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -37,13 +37,20 @@ def get_maxtext_sweep_gke_config(
     base_set_up_cmds: Iterable[str] = None,
     dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.BENCHMARK_DATASET,
     metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
+    dataset_project: str = None,
+    composer_project: str = None,
 ) -> List[task.TpuXpkTask]:
+  if not dataset_project:
+    dataset_project = project_name
+  if not composer_project:
+    composer_project = project_name
+
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project_name,
       zone=tpu_zone,
       dataset_name=dataset_name,
-      dataset_project=project_name,
-      composer_project=project_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
   )
 
   # Add num_slices as a sweep param

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -63,4 +63,6 @@ with models.DAG(
         run_model_cmds=run_command,
         docker_image=DockerImage.MAXTEXT_JAX_STABLE.value,
         test_owner=test_owner.MATT_D,
-    ).run()
+        base_output_directory=base_output_directory,
+        metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
+    ).run_with_run_name_generation()


### PR DESCRIPTION
# Description

Add metric collection into BigQuery for maxtext convergence test. Will be able to store metrics like final loss.
This PR needs https://github.com/google/maxtext/pull/512 to be submitted first into maxtext to prevent run_name conflicts.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

Ran maxtext_convergence test in local composer env http://shortn/_25kKsnd9y2 and was able to automatically collect metrics into BigQuery http://screen/8nLdcWaZAze5NC2.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.