### PR TITLE
Extend Mixtral test timeout

### DIFF
--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -184,7 +184,7 @@ with models.DAG(
               "cpu_device_type": CpuVersion.M1_MEGAMEM,
               "cpu_zone": Zone.US_CENTRAL1_B.value,
               "cluster_name": ClusterName.CPU_M1_MEGAMEM_96.value,
-              "time_out_in_min": 180,
+              "time_out_in_min": 240,
           },
           {
               "script_name": "tpu/mixtral/8x7b/2_test_mixtral",


### PR DESCRIPTION
# Description

Extend Mixtral test timeout from 3 hours to 4 hours.
* current run on XL ML is very close to 3 hours, add some buffer period to test. 

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...
N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.