### PR TITLE
Use reserved v5p

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,8 @@ dags/solutions_team/solutionsteam_flax* @sshahrokhi
 dags/solutions_team/configs/tensorflow @chandrasekhard2 @ZhaoyueCheng
 dags/solutions_team/solutionsteam_tf* @chandrasekhard2 @ZhaoyueCheng
 
-dags/pytorch_xla @will-cromar @jonb377 @JackCaoG @vanbasten23 @zpcore
-dags/legacy_test/tests/pytorch @will-cromar @jonb377 @JackCaoG @vanbasten23 @zpcore
+dags/pytorch_xla @will-cromar @jonb377 @JackCaoG @vanbasten23 @zpcore @ManfeiBai
+dags/legacy_test/tests/pytorch @will-cromar @jonb377 @JackCaoG @vanbasten23 @zpcore @ManfeiBai
 
 dags/multipod @jonb377
 

--- a/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
+++ b/dags/pytorch_xla/configs/pytorchxla_torchbench_config.py
@@ -35,8 +35,8 @@ class VERSION(enum.Enum):
 class VERSION_MAPPING:
 
   class NIGHTLY(enum.Enum):
-    TORCH_XLA_TPU_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl"
-    TORCH_XLA_CUDA_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.1/torch_xla-nightly-cp310-cp310-linux_x86_64.whl"
+    TORCH_XLA_TPU_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.5.0.dev-cp310-cp310-linux_x86_64.whl"
+    TORCH_XLA_CUDA_WHEEL = "https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.1/torch_xla-2.5.0.dev-cp310-cp310-linux_x86_64.whl"
     TORCH = "torch"
     TORCHVISION = "torchvision"
     TORCHAUDIO = "torchaudio"

--- a/dags/pytorch_xla/pytorchxla2_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla2_torchbench.py
@@ -58,6 +58,8 @@ with models.DAG(
       time_out_in_min=700,
       use_xla2=True,
       model_name=model,
+      reserved=True,
+      preemptible=False,
       extraFlags=" ".join(torchbench_extra_flags),
   )
 

--- a/dags/pytorch_xla/pytorchxla_torchbench.py
+++ b/dags/pytorch_xla/pytorchxla_torchbench.py
@@ -61,7 +61,7 @@ with models.DAG(
       subnetwork=resource.V5P_SUBNETWORKS,
       time_out_in_min=1800,
       model_name=model,
-      reserved=False,
+      reserved=True,
       preemptible=False,
       extraFlags=" ".join(torchbench_extra_flags),
   )


### PR DESCRIPTION
# Description

1. Use reserved resource for torchbench v5p;  
2. Use the new torch_xla wheel path based on https://github.com/pytorch/xla/pull/7883.

# Tests

https://60bb71acc6784780b3bbdbae4ffa636f-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-torchbench/grid
<img width="392" alt="image" src="https://github.com/user-attachments/assets/ffeb26f7-49d2-45dc-8cb9-8288da5b4e42">


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.