### PR TITLE
Modified DAGs to consume jax-stable-stack docker image

### DIFF
--- a/dags/imagegen_devx/configs/jax_ss_config.py
+++ b/dags/imagegen_devx/configs/jax_ss_config.py
@@ -52,7 +52,7 @@ def get_current_datetime() -> str:
   return current_datetime
 
 
-def get_gke_jax_ss_config(
+def get_gke_jax_stable_stack_config(
     tpu_version: TpuVersion,
     tpu_cores: int,
     tpu_zone: str,

--- a/dags/imagegen_devx/jax_stable_stack_e2e.py
+++ b/dags/imagegen_devx/jax_stable_stack_e2e.py
@@ -27,9 +27,9 @@ SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(
-    dag_id="jax_ss_e2e",
+    dag_id="jax_stable_stack_e2e",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "jax-ss"],
+    tags=["multipod_team", "maxtext", "jax-stable-stack"],
     start_date=datetime.datetime(2024, 6, 7),
     catchup=False,
 ) as dag:
@@ -46,7 +46,7 @@ with models.DAG(
   for accelerator, slices in maxtext_test_configs.items():
     cores = accelerator.rsplit("-", maxsplit=1)[-1]
     for slice_num in slices:
-      maxtext_jax_ss_test = config.get_gke_jax_ss_config(
+      maxtext_jax_ss_test = config.get_gke_jax_stable_stack_config(
           tpu_version=config.tpu_versions[accelerator],
           tpu_cores=cores,
           num_slices=slice_num,
@@ -55,21 +55,21 @@ with models.DAG(
           project_name=config.project_names[accelerator].value,
           time_out_in_min=60,
           run_model_cmds=(
-              f"python MaxText/train.py MaxText/configs/base.yml run_name={slice_num}slice-V{config.tpu_versions[accelerator]}_{cores}-maxtext-jax-ss-{current_datetime} "
+              f"python MaxText/train.py MaxText/configs/base.yml run_name={slice_num}slice-V{config.tpu_versions[accelerator]}_{cores}-maxtext-jax-stable-stack-{current_datetime} "
               "steps=30 per_device_batch_size=1 max_target_length=4096 model_name=llama2-7b "
               "enable_checkpointing=false attention=dot_product remat_policy=minimal_flash use_iota_embed=true scan_layers=false "
               "dataset_type=synthetic async_checkpointing=false "
               f"base_output_directory={gcs_bucket.BASE_OUTPUT_DIR}/maxtext/jax-ss/automated/{current_datetime}",
           ),
           test_name=f"maxtext-jax-ss-{accelerator}-{slice_num}x",
-          docker_image=DockerImage.MAXTEXT_TPU_JAX_SS.value,
+          docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
           test_owner=test_owner.PARAM_B,
       ).run()
 
   for accelerator, slices in maxdiffusion_test_configs.items():
     cores = accelerator.rsplit("-", maxsplit=1)[-1]
     for slice_num in slices:
-      maxdiffusion_jax_ss_test = config.get_gke_jax_ss_config(
+      maxdiffusion_jax_ss_test = config.get_gke_jax_stable_stack_config(
           tpu_version=config.tpu_versions[accelerator],
           tpu_cores=cores,
           num_slices=slice_num,
@@ -79,10 +79,10 @@ with models.DAG(
           time_out_in_min=60,
           run_model_cmds=(
               f"python -m src.maxdiffusion.models.train src/maxdiffusion/configs/base_2_base.yml "
-              f"run_name={slice_num}slice-V{config.tpu_versions[accelerator]}_{cores}-maxdiffusion-jax-ss-{current_datetime} "
+              f"run_name={slice_num}slice-V{config.tpu_versions[accelerator]}_{cores}-maxdiffusion-jax-stable-stack-{current_datetime} "
               f"base_output_directory={gcs_bucket.BASE_OUTPUT_DIR}/maxdiffusion/jax-ss/automated/{current_datetime}",
           ),
           test_name=f"maxdiffusion-jax-ss-{accelerator}-{slice_num}x",
-          docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_SS.value,
+          docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK.value,
           test_owner=test_owner.PARAM_B,
       ).run()

--- a/dags/multipod/configs/common.py
+++ b/dags/multipod/configs/common.py
@@ -23,6 +23,7 @@ UPGRADE_PIP = "pip install --upgrade pip"
 class SetupMode(enum.Enum):
   STABLE = "stable"
   NIGHTLY = "nightly"
+  JAX_STABLE_STACK = "jax_stable_stack"
 
 
 class Platform(enum.Enum):

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -71,3 +71,19 @@ with models.DAG(
         base_output_directory=base_output_directory,
         metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
     ).run_with_run_name_generation()
+    jax_stable_stack_maxtext_v4_configs_test = gke_config.get_gke_config(
+        tpu_version=TpuVersion.V4,
+        tpu_cores=128,
+        tpu_zone=Zone.US_CENTRAL2_B.value,
+        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+        time_out_in_min=300,
+        test_name="jax-stable-stack" + "-" + test_name,
+        run_model_cmds=run_command,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
+        test_owner=test_owner.MATT_D,
+        base_output_directory=base_output_directory,
+        metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
+    ).run_with_run_name_generation()
+    jax_stable_stack_maxtext_v4_configs_test.set_upstream(
+        maxtext_v4_configs_test
+    )

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -38,6 +38,7 @@ with models.DAG(
   docker_images = [
       (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
+      (SetupMode.JAX_STABLE_STACK, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
   ]
 
   for mode, image in docker_images:

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -187,11 +187,13 @@ class DockerImage(enum.Enum):
       "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXTEXT_TPU_JAX_SS = (
-      "gcr.io/tpu-prod-env-multipod/jax-ss-maxtext-unpinned:06032024"
+  MAXTEXT_TPU_JAX_STABLE_STACK = (
+      "us-docker.pkg.dev/tpu-prod-env-multipod/maxtext-jax-stable-stack/tpu:"
+      f"jax0.4.30-rev1-{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXDIFFUSION_TPU_JAX_SS = (
-      "gcr.io/tpu-prod-env-multipod/maxdiffusion_jax_ss:06112024"
+  MAXDIFFUSION_TPU_JAX_STABLE_STACK = (
+      "us-docker.pkg.dev/tpu-prod-env-multipod/maxdiffusion-jax-stable-stack/tpu:"
+      f"jax0.4.30-rev1-{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXTEXT_TPU_JAX_NIGHTLY = (
       "gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:"


### PR DESCRIPTION
# Description

This change introduces JAX-Stable-Stack workload images for `maxtext` and `maxdiffusion`. Modified existing DAGs to incorporate these new images into our testing pipelines.

*Key Changes:*

New Images: Added JAX-SS images specifically optimized for maxtext and maxdiffusion workloads.
DAG Modifications: Updated relevant DAGs to consume these JAX-Stabke-Stack images during testing.

*Goals:*

Thorough Testing: Soak tests with JAX-Stabke-Stack images.
Potential Replacement: Evaluate the feasibility of replacing existing stable diffusion images with JAX-Stabke-Stack ML workload images if testing proves successful.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.