### PR TITLE
stop running for Sunday and Mondays

### DIFF
--- a/dags/pytorch_xla/pytorchxla_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla_torchbench.py
@@ -21,7 +21,7 @@ from dags.pytorch_xla.configs import pytorchxla_torchbench_config as config
 import dags.vm_resource as resource
 
 # Schudule the job to run everyday at 3:00AM PST (11:00AM UTC).
-SCHEDULED_TIME = "0 11 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 11 * * 2-6" if composer_env.is_prod_env() else None
 
 
 with models.DAG(


### PR DESCRIPTION
# Description

Update to the torchbench schedule. This is no need to run on Sunday/Monday 3:00am PST. We will use the schedule to run other tasks to prevent resource competition.