### PR TITLE
Fix r2.4 GPU docker link

### DIFF
--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -77,7 +77,7 @@ class VERSION_MAPPING:
     TORCH = "torch==2.4.0"
     TORCHVISION = "torchvision==0.19.0"
     TORCHAUDIO = "torchaudio==2.4.0"
-    TORCH_XLA_GPU_DOCKER = "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0-rc2_3.10_cuda_12.1"
+    TORCH_XLA_GPU_DOCKER = "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0-rc8_3.10_cuda_12.1"
     TORCH_INDEX_CPU_URL = "https://download.pytorch.org/whl/test/cpu"
     TORCH_INDEX_CUDA_URL = "https://download.pytorch.org/whl/test/cu121"
     TORCH_REPO_BRANCH = "-b v2.4.0-rc8"


### PR DESCRIPTION
# Description

Fix incorrect Pytorch/XLA r2.4 GPU docker link.

# Tests

https://60bb71acc6784780b3bbdbae4ffa636f-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-torchbench-release/grid?dag_run_id=manual__2024-07-29T22%3A32%3A25.229712%2B00%3A00&tab=graph

(stream_logs passed, doesn't need to care about the post-process here)
<img width="529" alt="image" src="https://github.com/user-attachments/assets/e8fafd6b-be84-4c30-bdba-8d5132129415">

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.