### PR TITLE
fix flax tests by disabling profiling from the flax tests

### DIFF
--- a/dags/solutions_team/configs/flax/solutionsteam_flax_latest_supported_config.py
+++ b/dags/solutions_team/configs/flax/solutionsteam_flax_latest_supported_config.py
@@ -57,7 +57,7 @@ def get_flax_resnet_config(
           f"export TFDS_DATA_DIR={data_dir} &&"
           " JAX_PLATFORM_NAME=TPU python3 /tmp/flax/examples/imagenet/main.py"
           " --config=/tmp/flax/examples/imagenet/configs/tpu.py"
-          f" --workdir={work_dir} --config.num_epochs=1 {extraFlags}"
+          f" --workdir={work_dir} --config.num_epochs=1 --config.profile=False {extraFlags}"
       ),
   )
 


### PR DESCRIPTION
# Description

fix flax tests by removing profiling from flax tests which is causing the grpc issue

# Tests
<img width="1898" alt="image" src="https://github.com/user-attachments/assets/690c52a6-635f-43e9-9764-eccbf136d62f">

The failing test `flax_resnet_imagenet-v5litepod-4` is now passing

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.