### PR TITLE
Fix permissions for PT/XLA llama tests

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/llama2-model.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/llama2-model.libsonnet
@@ -41,7 +41,7 @@ local utils = import 'templates/utils.libsonnet';
     tpuSettings+: {
       tpuVmExtraSetup: |||
         # install tokenizer model
-        wget https://storage.googleapis.com/tpu-pytorch/lsiyuan-experiment/llama/spiece.model
+        gsutil cp gs://tpu-pytorch/lsiyuan-experiment/llama/spiece.model .
 
         # git clone and build llama
         git clone --branch llama2-google-next-inference https://github.com/pytorch-tpu/llama.git
@@ -109,7 +109,7 @@ local utils = import 'templates/utils.libsonnet';
       |||,
       tpuVmExtraSetup: |||
         # install tokenizer model
-        wget https://storage.googleapis.com/tpu-pytorch/lsiyuan-experiment/llama/spiece.model
+        gsutil cp gs://tpu-pytorch/lsiyuain-experiment/llama/spiece.model .
 
         # git clone and build transformers ### llama/transformers/
         git clone -b llama2-google-next-training https://github.com/pytorch-tpu/transformers.git
@@ -125,7 +125,7 @@ local utils = import 'templates/utils.libsonnet';
         # 7B config
         mkdir 7B
         cd 7B/
-        wget https://storage.googleapis.com/manfei_public_experimental/2B.json
+        gsutil cp gs://manfei_public_experimental/2B.json .
       |||,
     },
   },


### PR DESCRIPTION
# Description

This test relies on buckets that are no longer public. Granted read permissions to test SA and use `gsutil` to authenticate request.

# Tests

![image](https://github.com/user-attachments/assets/1b425baa-b498-4f97-a6c5-a09999b665cd)