### PR TITLE
Adds a DLRM Tensorflow test that runs on a v5p-8

### DIFF
--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -50,14 +50,13 @@ def get_tf_keras_config(
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
-  env_variable = export_env_variable(is_pod, is_pjrt)
+  env_variable = common.export_env_variables(tpu_name, is_pod, is_pjrt)
   skipped_tag = "--tags=-failspod" if is_pod else ""
   run_model_cmds = (
       "sudo chmod -R 777 /tmp/",
       (
           "export PATH=$PATH:/home/ml-auto-solutions/.local/bin &&"
-          f" export TPU_NAME={tpu_name} && {env_variable} &&"
-          " cd /tmp/tf2-api-tests && TF_USE_LEGACY_KERAS=1"
+          f" cd /tmp/tf2-api-tests && {env_variable} &&"
           " behave -e ipynb_checkpoints"
           f" --tags=-fails {skipped_tag} -i {test_feature}"
       ),
@@ -139,16 +138,15 @@ def get_tf_resnet_config(
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
-  env_variable = export_env_variable(is_pod, is_pjrt)
+  env_variable = common.export_env_variables(tpu_name, is_pod, is_pjrt)
   run_model_cmds = (
       "sudo chmod -R 777 /tmp/",
       (
           f"cd /usr/share/tpu/models && {env_variable} &&"
-          " PYTHONPATH='.' TF_USE_LEGACY_KERAS=1"
           " python3 official/vision/train.py"
-          f" --tpu={tpu_name} --experiment=resnet_imagenet"
+          f" --experiment=resnet_imagenet"
           " --mode=train_and_eval --model_dir=/tmp/"
-          " --params_override='%s'" % str(params_override)
+          f" --params_override='{params_override}'"
       ),
   )
 
@@ -199,9 +197,21 @@ def get_tf_dlrm_config(
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
+  # Add default_var to pass DAG check
+  # TODO(ranran): replace Variable.get() to XCOM when it applies
+  test_name = "tf_dlrm_criteo"
+  benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
+  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  is_v5p = tpu_version == TpuVersion.V5P
+  env_variable = common.export_env_variables(
+      tpu_name, is_pod, is_pjrt, is_v5p_sc=is_v5p
+  )
+
   set_up_cmds = common.set_up_tensorflow_models() + common.install_tf()
   if not is_pjrt and is_pod:
     set_up_cmds += common.set_up_se_nightly()
+  if is_v5p:
+    set_up_cmds += common.set_up_dlrm_v5p()
 
   params_override = {
       "runtime": {"distribution_strategy": "tpu"},
@@ -269,19 +279,23 @@ def get_tf_dlrm_config(
       },
   }
 
-  test_name = "tf_dlrm_criteo"
-  benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
-  # Add default_var to pass DAG check
-  # TODO(ranran): replace Variable.get() to XCOM when it applies
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
-  env_variable = export_env_variable(is_pod, is_pjrt)
+  model_dir = "/tmp/"
+  if is_v5p:
+    params_override["trainer"]["pipeline_sparse_and_dense_execution"] = "true"
+    tpu_id = Variable.get(benchmark_id, default_var=None)
+    # TODO (ericlefort): Replace the model_dir with this line when the var is available
+    # model_dir = metric_config.SshEnvVars.GCS_OUTPUT.value + f"/dlrm/v5p/{benchmark_id}"
+    model_dir = f"{gcs_bucket.BASE_OUTPUT_DIR}/{test_owner.Team.SOLUTIONS_TEAM.value}/dlrm/v5p/{benchmark_id}"
+
+  # Clean out the prior checkpoint if it exists
   run_model_cmds = (
       "sudo chmod -R 777 /tmp/",
+      f"gsutil rm {model_dir}/* 2> /dev/null || true" if is_v5p else "echo",
       (
           f"cd /usr/share/tpu/models && {env_variable} &&"
-          " TF_USE_LEGACY_KERAS=1 PYTHONPATH='.' python3 official/recommendation/ranking/train.py"
-          f" --tpu={tpu_name} --model_dir=/tmp/output {extraFlags}"
-          " --params_override='%s'" % str(params_override)
+          " python3 official/recommendation/ranking/train.py"
+          f" --model_dir=/tmp/output {extraFlags}"
+          f" --params_override='{params_override}'"
       ),
   )
 
@@ -307,14 +321,3 @@ def get_tf_dlrm_config(
       tpu_name_env_var=is_pod,
       all_workers=not is_pod,
   )
-
-
-def export_env_variable(is_pod: bool, is_pjrt: bool) -> str:
-  """Export environment variables for training if any."""
-  if is_pod:
-    return "export TPU_LOAD_LIBRARY=0"
-  elif is_pjrt:
-    return "export NEXT_PLUGGABLE_DEVICE_USE_C_API=true && export TF_PLUGGABLE_DEVICE_LIBRARY_PATH=/lib/libtpu.so"
-  else:
-    # dummy command
-    return "echo"

--- a/dags/solutions_team/solutionsteam_tf_release_se_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_release_se_supported.py
@@ -17,7 +17,7 @@
 import datetime
 from airflow import models
 from dags import composer_env
-from dags.vm_resource import TpuVersion, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
+from dags.vm_resource import TpuVersion, Project, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
 from dags.solutions_team.configs.tensorflow import solutionsteam_tf_release_supported_config as tf_config
 from dags.solutions_team.configs.tensorflow import common
 
@@ -100,6 +100,7 @@ with models.DAG(
       is_pjrt=False,
       runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
   ).run()
+
   tf_resnet_v4_32 = tf_config.get_tf_resnet_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
@@ -109,27 +110,30 @@ with models.DAG(
       is_pjrt=False,
       runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
   ).run()
+
   # DLRM
+  embedding_dim = 16
   tf_dlrm_v2_8 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V2,
       tpu_cores=8,
       tpu_zone=Zone.US_CENTRAL1_C.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 16],
-      embedding_dim=16,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=10000,
       extraFlags="--mode=train",
       is_pjrt=False,
       runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
   ).run()
 
+  embedding_dim = 64
   tf_dlrm_v2_32 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V2,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL1_A.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 64],
-      embedding_dim=64,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=256054,
       extraFlags="--mode=train_and_eval",
       is_pod=True,
@@ -137,31 +141,51 @@ with models.DAG(
       runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
   ).run()
 
+  embedding_dim = 64
   tf_dlrm_v4_8 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=8,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 64],
-      embedding_dim=64,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=10000,
       extraFlags="--mode=train",
       is_pjrt=False,
       runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
   ).run()
 
+  embedding_dim = 128
   tf_dlrm_v4_32 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 128],
-      embedding_dim=128,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=256054,
       extraFlags="--mode=train_and_eval",
       is_pod=True,
       is_pjrt=False,
       runtime_version=RuntimeVersion.V2_ALPHA_TPUV5.value,
+  ).run()
+
+  embedding_dim = 32
+  tf_dlrm_v5p_8 = tf_config.get_tf_dlrm_config(
+      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+      tpu_version=TpuVersion.V5P,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST5_A.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
+      train_steps=10000,
+      extraFlags="--mode=train",
+      is_pod=False,
+      is_pjrt=False,
+      network=V5_NETWORKS,
+      subnetwork=V5P_SUBNETWORKS,
+      runtime_version=RuntimeVersion.TPU_VM_TF_V5P_ALPHA.value,
   ).run()
 
   # Test dependencies
@@ -171,3 +195,4 @@ with models.DAG(
   tf_resnet_v4_8 >> tf_resnet_v4_32
   tf_dlrm_v2_8 >> tf_dlrm_v2_32
   tf_dlrm_v4_8 >> tf_dlrm_v4_32
+  tf_dlrm_v5p_8

--- a/dags/solutions_team/solutionsteam_tf_se_nightly_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_se_nightly_supported.py
@@ -17,7 +17,7 @@
 import datetime
 from airflow import models
 from dags import composer_env
-from dags.vm_resource import TpuVersion, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
+from dags.vm_resource import TpuVersion, Project, Zone, RuntimeVersion, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS
 from dags.solutions_team.configs.tensorflow import solutionsteam_tf_nightly_supported_config as tf_config
 from dags.solutions_team.configs.tensorflow import common
 
@@ -107,27 +107,30 @@ with models.DAG(
       is_pjrt=False,
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY_POD.value,
   ).run()
+
   # DLRM
+  embedding_dim = 16
   tf_dlrm_v2_8 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V2,
       tpu_cores=8,
       tpu_zone=Zone.US_CENTRAL1_C.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 16],
-      embedding_dim=16,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=10000,
       extraFlags="--mode=train",
       is_pjrt=False,
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY.value,
   ).run()
 
+  embedding_dim = 64
   tf_dlrm_v2_32 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V2,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL1_A.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 64],
-      embedding_dim=64,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=256054,
       extraFlags="--mode=train_and_eval",
       is_pod=True,
@@ -135,31 +138,51 @@ with models.DAG(
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY_POD.value,
   ).run()
 
+  embedding_dim = 64
   tf_dlrm_v4_8 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=8,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 64],
-      embedding_dim=64,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=10000,
       extraFlags="--mode=train",
       is_pjrt=False,
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY.value,
   ).run()
 
+  embedding_dim = 128
   tf_dlrm_v4_32 = tf_config.get_tf_dlrm_config(
       tpu_version=TpuVersion.V4,
       tpu_cores=32,
       tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
-      bottom_mlp=[512, 256, 128],
-      embedding_dim=128,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
       train_steps=256054,
       extraFlags="--mode=train_and_eval",
       is_pod=True,
       is_pjrt=False,
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY_POD.value,
+  ).run()
+
+  embedding_dim = 32
+  tf_dlrm_v5p_8 = tf_config.get_tf_dlrm_config(
+      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
+      tpu_version=TpuVersion.V5P,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST5_A.value,
+      time_out_in_min=60,
+      bottom_mlp=[512, 256, embedding_dim],
+      embedding_dim=embedding_dim,
+      train_steps=10000,
+      extraFlags="--mode=train",
+      is_pod=False,
+      is_pjrt=False,
+      network=V5_NETWORKS,
+      subnetwork=V5P_SUBNETWORKS,
+      runtime_version=RuntimeVersion.TPU_VM_TF_V5P_ALPHA.value,
   ).run()
 
   # Test dependencies
@@ -169,3 +192,4 @@ with models.DAG(
   tf_resnet_v4_8 >> tf_resnet_v4_32
   tf_dlrm_v2_8 >> tf_dlrm_v2_32
   tf_dlrm_v4_8 >> tf_dlrm_v4_32
+  tf_dlrm_v5p_8

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -109,6 +109,7 @@ class RuntimeVersion(enum.Enum):
   TPU_VM_TF_STABLE_POD_SE = "tpu-vm-tf-2.16.0-pod-se"
   TPU_VM_TF_STABLE_PJRT = "tpu-vm-tf-2.16.0-pjrt"
   TPU_VM_TF_STABLE_POD_PJRT = "tpu-vm-tf-2.16.0-pod-pjrt"
+  TPU_VM_TF_V5P_ALPHA = "tpu-vm-tf-v5p-alpha-sc"
   TPU_UBUNTU2204_BASE = "tpu-ubuntu2204-base"
   TPU_VM_V4_BASE = "tpu-vm-v4-base"
   V2_ALPHA_TPUV5_LITE = "v2-alpha-tpuv5-lite"


### PR DESCRIPTION
# Description

Adds a v5p-8 DLRM test

Also does some other minor housekeeping changes

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**List links for your tests (use go/shortn-gen for any internal link):**
Nightly tests are failing in the same way as they are currently: http://shortn/_NvBaOUspmv http://shortn/_XR5kKdSdKn http://shortn/_fVMe30WNnY
Keras on tf 2.15: http://shortn/_Vgcnd0vVMQ
Keras + Resnet on tf se 2.15: http://shortn/_Nfb9IA09Xs http://shortn/_UsYbrGAtmw
DLRM v5p (second run shows clearing the directory for checkpointing):  http://shortn/_YlWBZUs47B http://shortn/_jn8lFG3GPv

DLRM v5p with the checkpoint path change: http://shortn/_FAJPUle0QF



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.