### PR TITLE
Untie HF accelerate v2 and v4 dependency.

### DIFF
--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -148,7 +148,7 @@ def torchvision():
 
 @task_group(prefix_group_id=False)
 def huggingface():
-  accelerate_v2_8 = task.TpuQueuedResourceTask(
+  task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-nightly-accelerate-smoke-v2-8-1vm", reserved=True
       ),
@@ -167,7 +167,6 @@ def huggingface():
       US_CENTRAL2_B,
   ).run()
 
-  accelerate_v4_8 >> accelerate_v2_8
   accelerate_v4_8 >> diffusers_v4_8
 
   task.TpuQueuedResourceTask(


### PR DESCRIPTION
# Description

Per the nightly runs https://screenshot.googleplex.com/BN7rpqy45tAvfSE, `pt-nightly-accelerate-smoke-v2-8-1vm` failed to run due to `upstream_failed: 3`. The upstream `pt-nightly-accelerate-smoke-v4-8-1vm` failed due to lack of tpu v4 resource. We really need a way to run the HF accelerate test in order to catch regression regardless the TPU VM version (v2/v4). IOW, if we have TPU v2 resource, we should try to run the test on it even if we don't have TPU v4. This PR breaks the dependency of  HF accelerate v2 and v4 dependency so we always try to run the test.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...na

**List links for your tests (use go/shortn-gen for any internal link):** ...na

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.