### PR TITLE
Adds the reserved flag for Jax pod tests

### DIFF
--- a/dags/solutions_team/solutionsteam_jax_integration.py
+++ b/dags/solutions_team/solutionsteam_jax_integration.py
@@ -49,14 +49,16 @@ with models.DAG(
 
   pod_latest = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
-          "jax-pod-latest-tpu-ubuntu2204-base-func-v2-32-1vm"
+          "jax-pod-latest-tpu-ubuntu2204-base-func-v2-32-1vm",
+          reserved=True,
       ),
       US_CENTRAL1_A,
   ).run()
 
   pod_head = task.TpuQueuedResourceTask(
       test_config.JSonnetTpuVmTest.from_jax(
-          "jax-pod-head-tpu-ubuntu2204-base-func-v2-32-1vm"
+          "jax-pod-head-tpu-ubuntu2204-base-func-v2-32-1vm",
+          reserved=True,
       ),
       US_CENTRAL1_A,
   ).run()


### PR DESCRIPTION
# Description

v2-32 Jax tests are failing due to not being able to acquire capacity. Adding the reserved flags resolves that issue.

# Tests

Ran the two relevant tests which are now passing: http://shortn/_zKfWWCHBri

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.