### PR TITLE
Add 1vm and 2vm llama 7b gpu training

### DIFF
--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -163,7 +163,7 @@ def get_maxtext_end_to_end_gpu_gke_test_config(
       zone=gpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
-  run_model_cmds = (f"bash end_to_end/{test_script}.sh",)
+  run_model_cmds = (f"bash {test_script}.sh",)
 
   job_test_config = test_config.GpuXpkTest(
       test_config.Gpu(

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -163,7 +163,7 @@ def get_maxtext_end_to_end_gpu_gke_test_config(
       zone=gpu_zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
-  run_model_cmds = (f"bash {test_script}.sh",)
+  run_model_cmds = (f"bash {test_script}",)
 
   job_test_config = test_config.GpuXpkTest(
       test_config.Gpu(

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -71,7 +71,7 @@ with models.DAG(
     stable_tpu >> nightly_tpu
 
   for model, (test_script, nnodes) in test_models_gpu.items():
-    stable_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
+    gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         accelerator_type=GpuVersion.XPK_H100,
         gpu_zone=Zone.US_CENTRAL1_C.value,
         time_out_in_min=300,
@@ -82,15 +82,3 @@ with models.DAG(
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
         test_owner=test_owner.NINA_C,
     ).run()
-    nightly_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        accelerator_type=GpuVersion.XPK_H100,
-        gpu_zone=Zone.US_CENTRAL1_C.value,
-        time_out_in_min=300,
-        test_name=f"{test_name_prefix}-nightly-{model}",
-        test_script=test_script,
-        num_slices=nnodes,
-        cluster_name=ClusterName.A3_CLUSTER.value,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_NIGHTLY.value,
-        test_owner=test_owner.NINA_C,
-    ).run()
-    stable_gpu >> nightly_gpu

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -42,9 +42,9 @@ with models.DAG(
   }
 
   test_models_gpu = {
-      "llama2-7b-train-1node": ("MaxText/configs/a3/llama_2_7b/1vm", 1),
-      "llama2-7b-train-2node": ("MaxText/configs/a3/llama_2_7b/2vm", 2),
-      "llama2-7b": ("end_to_end/gpu/a3/test_llama2_7b", 1),
+      "llama2-7b-train-1node": ("MaxText/configs/a3/llama_2_7b/1vm.sh", 1),
+      "llama2-7b-train-2node": ("MaxText/configs/a3/llama_2_7b/2vm.sh", 2),
+      "llama2-7b": ("end_to_end/gpu/a3/test_llama2_7b.sh", 1),
   }
 
   for model, test_script in test_models_tpu.items():


### PR DESCRIPTION
# Description

Add 1vm.sh and 2vm.sh for llama 7b gpu training

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Manually tested on Airflow

**List links for your tests (use go/shortn-gen for any internal link):** ...
https://540cef12d3da42ce97b48a97401b6c83-dot-us-central1.composer.googleusercontent.com/dags/maxtext_end_to_end/grid?dag_run_id=manual__2024-04-12T13%3A32%3A50.088355%2B00%3A00&tab=graph

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.