### PR TITLE
Propagate XPK exit code to pod phase

### DIFF
--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -70,6 +70,7 @@ def run_workload(
             f" --num-slices={num_slices} --docker-image={docker_image}"
             f" --project={cluster_project} --zone={zone}"
             f" --env {metric_config.SshEnvVars.GCS_OUTPUT.name}={gcs_path}"
+            " --restart-on-user-code-failure"
         ),
     )
     hook = SubprocessHook()


### PR DESCRIPTION
# Description

XPK introduced a change to avoid restarting the pod on usercode failure by default, which implies not propagating failure to the workload pods: https://github.com/google/xpk/pull/99

This has silently suppressed failures in the XL ML test grid, since the pod phase determines the success or failure of workloads (see http://shortn/_mxSv7puPQn)

Since max-restarts is [0](https://github.com/google/xpk/blob/main/xpk.py#L4908) by default, this flag won't actually trigger a rerun.

# Tests

Ran locally, and the tests failed as they should: https://screenshot.googleplex.com/AoCubXY75NCVUa3

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.