### PR TITLE
Adds tf-keras-nightly install to hugging_face_transformers setup

### DIFF
--- a/dags/solutions_team/configs/flax/common.py
+++ b/dags/solutions_team/configs/flax/common.py
@@ -21,6 +21,7 @@ INSTALL_LATEST_JAX = (
     "pip install jax[tpu] -f"
     " https://storage.googleapis.com/jax-releases/libtpu_releases.html"
 )
+INSTALL_TF_KERAS = "pip install tf-keras-nightly"
 
 
 def set_up_google_flax() -> Tuple[str]:
@@ -39,6 +40,7 @@ def set_up_hugging_face_transformers() -> Tuple[str]:
   return (
       UPGRADE_PIP,
       INSTALL_LATEST_JAX,
+      INSTALL_TF_KERAS,
       (
           "git clone https://github.com/huggingface/transformers.git"
           " /tmp/transformers"


### PR DESCRIPTION
# Description

Some of the Flax tests are failing due to a missing `tf-keras` install. They require this version instead of the plain `keras` version since they don't yet support Keras 3.

# Tests

Passing run of the `flax_bert_mrpc-v4-8` test which is one of the tests failing for this reason:
http://shortn/_F0jBYiO4H4

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.