### PR TITLE
Enable torchbench nightly tests on torch_xla2

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -35,12 +35,11 @@ class VERSION_MAPPING:
 
   class NIGHTLY(enum.Enum):
     TORCH_XLA_TPU_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl"
-    TORCH_XLA_CUDA_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.1/torch_xla-nightly-cp38-cp38-linux_x86_64.whl"
+    TORCH_XLA_CUDA_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.1/torch_xla-nightly-cp310-cp310-linux_x86_64.whl"
     TORCH = "torch"
     TORCHVISION = "torchvision"
     TORCHAUDIO = "torchaudio"
-    # TODO(@piz): update to xla:nightly_3.10_cuda_12.1 once available
-    TORCH_XLA_GPU_DOCKER = "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.8_cuda_12.1"
+    TORCH_XLA_GPU_DOCKER = "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_cuda_12.1"
     TORCH_INDEX_CPU_URL = "https://download.pytorch.org/whl/nightly/cpu"
     TORCH_INDEX_CUDA_URL = "https://download.pytorch.org/whl/nightly/cu121"
     TORCH_REPO_BRANCH = "-b main"
@@ -95,7 +94,10 @@ def get_version_mapping(test_version):
 
 
 def set_up_torchbench_tpu(
-    model_name: str = "", test_version: VERSION = VERSION.NIGHTLY
+    model_name: str = "",
+    test_version: VERSION = VERSION.NIGHTLY,
+    use_startup_script: bool = False,
+    use_xla2: bool = False,
 ) -> Tuple[str]:
   """Common set up for TorchBench."""
 
@@ -114,6 +116,17 @@ def set_up_torchbench_tpu(
     if not model_name or model_name.lower() == "all":
       return f"python install.py --continue_on_fail {pipe_file_cmd}"
     return f"python install.py models {model_name} {pipe_file_cmd}"
+
+  install_torch_xla2_dependency = (
+      (
+          # TODO(piz): torch_xla2 only support nightly test at this time.
+          # "pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html",
+          "cd ~/xla/experimental/torch_xla2/",
+          "pip install -e .[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html",
+      )
+      if use_xla2
+      else ()
+  )
 
   return (
       "pip3 install -U setuptools",
@@ -134,6 +147,7 @@ def set_up_torchbench_tpu(
       f"cd benchmark && {model_install_cmds()}",
       f"cd; git clone {version_mapping.TORCH_REPO_BRANCH.value} https://github.com/pytorch/pytorch.git",
       f"cd; git clone {version_mapping.TORCH_XLA_REPO_BRANCH.value} https://github.com/pytorch/xla.git",
+      *install_torch_xla2_dependency,
   )
 
 
@@ -144,6 +158,7 @@ def get_torchbench_tpu_config(
     tpu_zone: resource.Zone,
     runtime_version: resource.RuntimeVersion,
     time_out_in_min: int,
+    use_xla2: bool = False,
     network: str = "default",
     subnetwork: str = "default",
     test_version: VERSION = VERSION.NIGHTLY,
@@ -156,14 +171,16 @@ def get_torchbench_tpu_config(
       dataset_name=metric_config.DatasetOption.BENCHMARK_DATASET,
   )
 
-  set_up_cmds = set_up_torchbench_tpu(model_name, test_version)
+  set_up_cmds = set_up_torchbench_tpu(
+      model_name, test_version, use_xla2=use_xla2
+  )
   local_output_location = "~/xla/benchmarks/output/metric_report.jsonl"
 
   if not model_name or model_name.lower() == "all":
     run_filter = ""
   else:
     run_filter = f"--filter={model_name}"
-  run_script_cmds = (
+  run_script_cmds_xla1 = (
       "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
       (
           "export PJRT_DEVICE=TPU && cd ~/xla/benchmarks && python experiment_runner.py"
@@ -174,6 +191,19 @@ def get_torchbench_tpu_config(
       "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
       f"gsutil cp {local_output_location} {metric_config.SshEnvVars.GCS_OUTPUT.value}",
   )
+
+  run_script_cmds_xla2 = (
+      "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
+      (
+          "export PJRT_DEVICE=TPU && cd ~/xla/benchmarks && python experiment_runner.py"
+          " --suite-name=torchbench --xla=PJRT --accelerator=tpu --torch-xla2=torch_export"
+          f" --torch-xla2=extract_jax --progress-bar {run_filter}"
+      ),
+      "rm -rf ~/xla/benchmarks/output/metric_report.jsonl",
+      "python ~/xla/benchmarks/result_analyzer.py --output-format=jsonl",
+      f"gsutil cp {local_output_location} {metric_config.SshEnvVars.GCS_OUTPUT.value}",
+  )
+  run_script_cmds = run_script_cmds_xla2 if use_xla2 else run_script_cmds_xla1
 
   test_name = f"torchbench_{model_name}" if model_name else "torchbench_all"
   job_test_config = test_config.TpuVmTest(
@@ -211,6 +241,7 @@ def set_up_torchbench_gpu(
     test_version: VERSION,
     nvidia_driver_version: str = "n/a",
     use_self_docker: bool = True,
+    use_xla2: bool = False,
 ) -> Tuple[str]:
   """Common set up for TorchBench."""
   version_mapping = get_version_mapping(test_version)
@@ -242,6 +273,16 @@ def set_up_torchbench_gpu(
     )
     return nvidia_driver_install
 
+  install_torch_xla2_dependency = (
+      (
+          # TODO(piz): torch_xla2 only support nightly test at this time.
+          "cd /tmp/xla/experimental/torch_xla2/",
+          "pip install -e .[cuda] -f https://storage.googleapis.com/libtpu-releases/index.html",
+      )
+      if use_xla2
+      else ()
+  )
+
   docker_cmds_ls = (
       "apt-get update",
       "apt-get install -y libgl1",
@@ -262,6 +303,7 @@ def set_up_torchbench_gpu(
       "cd /tmp/",
       f"git clone {version_mapping.TORCH_REPO_BRANCH.value} https://github.com/pytorch/pytorch.git",
       f"git clone {version_mapping.TORCH_XLA_REPO_BRANCH.value} https://github.com/pytorch/xla.git",
+      *install_torch_xla2_dependency,
   )
 
   if not use_self_docker:
@@ -296,6 +338,7 @@ def get_torchbench_gpu_config(
     count: int,
     gpu_zone: resource.Zone,
     time_out_in_min: int,
+    use_xla2: bool = False,
     nvidia_driver_version: str = "525.125.06",
     test_version: VERSION = VERSION.NIGHTLY,
     model_name: str = "",
@@ -308,7 +351,11 @@ def get_torchbench_gpu_config(
   )
 
   set_up_cmds = set_up_torchbench_gpu(
-      model_name, test_version, nvidia_driver_version
+      model_name,
+      test_version,
+      nvidia_driver_version=nvidia_driver_version,
+      use_self_docker=True,
+      use_xla2=use_xla2,
   )
   local_output_location = "/tmp/xla/benchmarks/output/metric_report.jsonl"
 
@@ -316,15 +363,26 @@ def get_torchbench_gpu_config(
     run_filter = " "
   else:
     run_filter = f" --filter={model_name}"
-  cmd_list = (
+  cmd_list_xla1 = (
       "export PJRT_DEVICE=CUDA",
       f"export GPU_NUM_DEVICES={count}",
       "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
       "cd /tmp/xla/benchmarks",
-      f"python experiment_runner.py --suite-name=torchbench --accelerator=cuda --progress-bar --xla=PJRT --xla=None {run_filter}",
+      f"python experiment_runner.py --suite-name=torchbench --accelerator=cuda --progress-bar --xla=PJRT {run_filter}",
       "rm -rf /tmp/xla/benchmarks/output/metric_report.jsonl",
       "python /tmp/xla/benchmarks/result_analyzer.py --output-format=jsonl",
   )
+
+  cmd_list_xla2 = (
+      "export PJRT_DEVICE=CUDA",
+      f"export GPU_NUM_DEVICES={count}",
+      "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
+      "cd /tmp/xla/benchmarks",
+      f"python experiment_runner.py --suite-name=torchbench --accelerator=cuda --progress-bar --xla=PJRT --torch-xla2=torch_export --torch-xla2=extract_jax {run_filter}",
+      "rm -rf /tmp/xla/benchmarks/output/metric_report.jsonl",
+      "python /tmp/xla/benchmarks/result_analyzer.py --output-format=jsonl",
+  )
+  cmd_list = cmd_list_xla2 if use_xla2 else cmd_list_xla1
   cmds = "\n".join(cmd_list)
   run_script_cmds = (
       (
@@ -376,6 +434,7 @@ def get_torchbench_gpu_gke_config(
     gpu_zone: resource.Zone,
     time_out_in_min: int,
     count: int = 1,
+    use_xla2: bool = False,
     test_version: VERSION = VERSION.NIGHTLY,
     model_name: str = "",
     extraFlags: str = "",
@@ -397,7 +456,10 @@ def get_torchbench_gpu_gke_config(
     run_filter = f"--filter={model_name}"
 
   setup_script_cmds = set_up_torchbench_gpu(
-      model_name, test_version, use_self_docker=False
+      model_name,
+      test_version,
+      use_self_docker=False,
+      use_xla2=use_xla2,
   )
 
   set_lib_path = (
@@ -414,7 +476,7 @@ def get_torchbench_gpu_gke_config(
       "source /google-cloud-sdk/path.bash.inc",
       "which gsutil",
   )
-  run_script_cmds = (
+  run_script_cmds_xla1 = (
       "export PJRT_DEVICE=CUDA",
       f"export GPU_NUM_DEVICES={count}",
       "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
@@ -424,7 +486,17 @@ def get_torchbench_gpu_gke_config(
       "python /tmp/xla/benchmarks/result_analyzer.py --output-format=jsonl",
       f"gsutil cp {local_output_location} {metric_config.SshEnvVars.GCS_OUTPUT.value}",
   )
-
+  run_script_cmds_xla2 = (
+      "export PJRT_DEVICE=CUDA",
+      f"export GPU_NUM_DEVICES={count}",
+      "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
+      "cd /tmp/xla/benchmarks",
+      f"python experiment_runner.py --suite-name=torchbench --accelerator=cuda --progress-bar --xla=PJRT --torch-xla2=torch_export --torch-xla2=extract_jax {run_filter}",
+      "rm -rf /tmp/xla/benchmarks/output/metric_report.jsonl",
+      "python /tmp/xla/benchmarks/result_analyzer.py --output-format=jsonl",
+      f"gsutil cp {local_output_location} {metric_config.SshEnvVars.GCS_OUTPUT.value}",
+  )
+  run_script_cmds = run_script_cmds_xla2 if use_xla2 else run_script_cmds_xla1
   command_script = ["bash", "-cxue"]
   command_script.append(
       "\n".join(

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -121,8 +121,9 @@ def set_up_torchbench_tpu(
       (
           # TODO(piz): torch_xla2 only support nightly test at this time.
           # "pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html",
+          "pip3 uninstall -y libtpu-nightly jax jaxlib",
           "cd ~/xla/experimental/torch_xla2/",
-          "pip install -e .[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html",
+          "pip3 install --user -e .[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html",
       )
       if use_xla2
       else ()
@@ -276,8 +277,9 @@ def set_up_torchbench_gpu(
   install_torch_xla2_dependency = (
       (
           # TODO(piz): torch_xla2 only support nightly test at this time.
+          "pip3 uninstall -y libtpu-nightly jax jaxlib",  # in case libtpu is installed from torch_xla
           "cd /tmp/xla/experimental/torch_xla2/",
-          "pip install -e .[cuda] -f https://storage.googleapis.com/libtpu-releases/index.html",
+          "pip3 install --user -e .[cuda] -f https://storage.googleapis.com/libtpu-releases/index.html",
       )
       if use_xla2
       else ()

--- a/dags/pytorch_xla/pytorchxla2_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla2_torchbench.py
@@ -1,0 +1,137 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run all TorchBench tests with nightly version."""
+
+from airflow import models
+import datetime
+from dags import composer_env
+from dags.pytorch_xla.configs import pytorchxla_torchbench_config as config
+import dags.vm_resource as resource
+
+# Schudule the job to run everyday at 3:00AM PST (11:00AM UTC).
+SCHEDULED_TIME = "0 11 * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="pytorchxla2-torchbench",
+    schedule=SCHEDULED_TIME,
+    tags=["pytorchxla", "nightly", "torchbench"],
+    start_date=datetime.datetime(2024, 1, 1),
+    catchup=False,
+) as dag:
+  model = "all" if composer_env.is_prod_env() else "Background_Matting"
+  torchbench_extra_flags = [f"--filter={model}"]
+  # Running on V4-8:
+  config.get_torchbench_tpu_config(
+      tpu_version=resource.TpuVersion.V4,
+      tpu_cores=8,
+      project=resource.Project.CLOUD_ML_AUTO_SOLUTIONS,
+      tpu_zone=resource.Zone.US_CENTRAL2_B,
+      runtime_version=resource.RuntimeVersion.TPU_UBUNTU2204_BASE,
+      model_name=model,
+      use_xla2=True,
+      time_out_in_min=1600,
+      extraFlags=" ".join(torchbench_extra_flags),
+  )
+
+  # Running on V5P
+  config.get_torchbench_tpu_config(
+      tpu_version=resource.TpuVersion.V5P,
+      tpu_cores=8,
+      project=resource.Project.TPU_PROD_ENV_AUTOMATED,
+      tpu_zone=resource.Zone.US_EAST5_A,
+      runtime_version=resource.RuntimeVersion.V2_ALPHA_TPUV5,
+      network=resource.V5_NETWORKS,
+      subnetwork=resource.V5P_SUBNETWORKS,
+      time_out_in_min=700,
+      use_xla2=True,
+      model_name=model,
+      extraFlags=" ".join(torchbench_extra_flags),
+  )
+
+  # Running on V5E
+  config.get_torchbench_tpu_config(
+      tpu_version=resource.TpuVersion.V5E,
+      tpu_cores=4,
+      project=resource.Project.TPU_PROD_ENV_AUTOMATED,
+      tpu_zone=resource.Zone.US_EAST1_C,
+      runtime_version=resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE,
+      network=resource.V5_NETWORKS,
+      subnetwork=resource.V5E_SUBNETWORKS,
+      time_out_in_min=1600,
+      use_xla2=True,
+      model_name=model,
+      extraFlags=" ".join(torchbench_extra_flags),
+  )
+
+  # Running on V100 GPU
+  config.get_torchbench_gpu_gke_config(
+      machine_type=resource.MachineVersion.N1_STANDARD_8,
+      image_family=resource.ImageFamily.COMMON_CU121_DEBIAN_11,
+      accelerator_type=resource.GpuVersion.V100,
+      count=1,
+      use_xla2=True,
+      gpu_zone=resource.Region.US_CENTRAL1,
+      model_name=model,
+      time_out_in_min=1600,
+      extraFlags=" ".join(torchbench_extra_flags),
+  )
+
+  # # TODO(piz): switch to GKE for all GPU.
+  # # Running on A100 GPU
+  # config.get_torchbench_gpu_config(
+  #     machine_type=resource.MachineVersion.A2_HIGHGPU_1G,
+  #     image_project=resource.ImageProject.DEEP_LEARNING_PLATFORM_RELEASE,
+  #     image_family=resource.ImageFamily.COMMON_CU121_DEBIAN_11,
+  #     accelerator_type=resource.GpuVersion.A100,
+  #     count=1,
+  #     gpu_zone=resource.Zone.US_CENTRAL1_F,
+  #     nvidia_driver_version="535.86.10",
+  #     model_name=model,
+  #     time_out_in_min=1600,
+  #     use_xla2 = True,
+  #     extraFlags=" ".join(torchbench_extra_flags),
+  # )
+
+  # # Running on H100 GPU
+  # # Note: H100 must use ssd.
+  # config.get_torchbench_gpu_config(
+  #     machine_type=resource.MachineVersion.A3_HIGHGPU_8G,
+  #     image_project=resource.ImageProject.DEEP_LEARNING_PLATFORM_RELEASE,
+  #     image_family=resource.ImageFamily.COMMON_CU121_DEBIAN_11,
+  #     accelerator_type=resource.GpuVersion.H100,
+  #     count=8,
+  #     gpu_zone=resource.Zone.US_CENTRAL1_A,
+  #     nvidia_driver_version="535.86.10",
+  #     model_name=model,
+  #     time_out_in_min=1600,
+  #     use_xla2 = True,
+  #     extraFlags=" ".join(torchbench_extra_flags),
+  # )
+
+  # # Running on L4 GPU
+  # config.get_torchbench_gpu_config(
+  #     machine_type=resource.MachineVersion.G2_STAND_4,
+  #     image_project=resource.ImageProject.DEEP_LEARNING_PLATFORM_RELEASE,
+  #     image_family=resource.ImageFamily.COMMON_CU121_DEBIAN_11,
+  #     accelerator_type=resource.GpuVersion.L4,
+  #     count=1,
+  #     gpu_zone=resource.Zone.US_CENTRAL1_C,
+  #     nvidia_driver_version="535.86.10",
+  #     model_name=model,
+  #     time_out_in_min=1600,
+  #     use_xla2 = True,
+  #     extraFlags=" ".join(torchbench_extra_flags),
+  # )


### PR DESCRIPTION
# Description

Torchbench daily run on torch-xla2.

I comment out tests on majority of GPU platforms to avoid competing resources with other runs.

Note: This PR depends on https://github.com/pytorch/xla/pull/7126/. Wait for that PR to merge before this one.

# Tests

The dags should only impact torch_xla2

https://60bb71acc6784780b3bbdbae4ffa636f-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla2-torchbench/grid

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.