### PR TITLE
Migrate MaxText end_to_end to xpk

### DIFF
--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -25,9 +25,13 @@ from xlml.utils import gke
 
 @task
 def generate_workload_id(benchmark_id: str) -> str:
-  """Generate a workload ID."""
+  """Generate a valid workload ID."""
+  import re
   short_id = str(uuid.uuid4())[:8]
-  return f"{benchmark_id}-{short_id}"
+  # Remove all non-alphanumeric characters, and truncate to ensure the result
+  # is less than 40 characters.
+  short_benchmark = re.sub(r'[^a-zA-Z0-9-]+', '', benchmark_id)[:32]
+  return f"{short_benchmark}{short_id}"
 
 
 def _run_workload(

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -54,18 +54,7 @@ def _run_workload(
       "set -xue",
       "git clone https://github.com/google/xpk.git /tmp/xpk",
       "cd /tmp/xpk",
-      (
-          "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg |"
-          " gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg"
-      ),
-      (
-          'echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg]'
-          ' https://packages.cloud.google.com/apt cloud-sdk main" |'
-          " tee -a /etc/apt/sources.list.d/google-cloud-sdk.list"
-      ),
-      "apt-get update && apt-get install -y google-cloud-cli",
-      "apt-get install -y kubectl",
-      "apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin",
+      "gcloud components install kubectl",
       f"gcloud config set project {cluster_project}",
       f"gcloud config set compute/zone {zone}",
       (
@@ -82,12 +71,12 @@ def _run_workload(
 # To support local execution using `scripts/local-airflow.sh`, run using
 # task.docker in local environments. Otherwise, task.kubernetes should be used.
 if "XLMLTEST_LOCAL_AIRFLOW" in os.environ:
-  run_workload = task.docker(_run_workload, image="python:3.10")
+  run_workload = task.docker(_run_workload, image="google/cloud-sdk:alpine")
 else:
   run_workload = task.kubernetes(
       _run_workload,
       namespace="composer-user-workloads",
-      image="python:3.10",
+      image="google/cloud-sdk:alpine",
       config_file="/home/airflow/composer_kube_config",
       kubernetes_conn_id="kubernetes_default",
       container_resources=k8s_models.V1ResourceRequirements(

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -27,10 +27,11 @@ from xlml.utils import gke
 def generate_workload_id(benchmark_id: str) -> str:
   """Generate a valid workload ID."""
   import re
+
   short_id = str(uuid.uuid4())[:8]
   # Remove all non-alphanumeric characters, and truncate to ensure the result
   # is less than 40 characters.
-  short_benchmark = re.sub(r'[^a-zA-Z0-9-]+', '', benchmark_id)[:32]
+  short_benchmark = re.sub(r"[^a-zA-Z0-9-]+", "", benchmark_id)[:32]
   return f"{short_benchmark}{short_id}"
 
 


### PR DESCRIPTION
# Description

Migrate MaxText end_to_end tests to use XPK capacity. It also adds dependencies between the stable and nightly tests and ensures the generated name is valid for XPK workloads.

# Tests

Ran in a cloud composer environment: https://fc137785b6c943a4af82d0671bf0ebe5-dot-us-central1.composer.googleusercontent.com/dags/maxtext_end_to_end/grid

Failures have been addressed in MaxText and will be picked up in tonight's docker image.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.