### PR TITLE
fix torchxla2 GPU failure

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -493,6 +493,7 @@ def get_torchbench_gpu_gke_config(
   )
   run_script_cmds_xla2 = (
       "export PJRT_DEVICE=CUDA",
+      "export JAX_PLATFORMS=CUDA",
       f"export GPU_NUM_DEVICES={count}",
       "export HUGGING_FACE_HUB_TOKEN=hf_AbCdEfGhIjKlMnOpQ",  # Use a fake token to bypass torchbench hf init.
       "cd /tmp/xla/benchmarks",


### PR DESCRIPTION
# Description

Torch_xla2 GPU run need to set JAX_PLATFORMS=CUDA.

# Tests

https://60bb71acc6784780b3bbdbae4ffa636f-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla2-torchbench/grid?dag_run_id=manual__2024-06-18T19%3A58%3A37.252342%2B00%3A00&task_id=torchbench-background-matting-nvidia-h100-80gb.run_model.stream_logs&tab=logs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.