### PR TITLE
Add HF accelerate to the PATH

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -181,10 +181,13 @@ local volumes = import 'templates/volumes.libsonnet';
         export PATH=~/.local/bin:$PATH
       |||,
       tpuVmExtraSetup: |||
+        if [ -d "$HOME/.local/bin" ] ; then
+          export PATH="$HOME/.local/bin:$PATH"
+        fi
         # Dependency of acceelerate, unfortunately there is no requirements.txt in acceelerate.
         pip install pytest
         git clone https://github.com/huggingface/accelerate.git
-        pip install --user ./accelerate
+        pip install ./accelerate
 
         mkdir -p ~/.cache/huggingface/accelerate/
         cat > ~/.cache/huggingface/accelerate/default_config.yaml << 'HF_CONFIG_EOF'
@@ -204,7 +207,7 @@ local volumes = import 'templates/volumes.libsonnet';
         use_cpu: false
         HF_CONFIG_EOF
 
-        .local/bin/accelerate env
+        accelerate env
       ||| % [config.accelerator.numCores],
     },
   },

--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -184,7 +184,7 @@ local volumes = import 'templates/volumes.libsonnet';
         if [ -d "$HOME/.local/bin" ] ; then
           export PATH="$HOME/.local/bin:$PATH"
         fi
-        # Dependency of acceelerate, unfortunately there is no requirements.txt in acceelerate.
+        # Dependency of accelerate, unfortunately there is no requirements.txt in accelerate.
         pip install pytest
         git clone https://github.com/huggingface/accelerate.git
         pip install ./accelerate

--- a/dags/legacy_test/tests/pytorch/r2.3/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.3/common.libsonnet
@@ -185,10 +185,13 @@ local volumes = import 'templates/volumes.libsonnet';
         export PATH=~/.local/bin:$PATH
       |||,
       tpuVmExtraSetup: |||
-        # Dependency of acceelerate, unfortunately there is no requirements.txt in acceelerate.
+        if [ -d "$HOME/.local/bin" ] ; then
+          export PATH="$HOME/.local/bin:$PATH"
+        fi
+        # Dependency of accelerate, unfortunately there is no requirements.txt in accelerate.
         pip install pytest
         git clone https://github.com/huggingface/accelerate.git
-        pip install --user ./accelerate
+        pip install ./accelerate
 
         mkdir -p ~/.cache/huggingface/accelerate/
         cat > ~/.cache/huggingface/accelerate/default_config.yaml << 'HF_CONFIG_EOF'
@@ -208,7 +211,7 @@ local volumes = import 'templates/volumes.libsonnet';
         use_cpu: false
         HF_CONFIG_EOF
 
-        .local/bin/accelerate env
+        accelerate env
       ||| % [config.accelerator.numCores],
     },
   },


### PR DESCRIPTION
# Description

Currently `accelerate test` fails in the setup phase:
```
[2024-04-16, 08:17:36 PDT] {logging_mixin.py:150} WARNING - + .local/bin/accelerate env
[2024-04-16, 08:17:43 PDT] {logging_mixin.py:150} WARNING - Traceback (most recent call last):
  File "/home/ml-auto-solutions/.local/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 46, in main
    args.func(args)
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/accelerate/commands/env.py", line 67, in env_command
    bash_location = subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
[2024-04-16, 08:17:43 PDT] {logging_mixin.py:150} WARNING - subprocess.CalledProcessError: Command '['which', 'accelerate']' returned non-zero exit status 1.
```
It's likely caused by https://github.com/huggingface/accelerate/pull/2623. As per the pip install warning `WARNING: The scripts py.test and pytest are installed in '/home/ml-auto-solutions/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.`, it fails due to we couldn't find `accelerate` in the PATH.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:**: tested locally

**List links for your tests (use go/shortn-gen for any internal link):** https://screenshot.googleplex.com/9rARTQiCoe92kZP

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.