### PR TITLE
Add AoT test for A3 GPU

### DIFF
--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -18,7 +18,7 @@ A DAG to run AOT compilation tests for MaxText model configs.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, DockerImage
+from dags.vm_resource import GpuVersion, TpuVersion, Zone, DockerImage, ClusterName
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
@@ -34,7 +34,7 @@ with models.DAG(
     concurrency=2,
 ) as dag:
   # Testing configurations
-  model_configs = {
+  tpu_configs = {
       # accelerator: [(model_size, num_cores), ...],
       "v4": [("22b", 128), ("52b", 384)],
       "v5e": [("16b", 256), ("32b", 256), ("64b", 256), ("128b", 256)],
@@ -56,7 +56,7 @@ with models.DAG(
   ]
 
   run_model_cmds_dict = {}
-  for tpu, models in model_configs.items():
+  for tpu, models in tpu_configs.items():
     run_model_cmds = []
     for model_size, num_cores in models:
       for n in num_slices:
@@ -103,3 +103,17 @@ with models.DAG(
         >> maxtext_v5e_configs_test
         >> maxtext_v5p_configs_test
     )
+
+  # GPU AoT tests
+  cmd = f"bash MaxText/configs/a3/llama_2_7b/16vm.sh EXECUTABLE=train_compile.py M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=16"
+  stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
+      accelerator_type=GpuVersion.XPK_H100,
+      gpu_zone=Zone.US_CENTRAL1_C.value,
+      time_out_in_min=300,
+      test_name=f"maxtext-aot-a3-stable",
+      run_model_cmds=(cmd,),
+      num_slices=1,
+      cluster_name=ClusterName.A3_CLUSTER.value,
+      docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
+      test_owner=test_owner.JON_B,
+  ).run()


### PR DESCRIPTION
# Description

Add AoT tests for A3 GPUs.

Depends on this change in MaxText to support `EXECUTABLE` env var in 16vm.sh: https://github.com/google/maxtext/pull/826

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

http://shortn/_4tvul6cC2l

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.