### PR TITLE
Adding resiliency to the repo clone command

### DIFF
--- a/dags/solutions_team/configs/tensorflow/common.py
+++ b/dags/solutions_team/configs/tensorflow/common.py
@@ -120,7 +120,8 @@ def set_up_keras(version: Optional[str] = None) -> tuple[str]:
 
   return (
       cmd_install_keras,
-      "export PATH=$PATH:/root/google-cloud-sdk/bin && cd /tmp && sudo gcloud source repos clone tf2-api-tests --project=cloud-ml-auto-solutions",
+      "export PATH=$PATH:/root/google-cloud-sdk/bin && cd /tmp",
+      "gcloud source repos clone tf2-api-tests --project=cloud-ml-auto-solutions || (cd tf2-api-tests && git pull)"
       "cd /tmp/tf2-api-tests && pip install behave matplotlib",
   )
 


### PR DESCRIPTION
# Description

Makes the repo cloning step more resilient in case the repo already exists.

# Tests

I ran a keras test that was failing due to this issue and it is now passing that step.

**List links for your tests (use go/shortn-gen for any internal link):**
http://shortn/_RBZjspOxFM

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.