### PR TITLE
Integrate Mantaray into XLML

### DIFF
--- a/dags/composer_env.py
+++ b/dags/composer_env.py
@@ -34,6 +34,7 @@ def is_prod_env() -> bool:
   """Indicate if the composer environment is Prod."""
   return os.environ.get(COMPOSER_ENVIRONMENT) == PROD_COMPOSER_ENV_NAME
 
+
 def get_gs_bucket() -> str:
   if is_prod_env():
     return PROD_COMPOSER_ENV_GS_BUCKET

--- a/dags/composer_env.py
+++ b/dags/composer_env.py
@@ -35,6 +35,11 @@ def is_prod_env() -> bool:
   return os.environ.get(COMPOSER_ENVIRONMENT) == PROD_COMPOSER_ENV_NAME
 
 
+def is_dev_env() -> bool:
+  """Indicate if the composer environment is Dev."""
+  return os.environ.get(COMPOSER_ENVIRONMENT) == DEV_COMPOSER_ENV_GS_BUCKET
+
+
 def get_gs_bucket() -> str:
   if is_prod_env():
     return PROD_COMPOSER_ENV_GS_BUCKET

--- a/dags/composer_env.py
+++ b/dags/composer_env.py
@@ -26,7 +26,15 @@ DEV_COMPOSER_ENV_NAME = "ml-automation-solutions-dev"
 COMPOSER_ENVIRONMENT = "COMPOSER_ENVIRONMENT"
 COMPOSER_LOCATION = "COMPOSER_LOCATION"
 
+DEV_COMPOSER_ENV_GS_BUCKET = "gs://us-central1-ml-automation-s-bc6c8818-bucket"
+PROD_COMPOSER_ENV_GS_BUCKET = "gs://us-central1-ml-automation-s-bc954647-bucket"
+
 
 def is_prod_env() -> bool:
   """Indicate if the composer environment is Prod."""
   return os.environ.get(COMPOSER_ENVIRONMENT) == PROD_COMPOSER_ENV_NAME
+
+def get_gs_bucket() -> str:
+  if is_prod_env():
+    return PROD_COMPOSER_ENV_GS_BUCKET
+  return DEV_COMPOSER_ENV_GS_BUCKET

--- a/dags/mantaray/mantaray.py
+++ b/dags/mantaray/mantaray.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DAGs to run Mantaray benchmarks."""
+
+
+import datetime
+from airflow import models
+from xlml.utils import mantaray
+import yaml
+
+# Download xlml_jobs.yaml from GCS
+xlml_jobs_yaml = mantaray.load_file_from_gcs(
+    "gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/xlml_jobs/xlml_jobs.yaml"
+)
+xlml_jobs = yaml.safe_load(xlml_jobs_yaml)
+# Create a DAG for each job
+for job in xlml_jobs:
+  with models.DAG(
+      dag_id=job["task_name"],
+      schedule=job["schedule"],
+      tags=["ray"],
+      start_date=datetime.datetime(2024, 4, 22),
+      catchup=False,
+  ) as dag:
+    run_workload = mantaray.run_workload(
+        workload_file_name=job["file_name"],
+    )
+
+  run_workload

--- a/dags/mantaray/mantaray.py
+++ b/dags/mantaray/mantaray.py
@@ -19,12 +19,14 @@ import datetime
 from airflow import models
 from xlml.utils import mantaray
 import yaml
+from dags import composer_env
 
 # Download xlml_jobs.yaml from the ml-auto-solutions GCS bucket. Any update
 # to this file in the bucket will automatically trigger the execution of
 # this script, which recreates the Mantaray DAGs to reflect the changes.
+gs_bucket = composer_env.get_gs_bucket()
 xlml_jobs_yaml = mantaray.load_file_from_gcs(
-    "gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/xlml_jobs/xlml_jobs.yaml"
+    f"{gs_bucket}/mantaray/xlml_jobs/xlml_jobs.yaml"
 )
 xlml_jobs = yaml.safe_load(xlml_jobs_yaml)
 # Create a DAG for each job

--- a/dags/mantaray/mantaray.py
+++ b/dags/mantaray/mantaray.py
@@ -20,7 +20,9 @@ from airflow import models
 from xlml.utils import mantaray
 import yaml
 
-# Download xlml_jobs.yaml from GCS
+# Download xlml_jobs.yaml from the ml-auto-solutions GCS bucket. Any update
+# to this file in the bucket will automatically trigger the execution of
+# this script, which recreates the Mantaray DAGs to reflect the changes.
 xlml_jobs_yaml = mantaray.load_file_from_gcs(
     "gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/xlml_jobs/xlml_jobs.yaml"
 )

--- a/dags/mantaray/mantaray.py
+++ b/dags/mantaray/mantaray.py
@@ -45,3 +45,7 @@ if composer_env.is_prod_env() or composer_env.is_dev_env():
       )
 
     run_workload
+else:
+  print(
+      "Skipping creating Mantaray DAGs since not running in Prod or Dev composer environment."
+  )

--- a/scripts/upload-tests.sh
+++ b/scripts/upload-tests.sh
@@ -16,6 +16,7 @@
 
 set -e
 
+COMPOSER_ENVIRONMENT="test_env"
 GCS_DAGS_FOLDER=$1
 FOLDERS_TO_UPLOAD=("dags" "xlml")
 

--- a/xlml/utils/mantaray.py
+++ b/xlml/utils/mantaray.py
@@ -1,0 +1,60 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to run workloads with mantaray."""
+import subprocess
+import tempfile
+from airflow.decorators import task
+from airflow.hooks.subprocess import SubprocessHook
+
+
+def load_file_from_gcs(gs_file_path):
+  """Loads a file from a Google Cloud Storage bucket."""
+  with tempfile.TemporaryDirectory() as tmpdir:
+    subprocess.run(
+        f"gsutil -m cp {gs_file_path} {tmpdir}/file",
+        check=False,
+        shell=True,
+    )
+    with open(f"{tmpdir}/file", "r") as f:
+      return f.read()
+
+
+@task
+def run_workload(
+    workload_file_name: str,
+):
+  with tempfile.TemporaryDirectory() as tmpdir:
+    cmds = (
+        f"cd {tmpdir}",
+        "sudo apt-get update && sudo apt-get install -y rsync",  # Install rsync
+        "pip uninstall -y -q mantaray",  # Download and install mantaray
+        (
+            "gsutil cp"
+            " gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/mantaray-0.1-py2.py3-none-any.whl ."
+        ),
+        (
+            "gsutil cp -r"
+            " gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/xlml_jobs ."
+        ),
+        f"pip install mantaray-0.1-py2.py3-none-any.whl",
+        f"python xlml_jobs/{workload_file_name}",  # Run the workload
+    )
+    hook = SubprocessHook()
+    result = hook.run_command(
+        ["bash", "-c", ";".join(cmds)],
+    )
+    assert (
+        result.exit_code == 0
+    ), f"XPK command failed with code {result.exit_code}"

--- a/xlml/utils/mantaray.py
+++ b/xlml/utils/mantaray.py
@@ -46,10 +46,7 @@ def run_workload(
             "gsutil cp"
             f" {gs_bucket}/mantaray/mantaray-0.1-py2.py3-none-any.whl ."
         ),
-        (
-            "gsutil cp -r"
-            f" {gs_bucket}/mantaray/xlml_jobs ."
-        ),
+        ("gsutil cp -r" f" {gs_bucket}/mantaray/xlml_jobs ."),
         f"pip install mantaray-0.1-py2.py3-none-any.whl",
         f"python xlml_jobs/{workload_file_name}",  # Run the workload
     )

--- a/xlml/utils/mantaray.py
+++ b/xlml/utils/mantaray.py
@@ -17,6 +17,7 @@ import subprocess
 import tempfile
 from airflow.decorators import task
 from airflow.hooks.subprocess import SubprocessHook
+from dags import composer_env
 
 
 def load_file_from_gcs(gs_file_path):
@@ -35,6 +36,7 @@ def load_file_from_gcs(gs_file_path):
 def run_workload(
     workload_file_name: str,
 ):
+  gs_bucket = composer_env.get_gs_bucket()
   with tempfile.TemporaryDirectory() as tmpdir:
     cmds = (
         f"cd {tmpdir}",
@@ -42,11 +44,11 @@ def run_workload(
         "pip uninstall -y -q mantaray",  # Download and install mantaray
         (
             "gsutil cp"
-            " gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/mantaray-0.1-py2.py3-none-any.whl ."
+            f" {gs_bucket}/mantaray/mantaray-0.1-py2.py3-none-any.whl ."
         ),
         (
             "gsutil cp -r"
-            " gs://us-central1-ml-automation-s-bc954647-bucket/mantaray/xlml_jobs ."
+            f" {gs_bucket}/mantaray/xlml_jobs ."
         ),
         f"pip install mantaray-0.1-py2.py3-none-any.whl",
         f"python xlml_jobs/{workload_file_name}",  # Run the workload

--- a/xlml/utils/mantaray.py
+++ b/xlml/utils/mantaray.py
@@ -57,4 +57,4 @@ def run_workload(
     )
     assert (
         result.exit_code == 0
-    ), f"XPK command failed with code {result.exit_code}"
+    ), f"Mantaray command failed with code {result.exit_code}"

--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -266,6 +266,8 @@ def process_tensorboard_summary(
 
   if summary_config.use_regex_file_location:
     file_location = get_gcs_file_location_with_regex(file_location)
+    if file_location == "":
+      return [[]], [[]]
 
   aggregation_strategy = summary_config.aggregation_strategy
   include_tag_patterns = summary_config.include_tag_patterns
@@ -330,9 +332,8 @@ def get_gcs_file_location_with_regex(file_location: str) -> str:
         f"{next(filter(file_path_regex.match, all_blobs_names))}"
     )
   except StopIteration:
-    raise AirflowFailException(
-        f"No objects matched supplied regex: {file_location}"
-    )
+    logging.warning(f"No objects matched supplied regex: {file_location}")
+    return ""
 
 
 # TODO(qinwen): implement profile metrics & upload to Vertex AI TensorBoard


### PR DESCRIPTION
# Description

Enable running Mantaray jobs on XLML Airflow. 

Mantaray is a benchmarking library. The Mantaray DAG first downloads the Mantaray wheel and the Mantaray benchmarks from GCS, and then launches the benchmarks. 

# Tests

Tested running Mantaray jobs e2e on the `cloud-ml-auto-solutions-dev` Composer Environment.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.