### PR TITLE
Update setup script for Fuji test

### DIFF
--- a/dags/imagegen_devx/configs/project_bite_config.py
+++ b/dags/imagegen_devx/configs/project_bite_config.py
@@ -28,9 +28,9 @@ GCS_SUBFOLDER_PREFIX = test_owner.Team.IMAGEGEN_DEVX.value
 def set_up_axlearn() -> Tuple[str]:
   return (
       common.UPGRADE_PIP,
-      *common.set_up_nightly_jax(),
-      "python -m pip install axlearn",
       "git clone https://github.com/apple/axlearn.git",
+      "python -m pip install ./axlearn",
+      *common.set_up_nightly_jax(),
   )
 
 


### PR DESCRIPTION
# Description

Update setup script to test nightly JAX against AxLearn HEAD

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test

**List links for your tests (use go/shortn-gen for any internal link):** ...

Failed at (probably this is what we want to test, catch, and fix)

```
[2024-04-30, 20:09:01 UTC] {logging_mixin.py:150} WARNING - + cd axlearn
[2024-04-30, 20:09:01 UTC] {logging_mixin.py:150} WARNING - + python -m axlearn.common.launch_trainer_main --module=text.gpt.c4_trainer --config=fuji_test --trainer_dir=gs://ml-auto-solutions/output/imagegen_devx/jax/jax_fuji_test-v4-8-2024-04-30-20-04-11/ --data_dir=gs://axlearn-public/tensorflow_datasets --jax_backend=tpu
[2024-04-30, 20:09:02 UTC] {logging_mixin.py:150} WARNING - jax version=0.4.27.dev20240430+a949ce772
[2024-04-30, 20:09:02 UTC] {logging_mixin.py:150} WARNING - 2024-04-30 20:09:02.403883: E tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:9342] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2024-04-30 20:09:02.403930: E tensorflow/compiler/xla/stream_executor/cuda/cuda_fft.cc:609] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2024-04-30 20:09:02.403960: E tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.cc:1518] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
[2024-04-30, 20:09:04 UTC] {logging_mixin.py:150} WARNING - I0430 20:09:04.421969 140363499071488 distributed.py:90] Starting JAX distributed service on 10.130.0.23:8476
[2024-04-30, 20:09:04 UTC] {logging_mixin.py:150} WARNING - I0430 20:09:04.424763 140363499071488 distributed.py:101] Connecting to JAX distributed service on 10.130.0.23:8476
[2024-04-30, 20:09:04 UTC] {logging_mixin.py:150} WARNING - Traceback (most recent call last):
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/jax/_src/xla_bridge.py", line 886, in backends
[2024-04-30, 20:09:04 UTC] {logging_mixin.py:150} WARNING -     backend = _init_backend(platform)
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/jax/_src/xla_bridge.py", line 977, in _init_backend
    backend = registration.factory()
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/jax/_src/xla_bridge.py", line 164, in tpu_client_timer_callback
    client = xla_client.make_tpu_client(_get_tpu_library_path())
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/jaxlib/xla_client.py", line 207, in make_tpu_client
[2024-04-30, 20:09:04 UTC] {logging_mixin.py:150} WARNING -     return make_tfrt_tpu_c_api_client()
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/jaxlib/xla_client.py", line 128, in make_tfrt_tpu_c_api_client
    initialize_pjrt_plugin('tpu')
  File "/home/ml-auto-solutions/.local/lib/python3.10/site-packages/jaxlib/xla_client.py", line 176, in initialize_pjrt_plugin
    _xla.initialize_pjrt_plugin(plugin_name)
[2024-04-30, 20:09:04 UTC] {logging_mixin.py:150} WARNING - jaxlib.xla_extension.XlaRuntimeError: INVALID_ARGUMENT: Mismatched PJRT plugin PJRT API version (0.49) and framework PJRT API version 0.50).
```




# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.