### PR TITLE
Update PyTorch/XLA nightly link.

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -98,7 +98,7 @@ local volumes = import 'templates/volumes.libsonnet';
         sudo apt install -y libsndfile-dev
         pip3 install --user --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
         pip install --user \
-          'torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl' \
+          'torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev-cp310-cp310-linux_x86_64.whl' \
           -f https://storage.googleapis.com/libtpu-releases/index.html
         pip3 install pillow
         git clone --depth=1 https://github.com/pytorch/pytorch.git


### PR DESCRIPTION
# Description
It looks like we have stopped generating torch_xla-nightly wheel since August 28 and this is causing version mismatch in airflow tests.

Temporarily changing this link to point to 2.6 nightly before adding back the nightly wheel.


# Tests
Tested on a dev airflow instance

# Checklist
Before submitting this PR, please make sure (put X in square brackets):

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
