### PR TITLE
Fix v5litepod CI

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/ci.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/ci.libsonnet
@@ -24,6 +24,7 @@ local tpus = import 'templates/tpus.libsonnet';
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip install expecttest==0.1.6 rich
+        pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
       |||,
     },
   },


### PR DESCRIPTION
# Description

Per the [log](https://46c56b977f2b44158661f1ef150119c7-dot-us-central1.composer.googleusercontent.com/log?dag_id=pytorchxla-nightly&task_id=pt-nightly-ci-func-v5litepod-4-1vm.run_model&execution_date=2024-03-12T14%3A00%3A00%2B00%3A00), the v5litepod CI is failing with error:
```
[2024-03-13, 15:13:27 UTC] {logging_mixin.py:150} WARNING - + python3 test/test_pallas.py
[2024-03-13, 15:13:30 UTC] {logging_mixin.py:150} WARNING - WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1710342810.006137  223407 pjrt_api.cc:100] GetPjrtApi was found for tpu at /home/ml-auto-solutions/.local/lib/python3.10/site-packages/torch_xla/lib/libtpu.so
I0000 00:00:1710342810.006186  223407 pjrt_api.cc:79] PJRT_Api is set for device type tpu
[2024-03-13, 15:13:30 UTC] {logging_mixin.py:150} WARNING - I0000 00:00:1710342810.006190  223407 pjrt_api.cc:146] The PJRT plugin has PJRT API version 0.40. The framework PJRT API version is 0.40.
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - .
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - .
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - .E
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - .
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - .
======================================================================
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - ERROR: test_tpu_custom_call_pallas_extract_add_payload (__main__.PallasTest)
----------------------------------------------------------------------
[2024-03-13, 15:13:47 UTC] {logging_mixin.py:150} WARNING - Traceback (most recent call last):
  File "/home/ml-auto-solutions/pytorch/xla/test/test_pallas.py", line 114, in test_tpu_custom_call_pallas_extract_add_payload
    import jax
ModuleNotFoundError: No module named 'jax'
```
This PR intends to fix this issue.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** I couldn't test the change locally because it fails to provision v5litepod though. Not sure if there is other ways of testing it. cc @will-cromar 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.