### PR TITLE
end_to_end tests for mixtral-8x22b

### DIFF
--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -217,6 +217,23 @@ with models.DAG(
               "time_out_in_min": 60,
           },
       ],
+      "mixtral-8x22b": [
+          {
+              "script_name": "tpu/mixtral/8x22b/1_test_mixtral",
+              "cpu_device_type": CpuVersion.M1_MEGAMEM,
+              "cpu_zone": Zone.US_CENTRAL1_B.value,
+              "cluster_name": ClusterName.CPU_M1_MEGAMEM_96.value,
+              "time_out_in_min": 360,
+          },
+          {
+              "script_name": "tpu/mixtral/8x22b/2_test_mixtral",
+              "tpu_version": TpuVersion.V5E,
+              "tpu_cores": 256,
+              "cluster_name": ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
+              "tpu_zone": Zone.US_WEST4_B.value,
+              "time_out_in_min": 60,
+          },
+      ],
       "llama2-70b": [
           {
               "script_name": "tpu/llama2/70b/1_test_llama2_70b",


### PR DESCRIPTION
# Description

Adding tests for Mixtral-8x22B-Instruct-v0.1 via MaxText's end_to_end tests.

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.