### PR TITLE
Fix maxtext_checkpointing test script location

### DIFF
--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -55,7 +55,7 @@ with models.DAG(
       cores = accelerator.rsplit("-", maxsplit=1)[-1]
       for slice_num in slices:
         command = (
-            "bash end_to_end/tpu/test_checkpointing.sh"
+            "bash end_to_end/test_checkpointing.sh"
             f" checkpointing-{mode.value}-{slice_num}x-{accelerator}"
             f" {base_output_directory} {dataset_path} true",
         )


### PR DESCRIPTION
# Description

* Fix the script location for maxtext_checkpointing tests: https://github.com/google/maxtext/blob/main/end_to_end/test_checkpointing.sh

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

Tested the changes on local airflow server.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.