### PR TITLE
Update hf-diffusers.libsonnet to require Pillow >= 9.4.0

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/hf-diffusers.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/hf-diffusers.libsonnet
@@ -57,6 +57,7 @@ local tpus = import 'templates/tpus.libsonnet';
         sed '/accelerate>=0.28.0/d' requirements.txt > clean_requirements.txt
         sed '/torchvision/d' requirements.txt > clean_requirements.txt
         sed -i 's/transformers>=.*/transformers>=4.36.2/g' clean_requirements.txt
+        echo "Pillow>=9.4.0" >> clean_requirements.txt
         pip install -r clean_requirements.txt
 
         # Skip saving the pretrained model, which contains invalid tensor storage


### PR DESCRIPTION


# Description

Please include a summary of relevant context/issue and your changes.
This is to fix failing Pytorch/XLA diffusers tests. One of the dependencies requires the version of pillow to be greater than 9.4.0 https://github.com/huggingface/datasets/pull/6883/files but we will have to wait for a new release of the dependency for a new version to be released. Temporarily fixing this by adding this line

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.