### PR TITLE
Reenable diffuser tests with a new dataset

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/hf-diffusers.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/hf-diffusers.libsonnet
@@ -11,7 +11,8 @@ local tpus = import 'templates/tpus.libsonnet';
       'launch',
       'train_text_to_image.py',
       '--pretrained_model_name_or_path=CompVis/stable-diffusion-v1-4',
-      '--dataset_name=lambdalabs/pokemon-blip-captions',
+      '--dataset_name=huggan/smithsonian_butterflies_subset',
+      "--caption_column=image_url",
       '--use_ema',
       '--resolution=512',
       '--center_crop',
@@ -53,7 +54,7 @@ local tpus = import 'templates/tpus.libsonnet';
         pip install .
 
         cd examples/text_to_image
-        sed '/accelerate/d' requirements.txt > clean_requirements.txt
+        sed '/accelerate>=0.28.0/d' requirements.txt > clean_requirements.txt
         sed '/torchvision/d' requirements.txt > clean_requirements.txt
         sed -i 's/transformers>=.*/transformers>=4.36.2/g' clean_requirements.txt
         pip install -r clean_requirements.txt

--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -160,16 +160,15 @@ def huggingface():
       ),
       US_CENTRAL2_B,
   ).run()
-  # TODO(yeounoh) the dataset is taken down, we need a new SD model with a new dataset.
-  # diffusers_v4_8 = task.TpuQueuedResourceTask(
-  #     test_config.JSonnetTpuVmTest.from_pytorch(
-  #         "pt-nightly-hf-diffusers-func-v4-8-1vm"
-  #     ),
-  #     US_CENTRAL2_B,
-  # ).run()
+  diffusers_v4_8 = task.TpuQueuedResourceTask(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-hf-diffusers-func-v4-8-1vm"
+      ),
+      US_CENTRAL2_B,
+  ).run()
 
   accelerate_v4_8 >> accelerate_v2_8
-  # accelerate_v4_8 >> diffusers_v4_8
+  accelerate_v4_8 >> diffusers_v4_8
 
   task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(

--- a/dags/pytorch_xla/r2_3.py
+++ b/dags/pytorch_xla/r2_3.py
@@ -160,16 +160,15 @@ def huggingface():
       ),
       US_CENTRAL2_B,
   ).run()
-  # TODO(yeounoh) the dataset is taken down, we need a new SD model with a new dataset.
-  # diffusers_v4_8 = task.TpuQueuedResourceTask(
-  #     test_config.JSonnetTpuVmTest.from_pytorch(
-  #         "pt-2-3-hf-diffusers-func-v4-8-1vm"
-  #     ),
-  #     US_CENTRAL2_B,
-  # ).run()
+  diffusers_v4_8 = task.TpuQueuedResourceTask(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-2-3-hf-diffusers-func-v4-8-1vm"
+      ),
+      US_CENTRAL2_B,
+  ).run()
 
   accelerate_v4_8 >> accelerate_v2_8
-  # accelerate_v4_8 >> diffusers_v4_8
+  accelerate_v4_8 >> diffusers_v4_8
 
   task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(


### PR DESCRIPTION
# Description

Reenable diffuser tests with a new dataset

# Tests

https://402f31b802dc42918d8712d630ea643a-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-nightly/grid?root=&dag_run_id=manual__2024-03-25T23%3A14%3A45.175887%2B00%3A00&tab=logs&task_id=pt-nightly-hf-diffusers-func-v4-8-1vm.run_model