### PR TITLE
Return empty string if gcs file location not found

### DIFF
--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -266,6 +266,8 @@ def process_tensorboard_summary(
 
   if summary_config.use_regex_file_location:
     file_location = get_gcs_file_location_with_regex(file_location)
+    if file_location == "":
+      return [[]], [[]]
 
   aggregation_strategy = summary_config.aggregation_strategy
   include_tag_patterns = summary_config.include_tag_patterns
@@ -330,9 +332,8 @@ def get_gcs_file_location_with_regex(file_location: str) -> str:
         f"{next(filter(file_path_regex.match, all_blobs_names))}"
     )
   except StopIteration:
-    raise AirflowFailException(
-        f"No objects matched supplied regex: {file_location}"
-    )
+    logging.warning(f"No objects matched supplied regex: {file_location}")
+    return ""
 
 
 # TODO(qinwen): implement profile metrics & upload to Vertex AI TensorBoard


### PR DESCRIPTION
# Description

Return empty string if tensorboard file is not found in GCS. Before, an `AirflowFailException` was raised if the tensorboard file was missing causing the `post_process` task to fail. If the `post_process` task fails, any dependent tests will also fail. The tensorboard file usually goes missing when running the model fails and no tensorboard file is generated. In this case, the `post_process` task should still succeed and upload the pass/fail test status to bigquery. 

# Tests

Tested in local Composer env that post_process task still continues when tensorboard file in GCS is not found http://shortn/_3KUXYpZGGk

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.