### PR TITLE
update ephermeral storage

### DIFF
--- a/deployment/clusters.tf
+++ b/deployment/clusters.tf
@@ -73,6 +73,9 @@ resource "google_container_node_pool" "nvidia-v100x2" {
         gpu_driver_version = "LATEST"
       }
     }
+    ephemeral_storage_local_ssd_config {
+      local_ssd_count = 2
+    }
   }
 }
 

--- a/deployment/clusters.tf
+++ b/deployment/clusters.tf
@@ -74,7 +74,7 @@ resource "google_container_node_pool" "nvidia-v100x2" {
       }
     }
     ephemeral_storage_local_ssd_config {
-      local_ssd_count = 2
+      local_ssd_count = 1
     }
   }
 }


### PR DESCRIPTION
# Description

Still saw the following error for torchbench:
```
The node was low on resource: ephemeral-storage. Threshold quantity: 10120387530, available: 9702960Ki. Container main was using 26498512Ki, request is 0, has larger consumption of ephemeral-storage. 
```
This is the graph https://screenshot.googleplex.com/5fFijjmWsDrgUCJ. Looks like the connection lost is due to the ephemeral-storage reaching the limit. Everytime it reaches the limit, the job will restart and eventually failed after 3 trials.

Request to increase the ephemeral-storage. After the change, the ephemeral storage is expected to reach 375GB [link](https://cloud.google.com/compute/docs/disks/local-ssd).

# Tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.