### PR TITLE
Record commit hash of maxtext/jetstream, and parameterize additional info

### DIFF
--- a/dags/inference/configs/maxtext_inference_gce_config.py
+++ b/dags/inference/configs/maxtext_inference_gce_config.py
@@ -65,6 +65,7 @@ def get_maxtext_inference_nightly_config(
   )
 
   additional_metadata_dict = {
+      "model_mode": f"{model_configs['model_mode']}",
       "checkpoint": f"{model_configs['checkpoint']}",
       "scan_layers": f"{model_configs['scan_layers']}",
       "dataset": f"{model_configs['dataset']}",

--- a/dags/inference/configs/maxtext_inference_gce_config.py
+++ b/dags/inference/configs/maxtext_inference_gce_config.py
@@ -55,6 +55,7 @@ def get_maxtext_inference_nightly_config(
       # Create a python virtual environment
       "sudo apt-get -y update",
       "sudo apt-get -y install python3.10-venv",
+      "sudo apt-get -y install jq",
       "python -m venv .env",
       "source .env/bin/activate",
       # Setup MaxText & JetStream
@@ -64,6 +65,12 @@ def get_maxtext_inference_nightly_config(
   )
 
   additional_metadata_dict = {
+      "checkpoint": f"{model_configs['checkpoint']}",
+      "scan_layers": f"{model_configs['scan_layers']}",
+      "dataset": f"{model_configs['dataset']}",
+      "max_prefill_predict_length": f"{model_configs['max_prefill_predict_length']}",
+      "max_target_length": f"{model_configs['max_target_length']}",
+      "max_output_length": f"{model_configs['max_output_length']}",
       "ici_fsdp_parallelism": f"{model_configs['ici_fsdp_parallelism']}",
       "ici_autoregressive_parallelism": f"{model_configs['ici_autoregressive_parallelism']}",
       "ici_tensor_parallelism": f"{model_configs['ici_tensor_parallelism']}",
@@ -74,6 +81,12 @@ def get_maxtext_inference_nightly_config(
   run_model_cmds = (
       # Start virtual environment
       "source .env/bin/activate",
+      # Get commit hash of the maxtext and jetstream repos
+      f"export METADATA_DICT='{json.dumps(additional_metadata_dict)}'",
+      'cd maxtext && export MAXTEXT_COMMIT_HASH=$(git log -1 --format="%H") && cd ..',
+      'cd JetStream && export JETSTREAM_COMMIT_HASH=$(git log -1 --format="%H") && cd ..',
+      'export METADATA_DICT=$(jq -c \'. + { "maxtext_commit_hash": $newVal}\' --arg newVal ${MAXTEXT_COMMIT_HASH} <<<"$METADATA_DICT")',
+      'export METADATA_DICT=$(jq -c \'. + { "jetstream_commit_hash": $newVal}\' --arg newVal ${JETSTREAM_COMMIT_HASH} <<<"$METADATA_DICT")',
       ### Benchmark
       "cd maxtext",
       # Configure flags
@@ -86,7 +99,7 @@ def get_maxtext_inference_nightly_config(
       f"export ICI_FSDP_PARALLELISM={model_configs['ici_fsdp_parallelism']}",
       f"export ICI_AUTOREGRESSIVE_PARALLELISM={model_configs['ici_autoregressive_parallelism']}",
       f"export ICI_TENSOR_PARALLELISM={model_configs['ici_tensor_parallelism']}",
-      "export SCAN_LAYERS=false",
+      f"export SCAN_LAYERS={model_configs['scan_layers']}",
       f"export WEIGHT_DTYPE={model_configs['weight_dtype']}",
       f"export PER_DEVICE_BATCH_SIZE={model_configs['per_device_batch_size']}",
       # Start JetStream MaxText server in the background
@@ -110,13 +123,13 @@ def get_maxtext_inference_nightly_config(
       f"""python JetStream/benchmarks/benchmark_serving.py \
       --tokenizer maxtext/assets/{model_configs['tokenizer']} \
       --model {model_configs['model_name']} \
-      --num-prompts 1000  \
-      --dataset openorca \
-      --max-output-length 1024 \
+      --num-prompts {model_configs['num_prompts']}  \
+      --dataset {model_configs['dataset']} \
+      --max-output-length {model_configs['max_output_length']} \
       --request-rate {model_configs['request_rate']} \
       --warmup-first true \
       --save-result \
-      --additional-metadata-metrics-to-save '{json.dumps(additional_metadata_dict)}' \
+      --additional-metadata-metrics-to-save ${{METADATA_DICT}} \
       --save-request-outputs \
       --run-eval true""",
       'export BENCHMARK_OUTPUT=$(find . -name "*JetStream*" -type f -printf "%T@ %Tc %p\n" | sort -n | head -1 | awk \'NF>1{print $NF}\')',

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -41,28 +41,36 @@ with models.DAG(
           "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/",
+          "scan_layers": "false",
+          "dataset": "openorca",
           "weight_dtype": "bfloat16",
           "tokenizer": "tokenizer.llama2",
           "per_device_batch_sizes": [1, 2, 4, 8, 11, 12],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,
+          "num_prompts": 1000,
           "max_prefill_predict_length": 1024,
           "max_target_length": 2048,
+          "max_output_length": 1024,
       },
       "llama2-13b": {
           "sleep_time": 120,
           "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/",
+          "scan_layers": "false",
+          "dataset": "openorca",
           "weight_dtype": "bfloat16",
           "tokenizer": "tokenizer.llama2",
           "per_device_batch_sizes": [1, 2, 4, 5, 6],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,
+          "num_prompts": 1000,
           "max_prefill_predict_length": 1024,
           "max_target_length": 2048,
+          "max_output_length": 1024,
       },
       "llama2-70b": {
           "sleep_time": 240,
@@ -70,27 +78,35 @@ with models.DAG(
           "per_device_batch_sizes": [12, 16, 20, 24],
           "checkpoint": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/",
+          "scan_layers": "false",
+          "dataset": "openorca",
           "weight_dtype": "bfloat16",
           "tokenizer": "tokenizer.llama2",
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,
+          "num_prompts": 1000,
           "max_prefill_predict_length": 1024,
           "max_target_length": 2048,
+          "max_output_length": 1024,
       },
       "gemma-7b": {
           "sleep_time": 120,
           "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
           "maxtext_logs": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/",
+          "scan_layers": "false",
+          "dataset": "openorca",
           "weight_dtype": "bfloat16",
           "tokenizer": "tokenizer.gemma",
           "per_device_batch_sizes": [1, 2, 4, 8, 11, 12],
           # (ici_fsdp_parallelism, ici_autoregressive_parallelism, ici_tensor_parallelism)
           "ici_parallelisms": [(1, -1, 1), (1, 1, -1)],
           "request_rate": 5,
+          "num_prompts": 1000,
           "max_prefill_predict_length": 1024,
           "max_target_length": 2048,
+          "max_output_length": 1024,
       },
   }
 
@@ -105,6 +121,8 @@ with models.DAG(
           model_configs["sleep_time"] = sweep_model_configs["sleep_time"]
           model_configs["checkpoint"] = sweep_model_configs["checkpoint"]
           model_configs["maxtext_logs"] = sweep_model_configs["maxtext_logs"]
+          model_configs["scan_layers"] = sweep_model_configs["scan_layers"]
+          model_configs["dataset"] = sweep_model_configs["dataset"]
           model_configs["weight_dtype"] = sweep_model_configs["weight_dtype"]
           model_configs["tokenizer"] = sweep_model_configs["tokenizer"]
           model_configs["per_device_batch_size"] = per_device_batch_size
@@ -115,11 +133,15 @@ with models.DAG(
           model_configs["ici_autoregressive_parallelism"] = ici_ar
           model_configs["ici_tensor_parallelism"] = ici_tensor
           model_configs["request_rate"] = sweep_model_configs["request_rate"]
+          model_configs["num_prompts"] = sweep_model_configs["num_prompts"]
           model_configs["max_target_length"] = sweep_model_configs[
               "max_target_length"
           ]
           model_configs["max_prefill_predict_length"] = sweep_model_configs[
               "max_prefill_predict_length"
+          ]
+          model_configs["max_output_length"] = sweep_model_configs[
+              "max_output_length"
           ]
 
           if tpu_version == TpuVersion.V5E:

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -40,6 +40,7 @@ with models.DAG(
           "sleep_time": 120,
           "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "model_mode": "base",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-7b/2024-04-25-14-01/",
           "scan_layers": "false",
           "dataset": "openorca",
@@ -58,6 +59,7 @@ with models.DAG(
           "sleep_time": 120,
           "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "model_mode": "base",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-13b/2024-04-25-14-01/",
           "scan_layers": "false",
           "dataset": "openorca",
@@ -77,6 +79,7 @@ with models.DAG(
           "tpu_version_cores": [(TpuVersion.V5P, 8)],
           "per_device_batch_sizes": [12, 16, 20, 24],
           "checkpoint": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "model_mode": "chat",
           "maxtext_logs": "gs://inference-benchmarks/models/llama2-70b-chat/2024-05-08-23-16/",
           "scan_layers": "false",
           "dataset": "openorca",
@@ -94,6 +97,7 @@ with models.DAG(
           "sleep_time": 120,
           "tpu_version_cores": [(TpuVersion.V5E, 8), (TpuVersion.V5P, 8)],
           "checkpoint": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/param-only-decode-ckpt-maxtext/checkpoints/0/items",
+          "model_mode": "base",
           "maxtext_logs": "gs://inference-benchmarks/models/gemma-7b/2024-04-25-14-01/",
           "scan_layers": "false",
           "dataset": "openorca",
@@ -118,6 +122,7 @@ with models.DAG(
           # Set per_device_batch_size to a single value, not a list
           model_configs = {}
           model_configs["model_name"] = model
+          model_configs["model_mode"] = sweep_model_configs["model_mode"]
           model_configs["sleep_time"] = sweep_model_configs["sleep_time"]
           model_configs["checkpoint"] = sweep_model_configs["checkpoint"]
           model_configs["maxtext_logs"] = sweep_model_configs["maxtext_logs"]


### PR DESCRIPTION
# Description

- Extract the commit hash of the maxtext and jetstream repos 
- Write additional metadata to BigQuery such as: `model_mode`, `maxtext_commit_hash`, `jetstream_commit_hash`, the `checkpoint` path, `scan_layers`, `dataset`, `max_prefill_predict_length`, `max_target_length`, `max_output_length`.
- Parameterize `model_mode`, `num_prompts`, `max_output_length`, `scan_layers`, `dataset` in the config.

# Tests
Tested in my dev env
<img width="796" alt="Screenshot 2024-05-16 at 12 42 38 PM" src="https://github.com/GoogleCloudPlatform/ml-auto-solutions/assets/14128880/072d0c73-9388-41ca-946d-382c5ae78e49">



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.