### PR TITLE
Refactored 2.16 release into a more reusable template

### DIFF
--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -42,7 +42,7 @@ def get_tf_keras_config(
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
-  set_up_cmds = common.install_tf_nightly() + common.set_up_tensorflow_keras()
+  set_up_cmds = common.set_up_keras() + common.install_tf()
   if not is_pjrt and is_pod:
     set_up_cmds += common.set_up_se_nightly()
   keras_test_name = f"tf_keras_api_{test_name}"
@@ -110,9 +110,7 @@ def get_tf_resnet_config(
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
-  set_up_cmds = (
-      common.install_tf_nightly() + common.set_up_google_tensorflow_models()
-  )
+  set_up_cmds = common.set_up_tensorflow_models() + common.install_tf()
   if not is_pjrt and is_pod:
     set_up_cmds += common.set_up_se_nightly()
 
@@ -201,9 +199,7 @@ def get_tf_dlrm_config(
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
-  set_up_cmds = (
-      common.install_tf_nightly() + common.set_up_google_tensorflow_models()
-  )
+  set_up_cmds = common.set_up_tensorflow_models() + common.install_tf()
   if not is_pjrt and is_pod:
     set_up_cmds += common.set_up_se_nightly()
 

--- a/dags/solutions_team/solutionsteam_tf_release_se_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_release_se_supported.py
@@ -18,17 +18,19 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.vm_resource import TpuVersion, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
-from dags.solutions_team.configs.tensorflow import solutionsteam_tf_2_16_supported_config as tf_config
+from dags.solutions_team.configs.tensorflow import solutionsteam_tf_release_supported_config as tf_config
 from dags.solutions_team.configs.tensorflow import common
 
 
 # Release tests only need to run once, they can be run manually as needed
 SCHEDULED_TIME = None
+VERSION = f"{tf_config.MAJOR_VERSION}.{tf_config.MINOR_VERSION}"
+
 
 with models.DAG(
-    dag_id="tf_2_16_se_nightly_supported",
+    dag_id=f"tf_{tf_config.MAJOR_VERSION}_{tf_config.MINOR_VERSION}_se_nightly_supported",
     schedule=SCHEDULED_TIME,
-    tags=["solutions_team", "tf", "se", "2.16", "supported", "xlml"],
+    tags=["solutions_team", "tf", "se", VERSION, "supported", "xlml"],
     start_date=datetime.datetime(2024, 1, 4),
     catchup=False,
 ) as dag:

--- a/dags/solutions_team/solutionsteam_tf_release_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_release_supported.py
@@ -18,18 +18,19 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.vm_resource import TpuVersion, Project, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
-from dags.solutions_team.configs.tensorflow import solutionsteam_tf_2_16_supported_config as tf_config
+from dags.solutions_team.configs.tensorflow import solutionsteam_tf_release_supported_config as tf_config
 from dags.solutions_team.configs.tensorflow import common
 
 
 # Release tests only need to run once, they can be run manually as needed
 SCHEDULED_TIME = None
+VERSION = f"{tf_config.MAJOR_VERSION}.{tf_config.MINOR_VERSION}"
 
 
 with models.DAG(
-    dag_id="tf_2_16_nightly_supported",
+    dag_id=f"tf_{tf_config.MAJOR_VERSION}_{tf_config.MINOR_VERSION}_nightly_supported",
     schedule=SCHEDULED_TIME,
-    tags=["solutions_team", "tf", "2.16", "supported", "xlml"],
+    tags=["solutions_team", "tf", VERSION, "supported", "xlml"],
     start_date=datetime.datetime(2023, 8, 16),
     catchup=False,
 ) as dag:


### PR DESCRIPTION
# Description

Refactors the release DAG to allow for easy swapping of versions for reuse in future releases and renames the modules to be more generic (`...tf_release...` instead of `...tf_2_16...`).

Also changes some typing references (e.g. `list` instead of `typing.List`) to adhere to Python best practices [PEP 585](https://peps.python.org/pep-0585/). This specific change will require python 3.11+ but adding `from __future__ import annotations` can allow python 3.7+. If we still need to support the older versions, I can update this change to include that.

# Tests

Ran 2.16 release PJRT and SE keras tests, both were successful.

**List links for your tests (use go/shortn-gen for any internal link):**
Variety of tests of both nightly and 2.15.1 DAGS as well as from resnet and tf-keras tests:
http://shortn/_2sfrmqsyfr
http://shortn/_v5h49gyH6t
http://shortn/_MNIr72f9Z5
http://shortn/_WBsR2NNTlT
http://shortn/_MbmkG5jqOF
http://shortn/_HVtxmvAvoP
http://shortn/_XneLXMOyTn
Note: nightly tests are failing *but* they're failing for the same reason as they are in the dashboard.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.