### PR TITLE
Add SA user role back

### DIFF
--- a/deployment/cloud_composer_template.tf
+++ b/deployment/cloud_composer_template.tf
@@ -51,6 +51,15 @@ resource "google_project_iam_member" "tpu_admin_role" {
   role     = "roles/tpu.admin"
 }
 
+resource "google_project_iam_member" "service_account_user_role" {
+  # need `iam.serviceAccounts.actAs` that SA admin does not have
+  provider = google-beta
+  for_each = local.environment_config_dict
+  project  = var.project_config.project_name
+  member   = format("serviceAccount:%s", google_service_account.custom_service_account[each.key].email)
+  role     = "roles/iam.serviceAccountUser"
+}
+
 resource "google_project_iam_member" "service_account_admin_role" {
   provider = google-beta
   for_each = local.environment_config_dict


### PR DESCRIPTION
# Description

Add SA user role back that has been deleted in this [PR](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/250/files), which causes permission missing in our tests ([link](https://screenshot.googleplex.com/AgNn5eRrEsam3kN))

Amin role is missing `iam.serviceAccounts.actAs` permission.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Manually add the permission, retrigger the test, and verified ([link](https://screenshot.googleplex.com/8Gujdqa4SskN6T9))

**List links for your tests (use go/shortn-gen for any internal link):** ...
Manually add the permission, retrigger the test, and verified


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.