### PR TITLE
Remove TF Keras API tests from tf nightly and tf se nightly and only keep Resnet and DLRM tests

### DIFF
--- a/dags/solutions_team/solutionsteam_tf_nightly_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_nightly_supported.py
@@ -33,7 +33,6 @@ with models.DAG(
     start_date=datetime.datetime(2023, 8, 16),
     catchup=False,
 ) as dag:
-
   # ResNet
   tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
       tpu_version=TpuVersion.V2,

--- a/dags/solutions_team/solutionsteam_tf_nightly_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_nightly_supported.py
@@ -33,54 +33,6 @@ with models.DAG(
     start_date=datetime.datetime(2023, 8, 16),
     catchup=False,
 ) as dag:
-  # Keras - tests run in sequence order
-  tf_keras_v2_8 = []
-  for feature, name in common.FEATURE_NAME.items():
-    test = tf_config.get_tf_keras_config(
-        tpu_version=TpuVersion.V2,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL1_C.value,
-        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-        test_feature=feature,
-        test_name=name,
-    )
-    if tf_keras_v2_8:
-      tf_keras_v2_8[-1] >> test
-    tf_keras_v2_8.append(test)
-
-  tf_keras_v5e_4 = []
-  for feature, name in common.FEATURE_NAME.items():
-    test = tf_config.get_tf_keras_config(
-        project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
-        tpu_version=TpuVersion.V5E,
-        tpu_cores=4,
-        tpu_zone=Zone.US_EAST1_C.value,
-        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-        test_feature=feature,
-        test_name=name,
-        network=V5_NETWORKS,
-        subnetwork=V5E_SUBNETWORKS,
-    )
-    if tf_keras_v5e_4:
-      tf_keras_v5e_4[-1] >> test
-    tf_keras_v5e_4.append(test)
-
-  tf_keras_v5p_8 = []
-  for feature, name in common.FEATURE_NAME.items():
-    test = tf_config.get_tf_keras_config(
-        project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
-        tpu_version=TpuVersion.V5P,
-        tpu_cores=8,
-        tpu_zone=Zone.US_EAST5_A.value,
-        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-        test_feature=feature,
-        test_name=name,
-        network=V5_NETWORKS,
-        subnetwork=V5P_SUBNETWORKS,
-    )
-    if tf_keras_v5p_8:
-      tf_keras_v5p_8[-1] >> test
-    tf_keras_v5p_8.append(test)
 
   # ResNet
   tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
@@ -161,9 +113,6 @@ with models.DAG(
   )
 
   # Test dependencies
-  tf_keras_v2_8
-  tf_keras_v5e_4
-  tf_keras_v5p_8
   tf_resnet_v2_8
   tf_resnet_v3_8
   tf_resnet_v4_8 >> tf_resnet_v4_32

--- a/dags/solutions_team/solutionsteam_tf_se_nightly_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_se_nightly_supported.py
@@ -32,7 +32,6 @@ with models.DAG(
     start_date=datetime.datetime(2024, 1, 4),
     catchup=False,
 ) as dag:
-
   # ResNet
   tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
       tpu_version=TpuVersion.V2,
@@ -150,7 +149,6 @@ with models.DAG(
       is_pjrt=False,
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY_POD.value,
   )
-
 
   # Test dependencies
   tf_resnet_v2_8 >> tf_resnet_v2_32

--- a/dags/solutions_team/solutionsteam_tf_se_nightly_supported.py
+++ b/dags/solutions_team/solutionsteam_tf_se_nightly_supported.py
@@ -32,22 +32,6 @@ with models.DAG(
     start_date=datetime.datetime(2024, 1, 4),
     catchup=False,
 ) as dag:
-  # Keras - tests run in sequence order
-  tf_keras_v2_8 = []
-  for feature, name in common.FEATURE_NAME.items():
-    test = tf_config.get_tf_keras_config(
-        tpu_version=TpuVersion.V2,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL1_C.value,
-        time_out_in_min=common.FEATURE_TIMEOUT.get(feature),
-        test_feature=feature,
-        test_name=name,
-        is_pjrt=False,
-        runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY.value,
-    )
-    if tf_keras_v2_8:
-      tf_keras_v2_8[-1] >> test
-    tf_keras_v2_8.append(test)
 
   # ResNet
   tf_resnet_v2_8 = tf_config.get_tf_resnet_config(
@@ -167,29 +151,10 @@ with models.DAG(
       runtime_version=RuntimeVersion.TPU_VM_TF_NIGHTLY_POD.value,
   )
 
-  embedding_dim = 32
-  tf_dlrm_v5p_8 = tf_config.get_tf_dlrm_config(
-      project_name=Project.TPU_PROD_ENV_AUTOMATED.value,
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
-      tpu_zone=Zone.US_EAST5_A.value,
-      time_out_in_min=60,
-      bottom_mlp=[512, 256, embedding_dim],
-      embedding_dim=embedding_dim,
-      train_steps=10000,
-      extraFlags="--mode=train",
-      is_pod=False,
-      is_pjrt=False,
-      network=V5_NETWORKS,
-      subnetwork=V5P_SUBNETWORKS,
-      runtime_version=RuntimeVersion.TPU_VM_TF_V5P_ALPHA.value,
-  )
 
   # Test dependencies
-  tf_keras_v2_8
   tf_resnet_v2_8 >> tf_resnet_v2_32
   tf_resnet_v3_8 >> tf_resnet_v3_32
   tf_resnet_v4_8 >> tf_resnet_v4_32
   tf_dlrm_v2_8 >> tf_dlrm_v2_32
   tf_dlrm_v4_8 >> tf_dlrm_v4_32
-  tf_dlrm_v5p_8


### PR DESCRIPTION
# Description

+ remove tf keras api tests and only keep DLRM and Resnet tests
+ remove DLRM tests on v5p from se

# Tests

<img width="1219" alt="image" src="https://github.com/GoogleCloudPlatform/ml-auto-solutions/assets/3590333/1625d420-a46f-4e45-8a8a-2f1f24e167e3">
<img width="1169" alt="image" src="https://github.com/GoogleCloudPlatform/ml-auto-solutions/assets/3590333/4a301670-d1db-40b8-a2a7-1fa21a8d9e27">

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to Airflow and test
**List links for your tests (use go/shortn-gen for any internal link):** ...
http://shortn/_P5ISh6YZfj
http://shortn/_7GScBOJLxK

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.