### PR TITLE
Package common library code in `xlml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ logs
 
 # Misc
 tmp
+
+# Build artifacts
+*.whl

--- a/deployment/.terraform.lock.hcl
+++ b/deployment/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "5.33.0"
   hashes = [
+    "h1:FZtf/G/RA1tuOZMmeM0er0e3Kbl6/Mh/DiquvWBvsdQ=",
     "h1:OJa8Btb9/XgW2i9XrVoizE20Qu89TvSfvXHGe0Q44JI=",
     "zh:220f955308b0b4a9609e976368af7f53f596b1a08980412e93a58b9a497c6772",
     "zh:251067e5154bb43e168b18f6b9687415c1817855c4e2d0735d93624f731162bd",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version = "5.33.0"
   hashes = [
     "h1:33Yp9CoesCX5mYUaZn9nCdNg8BQmNMxx5nqm+JtnMXs=",
+    "h1:QVeAxqJmMxcsdfMJfLQ6Fs7MHVs9/2oc5FYV3jKkYeI=",
     "zh:0c64d019316841e3b8d62a224c7248b5c62a85839b8106d7b5cba6b8518a0aa8",
     "zh:12618fa9c5a30603677c627e4f6872740189a809cfe3a9fa3ffda64126b86e9e",
     "zh:4a2dc170c3682945e4efcaa9c0114e8797620bda960baf9a048e6ad3c1f35950",
@@ -43,6 +45,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.31.0"
   hashes = [
     "h1:G8S89g+vfZOgJGbOpSKIQXrp+jIvTwapc89pMVsUo3s=",
+    "h1:wGHbATbv/pBVTST1MtEn0zyVhZbzZJD2NYq2EddASHY=",
     "zh:0d16b861edb2c021b3e9d759b8911ce4cf6d531320e5dc9457e2ea64d8c54ecd",
     "zh:1bad69ed535a5f32dec70561eb481c432273b81045d788eb8b37f2e4a322cc40",
     "zh:43c58e3912fcd5bb346b5cb89f31061508a9be3ca7dd4cd8169c066203bcdfb3",

--- a/deployment/artifact_registry.tf
+++ b/deployment/artifact_registry.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "private-xlml-index" {
+  project       = var.project_config.project_name
+  location      = "us-central1"
+  repository_id = "xlml-private"
+  description   = "Packaged `xlml` wheels"
+  format        = "python"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xlml"
+dependencies = [
+    # TODO: Add explicit dependencies. See .github/requirements.txt
+]
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+dynamic = ["version"]
+
+[tool.hatch.version]
+source = "vcs"


### PR DESCRIPTION
# Description

- Add basic configuration to package common library code in `xlml` in a Python package. This would allow us to create new Composer environments that share common code, but have their DAGs defined outside of this repository.
  - Build with `pip wheel .`
- Add Terraform config for private Python Artifact Registry. 
- Documentation for pulling from a private Artifact Registry in Composer: https://cloud.google.com/composer/docs/how-to/using/installing-python-dependencies#install-ar-repo

I'm not planning to migrate the main prod/dev environments to use this package right now.

# Tests

The terraform state was broken from a leftover lock (probably a canceled operation during #328) so there are some small inconsistencies. See next section.

<details>

```
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_artifact_registry_repository.private-xlml-index will be created
  + resource "google_artifact_registry_repository" "private-xlml-index" {
      + create_time      = (known after apply)
      + description      = "Packaged `xlml` wheels"
      + effective_labels = (known after apply)
      + format           = "python"
      + id               = (known after apply)
      + location         = "us-central1"
      + mode             = "STANDARD_REPOSITORY"
      + name             = (known after apply)
      + project          = "cloud-ml-auto-solutions"
      + repository_id    = "xlml-private"
      + terraform_labels = (known after apply)
      + update_time      = (known after apply)
    }

  # google_container_node_pool.nvidia-a100x1 will be created
  + resource "google_container_node_pool" "nvidia-a100x1" {
      + cluster                     = "benchmarking-gpu-uc1"
      + id                          = (known after apply)
      + initial_node_count          = 4
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nvidia-a100x1-pool"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "cloud-ml-benchmarking"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy      = "ANY"
          + total_max_node_count = 12
          + total_min_node_count = 4
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + network_config (known after apply)

      + node_config {
          + disk_size_gb      = 500
          + disk_type         = "pd-balanced"
          + effective_taints  = (known after apply)
          + guest_accelerator = [
              + {
                  + count                          = 1
                  + gpu_driver_installation_config = [
                      + {
                          + gpu_driver_version = "LATEST"
                        },
                    ]
                  + type                           = "nvidia-tesla-a100"
                },
            ]
          + image_type        = (known after apply)
          + labels            = (known after apply)
          + local_ssd_count   = (known after apply)
          + logging_variant   = (known after apply)
          + machine_type      = "a2-highgpu-1g"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = (known after apply)
          + spot              = false

          + confidential_nodes (known after apply)

          + shielded_instance_config (known after apply)

          + workload_metadata_config (known after apply)
        }

      + upgrade_settings (known after apply)
    }

  # module.composer["ml-automation-solutions"].google_composer_environment.example_environment will be updated in-place
  ~ resource "google_composer_environment" "example_environment" {
        id               = "projects/cloud-ml-auto-solutions/locations/us-central1/environments/ml-automation-solutions"
        name             = "ml-automation-solutions"
        # (5 unchanged attributes hidden)

      ~ config {
            # (8 unchanged attributes hidden)

          ~ software_config {
              ~ pypi_packages            = {
                  - "ray"                               = "[default]" -> null
                    # (4 unchanged elements hidden)
                }
                # (6 unchanged attributes hidden)

                # (1 unchanged block hidden)
            }

            # (8 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.composer["ml-automation-solutions-dev"].google_composer_environment.example_environment will be updated in-place
  ~ resource "google_composer_environment" "example_environment" {
        id               = "projects/cloud-ml-auto-solutions/locations/us-central1/environments/ml-automation-solutions-dev"
        name             = "ml-automation-solutions-dev"
        # (5 unchanged attributes hidden)

      ~ config {
            # (8 unchanged attributes hidden)

          ~ software_config {
              ~ pypi_packages            = {
                  - "ray"                               = "[default]" -> null
                    # (4 unchanged elements hidden)
                }
                # (6 unchanged attributes hidden)

                # (1 unchanged block hidden)
            }

            # (8 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 2 to add, 2 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

</details>

A GKE node pool may be re-created (cc @zpcore) and the `ray` package will be removed from prod and dev Composer environments since it's not in the configs (cc @allenwang28 and @wenxindongwork) . 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.