### PR TITLE
Generalize gcs location for tests

### DIFF
--- a/dags/gcs_bucket.py
+++ b/dags/gcs_bucket.py
@@ -22,8 +22,4 @@ PAX_DIR = "gs://cloud-tpu-checkpoints/pax"
 MAXTEXT_DIR = "gs://max-datasets-rogue"
 
 # GCS bucket for output
-OUTPUT_DIR = "gs://ml-auto-solutions/output"
-# TODO(ran/piz): remove BENCHMARK_OUTPUT_DIR, XLML_OUTPUT_DIR onces all dag
-# configs get rid of those two dependencies and use relative gcs storage path.
-BENCHMARK_OUTPUT_DIR = f"{OUTPUT_DIR}/benchmark"
-XLML_OUTPUT_DIR = f"{OUTPUT_DIR}/xlml"
+BASE_OUTPUT_DIR = "gs://ml-auto-solutions/output"

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -108,7 +108,7 @@ def get_gke_maxtext_nightly_config(
   current_date = current_time.strftime("%Y-%m-%d")
   current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
   base_output_directory = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
+      f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
   )
   run_name = f"{num_slices}slice-V{tpu_version.value}_{tpu_cores}-maxtext-nightly-{current_datetime}"
 
@@ -173,7 +173,7 @@ def get_gke_gpt3_6b_nightly_config(
   current_date = current_time.strftime("%Y-%m-%d")
   current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
   base_output_directory = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
+      f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
   )
   run_name = f"{num_slices}slice-V{tpu_version.value}_{tpu_cores}-gpt3-6b-nightly-{current_datetime}"
 

--- a/dags/multipod/configs/maxtext_gce_config.py
+++ b/dags/multipod/configs/maxtext_gce_config.py
@@ -50,7 +50,7 @@ def get_maxtext_nightly_config(
   current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
 
   trigger = "automated" if automated_test else "manual"
-  base_output_directory = f"{gcs_bucket.XLML_OUTPUT_DIR}/maxtext/{test_mode.value}/{trigger}/{current_date}"
+  base_output_directory = f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/{test_mode.value}/{trigger}/{current_date}"
 
   run_name = f"{num_slices}slice-V{tpu_version.value}_{tpu_cores}-maxtext-{test_mode.value}-{current_datetime}"
 

--- a/dags/multipod/configs/mxla_collective_config.py
+++ b/dags/multipod/configs/mxla_collective_config.py
@@ -50,7 +50,7 @@ def get_mxla_collective_config(
   current_date = current_time.strftime("%Y-%m-%d")
   current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
 
-  base_output_directory = f"{gcs_bucket.XLML_OUTPUT_DIR}/multipod/mxla/nightly/automated/{current_date}/{num_slices}slice-V{tpu_version.value}_{tpu_cores}-mxla-collective-{bytes_to_transfer}transferBytes-{current_datetime}"
+  base_output_directory = f"{gcs_bucket.BASE_OUTPUT_DIR}/multipod/mxla/nightly/automated/{current_date}/{num_slices}slice-V{tpu_version.value}_{tpu_cores}-mxla-collective-{bytes_to_transfer}transferBytes-{current_datetime}"
 
   test_platform = common.Platform.GCE
   set_up_cmds = common.setup_mxla_collective()

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -37,7 +37,7 @@ with models.DAG(
   current_time = datetime.datetime.now()
   current_date = current_time.strftime("%Y-%m-%d")
   base_output_directory = (
-      f"{gcs_bucket.XLML_OUTPUT_DIR}/maxtext/stable/automated/{current_date}"
+      f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/stable/automated/{current_date}"
   )
   dataset_path = gcs_bucket.MAXTEXT_DIR
 

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -152,7 +152,7 @@ def get_torchbench_tpu_config(
       ),
       "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
-      f"gsutil cp {local_output_location} ${metric_config.SshEnvVars.GCS_OUTPUT.value}",
+      f"gsutil cp {local_output_location} {metric_config.SshEnvVars.GCS_OUTPUT.value}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
@@ -313,7 +313,7 @@ def get_torchbench_gpu_config(
           "sudo docker cp $(sudo docker ps | awk 'NR==2 { print $1 }')"
           f":{local_output_location} ./"
       ),
-      f"gsutil cp metric_report.jsonl ${metric_config.SshEnvVars.GCS_OUTPUT.value}",
+      f"gsutil cp metric_report.jsonl {metric_config.SshEnvVars.GCS_OUTPUT.value}",
   )
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"

--- a/dags/solutions_team/configs/flax/solutionsteam_flax_latest_supported_config.py
+++ b/dags/solutions_team/configs/flax/solutionsteam_flax_latest_supported_config.py
@@ -21,6 +21,7 @@ from dags import gcs_bucket, test_owner
 from dags.solutions_team.configs.flax import common
 from dags.vm_resource import TpuVersion, Project, RuntimeVersion
 from datetime import datetime
+import os
 
 
 PROJECT_NAME = Project.CLOUD_ML_AUTO_SOLUTIONS.value
@@ -176,16 +177,14 @@ def get_flax_vit_conv_config(
   )
 
   set_up_cmds = get_flax_vit_setup_cmds()
-  tf_summary_location = (
-      "/tmp/transformers/vit-imagenette/events.out.tfevents.flax-vit.v2"
-  )
-  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/vit/{RUN_DATE}/events.out.tfevents.flax-vit.v2"
+  file_name = "events.out.tfevents.flax-vit.v2"
+  tf_summary_location = f"/tmp/transformers/vit-imagenette/{file_name}"
   extra_run_cmds = (
       (
           "cp /tmp/transformers/vit-imagenette/events.out.tfevents.*"
           f" {tf_summary_location} || exit 0"
       ),
-      f"gsutil cp {tf_summary_location} {gcs_location} || exit 0",
+      f"gsutil cp {tf_summary_location} {metric_config.SshEnvVars.GCS_OUTPUT.value} || exit 0",
   )
   run_model_cmds = get_flax_vit_run_model_cmds(
       num_train_epochs, extraFlags, extra_run_cmds
@@ -209,9 +208,10 @@ def get_flax_vit_conv_config(
 
   job_metric_config = metric_config.MetricConfig(
       tensorboard_summary=metric_config.SummaryConfig(
-          file_location=gcs_location,
+          file_location=file_name,
           aggregation_strategy=metric_config.AggregationStrategy.LAST,
-      )
+      ),
+      use_runtime_generated_gcs_folder=True,
   )
 
   return task.TpuQueuedResourceTask(
@@ -434,11 +434,11 @@ def get_flax_bart_conv_config(
 
   set_up_cmds = get_flax_bart_setup_cmds()
   work_dir = "/tmp/transformers/bart-base-wiki"
-  tf_summary_location = f"{work_dir}/events.out.tfevents.flax-bart.v2"
-  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bart/{RUN_DATE}/events.out.tfevents.flax-bart.v2"
+  file_name = "events.out.tfevents.flax-bart.v2"
+  tf_summary_location = os.path.join(work_dir, file_name)
   extra_run_cmds = (
       f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
-      f"gsutil cp {tf_summary_location} {gcs_location} || exit 0",
+      f"gsutil cp {tf_summary_location} {metric_config.SshEnvVars.GCS_OUTPUT.value} || exit 0",
   )
   run_model_cmds = get_flax_bart_run_model_cmds(
       num_train_epochs, extraFlags, extra_run_cmds
@@ -460,9 +460,10 @@ def get_flax_bart_conv_config(
 
   job_metric_config = metric_config.MetricConfig(
       tensorboard_summary=metric_config.SummaryConfig(
-          file_location=gcs_location,
+          file_location=file_name,
           aggregation_strategy=metric_config.AggregationStrategy.LAST,
-      )
+      ),
+      use_runtime_generated_gcs_folder=True,
   )
 
   return task.TpuQueuedResourceTask(
@@ -555,11 +556,11 @@ def get_flax_bert_conv_config(
 
   set_up_cmds = get_flax_bert_setup_cmds()
   work_dir = "/tmp/transformers/bert-glue"
-  tf_summary_location = f"{work_dir}/events.out.tfevents.flax-bert.v2"
-  gcs_location = f"{gcs_bucket.XLML_OUTPUT_DIR}/flax/bert/{task_name}/{RUN_DATE}/events.out.tfevents.flax-bert.v2"
+  file_name = "events.out.tfevents.flax-bert.v2"
+  tf_summary_location = os.path.join(work_dir, file_name)
   extra_run_cmds = (
       f"cp {work_dir}/events.out.tfevents.* {tf_summary_location} || exit 0",
-      f"gsutil cp {tf_summary_location} {gcs_location} || exit 0",
+      f"gsutil cp {tf_summary_location} {metric_config.SshEnvVars.GCS_OUTPUT.value} || exit 0",
   )
   run_model_cmds = get_flax_bert_run_model_cmds(
       task_name, num_train_epochs, extraFlags, extra_run_cmds
@@ -581,9 +582,10 @@ def get_flax_bert_conv_config(
 
   job_metric_config = metric_config.MetricConfig(
       tensorboard_summary=metric_config.SummaryConfig(
-          file_location=gcs_location,
+          file_location=file_name,
           aggregation_strategy=metric_config.AggregationStrategy.LAST,
-      )
+      ),
+      use_runtime_generated_gcs_folder=True,
   )
 
   return task.TpuQueuedResourceTask(

--- a/dags/solutions_team/solutionsteam_pax_latest_supported.py
+++ b/dags/solutions_team/solutionsteam_pax_latest_supported.py
@@ -32,7 +32,7 @@ with models.DAG(
     start_date=datetime.datetime(2023, 11, 8),
     catchup=False,
 ) as dag:
-  log_dir_prefix = f"{gcs_bucket.XLML_OUTPUT_DIR}/pax/stable"
+  log_dir_prefix = f"{gcs_bucket.BASE_OUTPUT_DIR}/pax/stable"
 
   # Language model with SPMD
   lmspmd2b_exp_path = "tasks.lm.params.lm_cloud.LmCloudSpmd2BLimitSteps"

--- a/dags/solutions_team/solutionsteam_pax_nightly_supported.py
+++ b/dags/solutions_team/solutionsteam_pax_nightly_supported.py
@@ -32,7 +32,7 @@ with models.DAG(
     start_date=datetime.datetime(2023, 12, 5),
     catchup=False,
 ) as dag:
-  log_dir_prefix = f"{gcs_bucket.XLML_OUTPUT_DIR}/pax/nightly"
+  log_dir_prefix = f"{gcs_bucket.BASE_OUTPUT_DIR}/pax/nightly"
 
   # GPT-3 config with 1B params on c4 dataset with SPMD and Adam
   c4spmd1b_pretraining_exp_path = (

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -38,7 +38,7 @@ class AggregationStrategy(enum.Enum):
 
 
 class SshEnvVars(enum.Enum):
-  GCS_OUTPUT = "GCS_OUTPUT"
+  GCS_OUTPUT = "${GCS_OUTPUT}"
 
 
 @dataclasses.dataclass
@@ -46,7 +46,8 @@ class JSONLinesConfig:
   """This is a class to set up JSON Lines config.
 
   Attributes:
-    file_location: The locatioin of the file in GCS.
+    file_location: The locatioin of the file in GCS. When
+      `use_runtime_generated_gcs_folder` flag is ture, use relative path.
   """
 
   file_location: str
@@ -57,7 +58,8 @@ class SummaryConfig:
   """This is a class to set up TensorBoard summary config.
 
   Attributes:
-    file_location: The locatioin of the file in GCS.
+    file_location: The locatioin of the file in GCS. When
+      `use_runtime_generated_gcs_folder` flag is ture, use relative path.
     aggregation_strategy: The aggregation strategy for metrics.
     include_tag_patterns: The matching patterns of tags that wil be included.
       All tags are included by default.
@@ -80,9 +82,10 @@ class ProfileConfig:
   """This is a class to set up profile config.
 
   Attributes:
-    file_locations: The locatioin of the file in GCS. If JSON_LINES format type
-      is used for metrics and dimensions, please ensure the order of profiles
-      match with test runs in JSON Lines.
+    file_locations: The locatioin of the file in GCS. When
+      `use_runtime_generated_gcs_folder` flag is ture, use relative path.
+      If JSON_LINES format type is used for metrics and dimensions, please
+      ensure the order of profiles match with test runs in JSON Lines.
   """
 
   file_locations: List[str]
@@ -97,11 +100,11 @@ class MetricConfig:
     json_lines: The config for JSON Lines input.
     tensorboard_summary: The config for TensorBoard summary input.
     profile: The config for profile input.
+    use_runtime_generated_gcs_folder: Indicator to use path based on
+      benchmark_id from generate_gcs_folder_location()
   """
 
   json_lines: Optional[JSONLinesConfig] = None
   tensorboard_summary: Optional[SummaryConfig] = None
   profile: Optional[ProfileConfig] = None
-  # TODO (ran/piz): remove the following attribute once all dag configs are set to
-  # use relative gcs path.
   use_runtime_generated_gcs_folder: bool = False

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -78,7 +78,7 @@ class TpuQueuedResourceTask(BaseTask):
           and self.task_metric_config.use_runtime_generated_gcs_folder
       ):
         env_variable = {
-            f"{metric_config.SshEnvVars.GCS_OUTPUT.value}": gcs_location
+            f"{metric_config.SshEnvVars.GCS_OUTPUT.name}": gcs_location
         }
       else:
         env_variable = None
@@ -465,7 +465,7 @@ class GpuCreateResourceTask(BaseTask):
           and self.task_metric_config.use_runtime_generated_gcs_folder
       ):
         env_variable = {
-            f"{metric_config.SshEnvVars.GCS_OUTPUT.value}": gcs_location
+            f"{metric_config.SshEnvVars.GCS_OUTPUT.name}": gcs_location
         }
       else:
         env_variable = None

--- a/xlml/utils/metric_test.py
+++ b/xlml/utils/metric_test.py
@@ -213,7 +213,7 @@ class BenchmarkMetricTest(parameterized.TestCase, absltest.TestCase):
         exclude_tag_patterns=None,
     )
     actual_metrics, actual_metadata = metric.process_tensorboard_summary(
-        base_id, summary_config
+        base_id, summary_config, False, None
     )
 
     uuid = hashlib.sha256(str(base_id + "0").encode("utf-8")).hexdigest()

--- a/xlml/utils/name_format.py
+++ b/xlml/utils/name_format.py
@@ -49,13 +49,12 @@ def generate_tb_file_location(run_name: str, base_output_directory: str) -> str:
 
 @task
 def generate_gcs_folder_location(benchmark_id: str) -> str:
-  """Generates result file location in GCS.
+  """Generates folder location in GCS.
 
   Args:
     benchmark_id: Benchmark id of the test
 
-  Returns:
-    gsc file name with location
+  Returns: GCS folder name with location
   """
   current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-  return f"{gcs_bucket.OUTPUT_DIR}/{benchmark_id}-{current_datetime}/"
+  return f"{gcs_bucket.BASE_OUTPUT_DIR}/{benchmark_id}-{current_datetime}/"


### PR DESCRIPTION
# Description

Currently, we can generate a dedicated gcs folder for each test - [source](https://github.com/GoogleCloudPlatform/ml-auto-solutions/blob/067303ba64a25183ca7b592632c06507a10d1284/xlml/utils/name_format.py#L51), and this task is in provision in GCE track. 

We could have a separate PR to enable this for GKE track (xpk), so:
* we don't need to indicate `use_runtime_generated_gcs_folder` flag & base_output_directory
* all tests results are stored in dedicated folder based on benchmark ID.

Gradually, we want to reduce the gap between XLML functional tests and benchmarking tests. In this PR:
* Fix issue in TensorBoard summary processing
* Consolidate both func and benchmarking outputs into `output` folder
* Update Flax conv tests' GCS folder to use the default one.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
I only tested BERT as both BART and ViT conv tests are failed before post_process step - [link](https://screenshot.googleplex.com/B9LsYZvNsUgC7fZ)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.