### PR TITLE
Added maxtext sweep example for AQTP library version compatibility test

### DIFF
--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -1,0 +1,107 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+An example DAG to launch a sweep of MaxText GKE XPK workloads
+sweeping over aqtp version and quantization option on different tpu topologies.
+Used upon library upgrades.
+"""
+
+import datetime
+from airflow import models
+from dags import test_owner
+from dags.vm_resource import TpuVersion, Zone, Project, ClusterName, DockerImage
+from dags.multipod.configs import maxtext_sweep_gke_config
+
+# Set concurrency to number of workers otherwise tasks may time out
+# if there are more concurrent tasks running at a time than number of workers
+with models.DAG(
+    dag_id="maxtext_aqtp_version_sweep_gke_example_dag",
+    schedule=None,
+    tags=["multipod_team", "maxtext"],
+    start_date=datetime.datetime(2024, 1, 10),
+    catchup=False,
+    concurrency=2,
+) as dag:
+  base_output_directory = "gs://maxtext-experiments-multipod"
+
+  sweep_model_configs = {
+      "v5e": [("16b", 256), ("32b", 256), ("64b", 256), ("128b", 256)],
+  }
+
+  shared_task_config = {
+      "test_owner": test_owner.ZHIYU_L,
+      "project_name": Project.TPU_PROD_ENV_MULTIPOD.value,
+      "cluster_name": ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
+      "tpu_zone": Zone.US_WEST4_B.value,
+      "time_out_in_min": 60,
+      "base_output_directory": base_output_directory,
+      "tpu_version": TpuVersion.V5E,
+      "num_slices": [1, 2],
+      "docker_image": DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
+  }
+
+  tests = []
+  for tpu, models in sweep_model_configs.items():
+    for model_size, num_cores in models:
+      run_cmds = [
+          "pip show aqtp",
+          f"bash MaxText/configs/{tpu}/{model_size}.sh EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} PLATFORM=gke",
+      ]
+
+      tests.extend(
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              **shared_task_config,
+              tpu_cores=num_cores,
+              run_name_prefix=f"bf16-{model_size}",
+              base_run_model_cmds=run_cmds,
+              sweep_params={
+                  "M_QUANTIZATION": [
+                      "",
+                  ]
+              },
+          )
+      )
+
+      tests.extend(
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              **shared_task_config,
+              tpu_cores=num_cores,
+              run_name_prefix=f"int8-aqtp061-{model_size}",
+              base_run_model_cmds=["pip install aqtp==0.6.1"] + run_cmds,
+              sweep_params={
+                  "M_QUANTIZATION": [
+                      "int8",
+                  ]
+              },
+          )
+      )
+
+      tests.extend(
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              **shared_task_config,
+              tpu_cores=num_cores,
+              run_name_prefix=f"int8-aqpt062-{model_size}",
+              base_run_model_cmds=["pip install aqtp==0.6.2"] + run_cmds,
+              sweep_params={
+                  "M_QUANTIZATION": [
+                      "int8",
+                  ]
+              },
+          )
+      )
+
+  # Run jobs
+  for test in tests:
+    test.run_with_run_name_generation()

--- a/dags/test_owner.py
+++ b/dags/test_owner.py
@@ -36,6 +36,7 @@ RAYMOND_Z = "Raymond Z."
 MATT_D = "Matt D."
 NINA_C = "Nina C."
 SURBHI_J = "Surbhi J."
+ZHIYU_L = "Zhiyu L."
 
 # MLCompass
 ORTI_B = "Orti B."

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -65,6 +65,8 @@ class Zone(enum.Enum):
   US_EAST1_D = "us-east1-d"
   # reserved v5p in tpu-prod-env-automated
   US_EAST5_A = "us-east5-a"
+  # reserved v5e in tpu-prod-env-multipod
+  US_WEST4_B = "us-west4-b"
 
 
 class MachineVersion(enum.Enum):
@@ -126,6 +128,7 @@ class ClusterName(enum.Enum):
   V5P_8_MULTISLICE_CLUSTER = "v5p-8-bodaborg-us-east5-a"
   V5E_16_MULTISLICE_CLUSTER = "v5e-16-bodaborg"
   V5E_256_MULTISLICE_CLUSTER = "v5e-256-bodaborg"
+  V5E_256_US_WEST_4_MULTISLICE_CLUSTER = "v5e-256-bodaborg-us-west4"
 
   A3_CLUSTER = "maxtext-a3-20n"
 


### PR DESCRIPTION
# Description
As titled, added maxtext sweep example for AQTP library version compatibility test by following the gke sweeping api.
Scripts confirm performance remains consistent across versions. Will trigger this test ad-hoc upon library updates.


# Tests
- [x] [ablation test on AQTP library version bump from `v0.6.1` to `v0.6.2`](https://docs.google.com/spreadsheets/d/1l3QpFZF8ulgaGyJG5cFxhhfZj9jUJScUhJWfWCFla00/edit?resourcekey=0-siaBEVMHZMDMUxJep3QuAw#gid=0)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.