### PR TITLE
Change Hybridsim result file name

### DIFF
--- a/dags/multipod/maxtext_configs_aot_hybridsim.py
+++ b/dags/multipod/maxtext_configs_aot_hybridsim.py
@@ -99,7 +99,7 @@ with models.DAG(
           chip_config = "default" if tpu == TpuVersion.V5E else "megacore"
           hybridsim_cmd = (
               "gsutil cp gs://cloud-hybridsim-prod/run_hybridsim.sh .",
-              f"bash run_hybridsim.sh GCS_XLA_DUMP_PATH=${{GCS_OUTPUT}}xla_dump GCS_OUTPUT_PATH=${{GCS_OUTPUT}}result.txt CHIP_CONFIG={chip_config}",
+              f"bash run_hybridsim.sh GCS_XLA_DUMP_PATH=${{GCS_OUTPUT}}xla_dump GCS_OUTPUT_PATH=${{GCS_OUTPUT}}estimated_cost_ns.jsonl CHIP_CONFIG={chip_config}",
           )
           job_metric_config = metric_config.MetricConfig(
               json_lines=metric_config.JSONLinesConfig(


### PR DESCRIPTION
# Description
While running the Airflow tests for Hybridsim, noticed that `post_process` task checks for data in the result json. This [PR](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/295) changed the name of the result file name that caused the `post_process` task to fail. This PR fixes the name of the result file.

# Tests

Ran local Airflow server and verified the changes

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.