### PR TITLE
Increase number of dependencies in v5e maxtext perf tests

### DIFF
--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -75,11 +75,10 @@ with models.DAG(
           sweep_params=quantization_sweep,
       )
 
-      num_tests = len(maxtext_sweep_gke_test)
-      for i in range(num_tests // 2):
-        (
-            maxtext_sweep_gke_test[i].run_with_run_name_generation()
-            >> maxtext_sweep_gke_test[
-                num_tests - 1 - i
-            ].run_with_run_name_generation()
-        )
+      chain_num = 4
+      prev = maxtext_sweep_gke_test[0].run_with_run_name_generation()
+      for i in range(1, len(maxtext_sweep_gke_test)):
+        curr = maxtext_sweep_gke_test[i].run_with_run_name_generation()
+        if i % chain_num != 0:
+          prev >> curr
+        prev = curr


### PR DESCRIPTION

# Description

Increase number of dependencies in v5e maxtext perf tests due to workload start timeouts.

DAG dependencies now look like this https://screenshot.googleplex.com/7TfW2uPwC3xo9Rn

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.