### PR TITLE
Add llama2-70b-chat with v5p-8

### DIFF
--- a/dags/inference/configs/maxtext_inference_gce_config.py
+++ b/dags/inference/configs/maxtext_inference_gce_config.py
@@ -73,8 +73,6 @@ def get_maxtext_inference_nightly_config(
   run_model_cmds = (
       # Start virtual environment
       "source .env/bin/activate",
-      # Download dataset
-      "wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json > /dev/null 2>&1",
       ### Benchmark
       "cd maxtext",
       # Configure flags
@@ -112,8 +110,7 @@ def get_maxtext_inference_nightly_config(
       --tokenizer maxtext/assets/{model_configs['tokenizer']} \
       --model {model_configs['model_name']} \
       --num-prompts 1000  \
-      --dataset sharegpt \
-      --dataset-path ~/ShareGPT_V3_unfiltered_cleaned_split.json \
+      --dataset openorca \
       --max-output-length 1024 \
       --request-rate {model_configs['request_rate']} \
       --warmup-first true \

--- a/dags/inference/configs/maxtext_inference_gce_config.py
+++ b/dags/inference/configs/maxtext_inference_gce_config.py
@@ -81,8 +81,8 @@ def get_maxtext_inference_nightly_config(
       f"export UNSCANNED_CKPT_PATH={model_configs['checkpoint']}",
       f"export TOKENIZER_PATH=assets/{model_configs['tokenizer']}",
       "export LOAD_PARAMETERS_PATH=${UNSCANNED_CKPT_PATH}",
-      "export MAX_PREFILL_PREDICT_LENGTH=1024",
-      "export MAX_TARGET_LENGTH=2048",
+      f"export MAX_PREFILL_PREDICT_LENGTH={model_configs['max_prefill_predict_length']}",
+      f"export MAX_TARGET_LENGTH={model_configs['max_target_length']}",
       f"export MODEL_NAME={model_configs['model_name']}",
       f"export ICI_FSDP_PARALLELISM={model_configs['ici_fsdp_parallelism']}",
       f"export ICI_AUTOREGRESSIVE_PARALLELISM={model_configs['ici_autoregressive_parallelism']}",
@@ -106,7 +106,7 @@ def get_maxtext_inference_nightly_config(
         per_device_batch_size=${PER_DEVICE_BATCH_SIZE} > /dev/null 2>&1 &""",
       "cd ..",
       # Give server time to start
-      "sleep 120",
+      f"sleep {model_configs['sleep_time']}",
       # Run benchmark, run eval, save benchmark and eval results, and save predictions to /tmp/request-outputs.json
       f"""python JetStream/benchmarks/benchmark_serving.py \
       --tokenizer maxtext/assets/{model_configs['tokenizer']} \
@@ -115,7 +115,7 @@ def get_maxtext_inference_nightly_config(
       --dataset sharegpt \
       --dataset-path ~/ShareGPT_V3_unfiltered_cleaned_split.json \
       --max-output-length 1024 \
-      --request-rate 5 \
+      --request-rate {model_configs['request_rate']} \
       --warmup-first true \
       --save-result \
       --additional-metadata-metrics-to-save '{json.dumps(additional_metadata_dict)}' \

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -110,8 +110,12 @@ with models.DAG(
           model_configs["ici_autoregressive_parallelism"] = ici_ar
           model_configs["ici_tensor_parallelism"] = ici_tensor
           model_configs["request_rate"] = sweep_model_configs["request_rate"]
-          model_configs["max_target_length"] = sweep_model_configs["max_target_length"]
-          model_configs["max_prefill_predict_length"] = sweep_model_configs["max_prefill_predict_length"]
+          model_configs["max_target_length"] = sweep_model_configs[
+              "max_target_length"
+          ]
+          model_configs["max_prefill_predict_length"] = sweep_model_configs[
+              "max_prefill_predict_length"
+          ]
 
           if tpu_version == TpuVersion.V5E:
             # v5e benchmarks

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -42,7 +42,7 @@ with models.DAG(
           "checkpoint": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/",
           "tokenizer": "tokenizer.llama2",
-          "per_device_batch_sizes": [1, 2, 4],
+          "per_device_batch_sizes": [1, 2, 4, 8, 11, 12],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,
@@ -55,7 +55,7 @@ with models.DAG(
           "checkpoint": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/",
           "tokenizer": "tokenizer.llama2",
-          "per_device_batch_sizes": [12, 16, 20, 24],
+          "per_device_batch_sizes": [1, 2, 4, 5, 6],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,
@@ -65,7 +65,7 @@ with models.DAG(
       "llama2-70b": {
           "sleep_time": 240,
           "tpu_version_cores": [(TpuVersion.V5P, 8)],
-          "per_device_batch_sizes": [2, 4],
+          "per_device_batch_sizes": [12, 16, 20, 24],
           "checkpoint": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/",
           "tokenizer": "tokenizer.llama2",
@@ -81,7 +81,7 @@ with models.DAG(
           "checkpoint": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/",
           "tokenizer": "tokenizer.gemma",
-          "per_device_batch_sizes": [1, 2, 4],
+          "per_device_batch_sizes": [1, 2, 4, 8, 11, 12],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -36,118 +36,123 @@ with models.DAG(
 ) as dag:
   test_name_prefix = "maxtext-inference"
   test_models = {
-      # "llama2-7b": {
-      #     "per_device_batch_sizes": [1, 2, 4],
-      #     "checkpoint": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
-      #     "maxtext_logs": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/",
-      #     "tokenizer": "tokenizer.llama2",
-      #     # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
-      #     "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
-      # },
+      "llama2-7b": {
+          "sleep_time": 120,
+          "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
+          "checkpoint": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "maxtext_logs": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/",
+          "tokenizer": "tokenizer.llama2",
+          "per_device_batch_sizes": [1, 2, 4],
+          # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
+          "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
+          "request_rate": 5,
+          "max_prefill_predict_length": 1024,
+          "max_target_length": 2048,
+      },
       "llama2-13b": {
-          "per_device_batch_sizes": [1, 2],
+          "sleep_time": 120,
+          "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/",
           "tokenizer": "tokenizer.llama2",
+          "per_device_batch_sizes": [1, 2],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
+          "request_rate": 5,
+          "max_prefill_predict_length": 1024,
+          "max_target_length": 2048,
       },
-      # "gemma-7b": {
-      #     "per_device_batch_sizes": [1, 2, 4],
-      #     "checkpoint": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
-      #     "maxtext_logs": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/",
-      #     "tokenizer": "tokenizer.gemma",
-      #     # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
-      #     "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
-      # },
+      "llama2-70b": {
+          "sleep_time": 240,
+          "tpu_version_cores": [(TpuVersion.V5P, 8)],
+          "per_device_batch_sizes": [2, 4],
+          "checkpoint": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "maxtext_logs": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/",
+          "tokenizer": "tokenizer.llama2",
+          # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
+          "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
+          "request_rate": 5,
+          "max_prefill_predict_length": 1024,
+          "max_target_length": 2048,
+      },
+      "gemma-7b": {
+          "sleep_time": 120,
+          "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
+          "checkpoint": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "maxtext_logs": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/",
+          "tokenizer": "tokenizer.gemma",
+          "per_device_batch_sizes": [1, 2, 4],
+          # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
+          "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
+          "request_rate": 5,
+          "max_prefill_predict_length": 1024,
+          "max_target_length": 2048,
+      },
   }
 
   for model, sweep_model_configs in test_models.items():
     # tasks_per_model = []
     for per_device_batch_size in sweep_model_configs["per_device_batch_sizes"]:
       for ici_parallelism in sweep_model_configs["ici_parallelisms"]:
-        # Set per_device_batch_size to a single value, not a list
-        model_configs = {}
-        model_configs["model_name"] = model
-        model_configs["per_device_batch_size"] = per_device_batch_size
-        model_configs["checkpoint"] = sweep_model_configs["checkpoint"]
-        model_configs["maxtext_logs"] = sweep_model_configs["maxtext_logs"]
-        model_configs["tokenizer"] = sweep_model_configs["tokenizer"]
-        ici_fsdp = ici_parallelism[0]
-        ici_ar = ici_parallelism[1]
-        ici_tensor = ici_parallelism[2]
-        model_configs["ici_fsdp_parallelism"] = ici_fsdp
-        model_configs["ici_autoregressive_parallelism"] = ici_ar
-        model_configs["ici_tensor_parallelism"] = ici_tensor
+        for tpu_version, tpu_cores in sweep_model_configs["tpu_version_cores"]:
+          # Set per_device_batch_size to a single value, not a list
+          model_configs = {}
+          model_configs["model_name"] = model
+          model_configs["sleep_time"] = sweep_model_configs["sleep_time"]
+          model_configs["checkpoint"] = sweep_model_configs["checkpoint"]
+          model_configs["maxtext_logs"] = sweep_model_configs["maxtext_logs"]
+          model_configs["tokenizer"] = sweep_model_configs["tokenizer"]
+          model_configs["per_device_batch_size"] = per_device_batch_size
+          ici_fsdp = ici_parallelism[0]
+          ici_ar = ici_parallelism[1]
+          ici_tensor = ici_parallelism[2]
+          model_configs["ici_fsdp_parallelism"] = ici_fsdp
+          model_configs["ici_autoregressive_parallelism"] = ici_ar
+          model_configs["ici_tensor_parallelism"] = ici_tensor
+          model_configs["request_rate"] = sweep_model_configs["request_rate"]
+          model_configs["max_target_length"] = sweep_model_configs["max_target_length"]
+          model_configs["max_prefill_predict_length"] = sweep_model_configs["max_prefill_predict_length"]
 
-        # v5e benchmarks
-        v5e_project_name = Project.TPU_PROD_ENV_AUTOMATED.value
-        v5e_zone = Zone.US_EAST1_C.value
-        v5_network = V5_NETWORKS
-        v5e_subnetwork = V5E_SUBNETWORKS
-        v5e_runtime_version = RuntimeVersion.V2_ALPHA_TPUV5_LITE.value
-        # maxtext_stable_1slice_v5e_8 = maxtext_inference_gce_config.get_maxtext_inference_nightly_config(
-        #     tpu_version=TpuVersion.V5E,
-        #     tpu_cores=8,
-        #     tpu_zone=v5e_zone,
-        #     runtime_version=v5e_runtime_version,
-        #     project_name=v5e_project_name,
-        #     time_out_in_min=60,
-        #     is_tpu_reserved=True,
-        #     test_name=f"{test_name_prefix}-stable-{model}-per_device_batch_size-{per_device_batch_size}-ici-fsdp{ici_fsdp}-ar{ici_ar}-tensor{ici_tensor}",
-        #     test_mode=SetupMode.STABLE,
-        #     network=v5_network,
-        #     subnetwork=v5e_subnetwork,
-        #     model_configs=model_configs,
-        # ).run()
-        # maxtext_nightly_1slice_v5e_8 = maxtext_inference_gce_config.get_maxtext_inference_nightly_config(
-        #     tpu_version=TpuVersion.V5E,
-        #     tpu_cores=8,
-        #     tpu_zone=v5e_zone,
-        #     runtime_version=v5e_runtime_version,
-        #     project_name=v5e_project_name,
-        #     time_out_in_min=60,
-        #     is_tpu_reserved=True,
-        #     test_name=f"{test_name_prefix}-nightly-{model}-per_device_batch_size-{per_device_batch_size}-ici-fsdp{ici_fsdp}-ar{ici_ar}-tensor{ici_tensor}",
-        #     test_mode=SetupMode.NIGHTLY,
-        #     network=v5_network,
-        #     subnetwork=v5e_subnetwork,
-        #     model_configs=model_configs,
-        # ).run()
+          if tpu_version == TpuVersion.V5E:
+            # v5e benchmarks
+            project_name = Project.TPU_PROD_ENV_AUTOMATED.value
+            zone = Zone.US_EAST1_C.value
+            network = V5_NETWORKS
+            subnetwork = V5E_SUBNETWORKS
+            runtime_version = RuntimeVersion.V2_ALPHA_TPUV5_LITE.value
+          elif tpu_version == TpuVersion.V5P:
+            zone = Zone.US_EAST5_A.value
+            runtime_version = RuntimeVersion.V2_ALPHA_TPUV5.value
+            project_name = Project.TPU_PROD_ENV_AUTOMATED.value
+            network = V5_NETWORKS
+            subnetwork = V5P_SUBNETWORKS
 
-        # v5p benchmarks
-        v5p_zone = Zone.US_EAST5_A.value
-        v5p_runtime_version = RuntimeVersion.V2_ALPHA_TPUV5.value
-        v5p_project_name = Project.TPU_PROD_ENV_AUTOMATED.value
-        v5p_subnetwork = V5P_SUBNETWORKS
-        maxtext_stable_1slice_v5p_8 = maxtext_inference_gce_config.get_maxtext_inference_nightly_config(
-            tpu_version=TpuVersion.V5P,
-            tpu_cores=8,
-            tpu_zone=v5p_zone,
-            runtime_version=v5p_runtime_version,
-            project_name=v5p_project_name,
-            time_out_in_min=60,
-            is_tpu_reserved=True,
-            test_name=f"{test_name_prefix}-nightly-{model}-per_device_batch_size-{per_device_batch_size}-ici-fsdp{ici_fsdp}-ar{ici_ar}-tensor{ici_tensor}",
-            test_mode=SetupMode.STABLE,
-            network=v5_network,
-            subnetwork=v5p_subnetwork,
-            model_configs=model_configs,
-        ).run()
-        maxtext_nightly_1slice_v5p_8 = maxtext_inference_gce_config.get_maxtext_inference_nightly_config(
-            tpu_version=TpuVersion.V5P,
-            tpu_cores=8,
-            tpu_zone=v5p_zone,
-            runtime_version=v5p_runtime_version,
-            project_name=v5p_project_name,
-            time_out_in_min=60,
-            is_tpu_reserved=True,
-            test_name=f"{test_name_prefix}-nightly-{model}-per_device_batch_size-{per_device_batch_size}-ici-fsdp{ici_fsdp}-ar{ici_ar}-tensor{ici_tensor}",
-            test_mode=SetupMode.NIGHTLY,
-            network=v5_network,
-            subnetwork=v5p_subnetwork,
-            model_configs=model_configs,
-        ).run()
-
-        # maxtext_stable_1slice_v5e_8 >> maxtext_nightly_1slice_v5e_8
-        maxtext_stable_1slice_v5p_8 >> maxtext_nightly_1slice_v5p_8
+          maxtext_stable_1slice = maxtext_inference_gce_config.get_maxtext_inference_nightly_config(
+              tpu_version=tpu_version,
+              tpu_cores=tpu_cores,
+              tpu_zone=zone,
+              runtime_version=runtime_version,
+              project_name=project_name,
+              time_out_in_min=60,
+              is_tpu_reserved=True,
+              test_name=f"{test_name_prefix}-stable-{model}-per_device_batch_size-{per_device_batch_size}-ici-fsdp{ici_fsdp}-ar{ici_ar}-tensor{ici_tensor}",
+              test_mode=SetupMode.STABLE,
+              network=network,
+              subnetwork=subnetwork,
+              model_configs=model_configs,
+          ).run()
+          maxtext_nightly_1slice = maxtext_inference_gce_config.get_maxtext_inference_nightly_config(
+              tpu_version=tpu_version,
+              tpu_cores=tpu_cores,
+              tpu_zone=zone,
+              runtime_version=runtime_version,
+              project_name=project_name,
+              time_out_in_min=60,
+              is_tpu_reserved=True,
+              test_name=f"{test_name_prefix}-nightly-{model}-per_device_batch_size-{per_device_batch_size}-ici-fsdp{ici_fsdp}-ar{ici_ar}-tensor{ici_tensor}",
+              test_mode=SetupMode.NIGHTLY,
+              network=network,
+              subnetwork=subnetwork,
+              model_configs=model_configs,
+          ).run()
+          maxtext_stable_1slice >> maxtext_nightly_1slice

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -55,7 +55,7 @@ with models.DAG(
           "checkpoint": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/",
           "tokenizer": "tokenizer.llama2",
-          "per_device_batch_sizes": [1, 2],
+          "per_device_batch_sizes": [12, 16, 20, 24],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,


### PR DESCRIPTION
# Description

- Add llama2-70b-chat. MaxText checkpoint created by downloading and converting Meta's PyTorch checkpoint.
- Add v5p-8
- Parameterize a few more variables such as MAX_PREFILL_PREDICT_LENGTH, MAX_TARGET_LENGTH, and sleep time (to wait for JetStream server to start).


# Tests

Ran in my local Composer environment. See dags here http://shortn/_gJ5bBfYLUi

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.