### PR TITLE
Ignore task group prefix in chained tests

### DIFF
--- a/dags/examples/xpk_example_dag.py
+++ b/dags/examples/xpk_example_dag.py
@@ -64,7 +64,13 @@ with models.DAG(
   test_group_id = "chained_tests"
   gcs_subfolder = f"{test_owner.Team.MULTIPOD.value}/maxtext"
   with TaskGroup(group_id=test_group_id, prefix_group_id=False) as group:
-    shared_gcs_location = name_format.generate_gcs_folder_location(
+    # With prefix_group_id=False, ensure each task
+    # under your chained tests in the same DAG has a unique task id.
+    # For gcs folder generation, the default task id is
+    # `generate_gcs_folder_location`.
+    shared_gcs_location = name_format.generate_gcs_folder_location.override(
+        task_id=f"{test_group_id}_generate_gcs_folder_location"
+    )(
         gcs_subfolder,
         test_group_id,
     )

--- a/dags/examples/xpk_example_dag.py
+++ b/dags/examples/xpk_example_dag.py
@@ -63,7 +63,7 @@ with models.DAG(
   #    "{gcs_bucket.BASE_OUTPUT_DIR}/{gcs_subfolder}/{group_id}-{current_datetime}/"
   test_group_id = "chained_tests"
   gcs_subfolder = f"{test_owner.Team.MULTIPOD.value}/maxtext"
-  with TaskGroup(group_id=test_group_id) as group:
+  with TaskGroup(group_id=test_group_id, prefix_group_id=False) as group:
     shared_gcs_location = name_format.generate_gcs_folder_location(
         gcs_subfolder,
         test_group_id,


### PR DESCRIPTION
# Description

Update example to ignore task group prefix in chained XPK tests to keep metric processing working as expected.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to airflow and test.

**List links for your tests (use go/shortn-gen for any internal link):** ...
Test: [link](https://screenshot.googleplex.com/9fPtR7vr2xWir4g)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.