### PR TITLE
Replacing MAXTEXT_TPU_STABLE with jax stable stack maxtext docker image

### DIFF
--- a/dags/imagegen_devx/jax_stable_stack_e2e.py
+++ b/dags/imagegen_devx/jax_stable_stack_e2e.py
@@ -61,7 +61,7 @@ with models.DAG(
               f"base_output_directory={gcs_bucket.BASE_OUTPUT_DIR}/maxtext/jax-ss/automated/{current_datetime}",
           ),
           test_name=f"maxtext-jax-ss-{accelerator}-{slice_num}x",
-          docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
+          docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
           test_owner=test_owner.PARAM_B,
       ).run()
 
@@ -82,6 +82,6 @@ with models.DAG(
               f"output_dir={gcs_bucket.BASE_OUTPUT_DIR}/maxdiffusion/jax-ss/automated/{current_datetime}",
           ),
           test_name=f"maxdiffusion-jax-ss-{accelerator}-{slice_num}x",
-          docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK.value,
+          docker_image=DockerImage.MAXDIFFUSION_TPU_STABLE.value,
           test_owner=test_owner.PARAM_B,
       ).run()

--- a/dags/multipod/maxtext_configs_aot_hybridsim.py
+++ b/dags/multipod/maxtext_configs_aot_hybridsim.py
@@ -94,17 +94,6 @@ with models.DAG(
               test_owner=test_owner.RAYMOND_Z,
           ).run(gcs_location=shared_gcs_location)
 
-          jax_stable_stack_maxtext_aot = gke_config.get_gke_config(
-              tpu_version=TpuVersion.V4,
-              tpu_cores=8,
-              tpu_zone=Zone.US_CENTRAL2_B.value,
-              time_out_in_min=240,
-              test_name=f"jax-stable-stack-maxtext-{model_size}-{n}xv{tpu.value}-{num_cores}-aot",
-              run_model_cmds=aot_cmd,
-              docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
-              test_owner=test_owner.RAYMOND_Z,
-          ).run(gcs_location=shared_gcs_location)
-
           # Run HybridSim workload: read HLO from GCS, generate estimated step time
           cluster_name, zone, project_name, cores = clusters[tpu]
           chip_config = "default" if tpu == TpuVersion.V5E else "megacore"

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -71,19 +71,3 @@ with models.DAG(
         base_output_directory=base_output_directory,
         metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
     ).run_with_run_name_generation()
-    jax_stable_stack_maxtext_v4_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=128,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
-        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-        time_out_in_min=300,
-        test_name="jax-stable-stack" + "-" + test_name,
-        run_model_cmds=run_command,
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
-        test_owner=test_owner.MATT_D,
-        base_output_directory=base_output_directory,
-        metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
-    ).run_with_run_name_generation()
-    jax_stable_stack_maxtext_v4_configs_test.set_upstream(
-        maxtext_v4_configs_test
-    )

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -133,17 +133,7 @@ with models.DAG(
         docker_image=DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
         test_owner=test_owner.JON_B,
     ).run()
-    jax_stable_stack_tpu = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
-        time_out_in_min=60,
-        test_name=f"jax-stable-stack-{test_name_prefix}-nightly-{model}",
-        run_model_cmds=(f"bash end_to_end/{test_script}.sh",),
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
-        test_owner=test_owner.JON_B,
-    ).run()
-    stable_tpu >> nightly_tpu >> jax_stable_stack_tpu
+    stable_tpu >> nightly_tpu
 
   for model, (test_script, nnodes) in test_models_gpu.items():
     pinned_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
@@ -328,23 +318,4 @@ with models.DAG(
           gcs_subfolder,
           test_group_id,
       )
-      jax_stable_stack_tpu = gke_config.get_gke_config(
-          tpu_version=test_scripts_details[1]["tpu_version"],
-          tpu_cores=test_scripts_details[1]["tpu_cores"],
-          tpu_zone=test_scripts_details[1]["tpu_zone"],
-          time_out_in_min=test_scripts_details[1]["time_out_in_min"],
-          test_name=f"{test_name_prefix}-jax-stable-stack-{model}",
-          run_model_cmds=(
-              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash end_to_end/{test_scripts_details[1]['script_name']}.sh",
-          ),
-          docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
-          test_owner=test_owner.ANISHA_M,
-          cluster_name=test_scripts_details[1]["cluster_name"],
-      ).run(gcs_location=shared_gcs_location)
-      (
-          stable_cpu
-          >> stable_tpu
-          >> nightly_cpu
-          >> nightly_tpu
-          >> jax_stable_stack_tpu
-      )
+      (stable_cpu >> stable_tpu >> nightly_cpu >> nightly_tpu)

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -38,7 +38,6 @@ with models.DAG(
   docker_images = [
       (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
-      (SetupMode.JAX_STABLE_STACK, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
   ]
 
   for mode, image in docker_images:

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -184,14 +184,10 @@ class DockerImage(enum.Enum):
       f"xla:nightly_3.10_tpuvm_{datetime.datetime.today().strftime('%Y%m%d')}"
   )
   MAXTEXT_TPU_JAX_STABLE = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:"
-      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
-  )
-  MAXTEXT_TPU_JAX_STABLE_STACK = (
       "us-docker.pkg.dev/tpu-prod-env-multipod/maxtext-jax-stable-stack/tpu:"
       f"jax0.4.30-rev1-{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXDIFFUSION_TPU_JAX_STABLE_STACK = (
+  MAXDIFFUSION_TPU_STABLE = (
       "us-docker.pkg.dev/tpu-prod-env-multipod/maxdiffusion-jax-stable-stack/tpu:"
       f"jax0.4.30-rev1-{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )


### PR DESCRIPTION
# Description

- Replacing `MAXTEXT_TPU_STABLE` docker image with jax stable stack maxtext docker image.
- Removing interim tests that were built to verify jax stable stack with workload in https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/353

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.