### PR TITLE
Remove moe_matmul parameter in JetStream+Maxtext benchmarks

### DIFF
--- a/dags/inference/configs/jetstream_benchmark_serving_gce_config.py
+++ b/dags/inference/configs/jetstream_benchmark_serving_gce_config.py
@@ -141,7 +141,6 @@ def get_config(
       f"export COMPUTE_AXIS_ORDER={model_configs['compute_axis_order']}",
       f"export RESHAPE_Q={model_configs['reshape_q']}",
       f"export KV_QUANT_AXIS={model_configs['kv_quant_axis']}",
-      f"export MOE_MATMUL={model_configs['moe_matmul']}",
       # Start JetStream MaxText server in the background
       """python MaxText/maxengine_server.py \
         MaxText/configs/inference_jetstream.yml \
@@ -168,8 +167,7 @@ def get_config(
         ar_cache_axis_order=${AR_CACHE_AXIS_ORDER} \
         compute_axis_order=${COMPUTE_AXIS_ORDER} \
         reshape_q=${RESHAPE_Q} \
-        kv_quant_axis=${KV_QUANT_AXIS} \
-        moe_matmul=${MOE_MATMUL} &""",
+        kv_quant_axis=${KV_QUANT_AXIS} &""",
       "cd ..",
       # Give server time to start
       f"sleep {model_configs['sleep_time']}",

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -262,8 +262,6 @@ with models.DAG(
           "num_prompts": 1000,
           "max_output_length": 1024,
           "warmup_mode": "full",
-          # Only used for MoE models
-          "moe_matmul": "true",
       },
       f"{MIXTRAL_8_7B}-{W_BF16_KV_BF16}-dot-product": {
           "attention": "dot_product",

--- a/dags/inference/maxtext_model_config_generator.py
+++ b/dags/inference/maxtext_model_config_generator.py
@@ -84,7 +84,6 @@ def generate_model_configs(
   model_configs["max_output_length"] = sweep_model_configs["max_output_length"]
   model_configs["warmup_mode"] = sweep_model_configs["warmup_mode"]
   model_configs["run_eval"] = sweep_model_configs["run_eval"]
-  model_configs["moe_matmul"] = sweep_model_configs.get("moe_matmul", "false")
 
   per_device_batch_size = model_configs["per_device_batch_size"]
   attention = model_configs["attention"][:3]


### PR DESCRIPTION
# Description

Recent MaxText changes https://github.com/google/maxtext/pull/741 are causing failures. Removed `moe_matmul` to fix the failures.

# Tests

<img width="1021" alt="Screenshot 2024-07-10 at 2 14 11 PM" src="https://github.com/GoogleCloudPlatform/ml-auto-solutions/assets/14128880/ea40dd2a-68a3-497b-ab19-c5dec17f0b70">


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.