### PR TITLE
Add gpt3 175B to nightly v5e perf tests

### DIFF
--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -36,7 +36,7 @@ with models.DAG(
 ) as dag:
   # MaxText set up
   quantization_sweep = {"M_QUANTIZATION": ["", "int8"]}
-  model_configs = ["16b", "32b", "64b", "128b"]
+  model_configs = ["16b", "32b", "64b", "128b", "gpt3_175b"]
   docker_images = [
       (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),


### PR DESCRIPTION
# Description

Adding GPT-3 175B model to nightly v5e perf tests. https://github.com/google/maxtext/pull/687 should be merged into maxtext before this PR is merged.

# Tests

Ran in local composer env: https://screenshot.googleplex.com/BpfRWutGq2YCgsF

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.