### PR TITLE
Centralize XPK cluster details

### DIFF
--- a/dags/examples/configs/xpk_example_config.py
+++ b/dags/examples/configs/xpk_example_config.py
@@ -16,24 +16,21 @@
 
 import datetime
 from xlml.apis import gcp_config, metric_config, task, test_config
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags import test_owner
 from dags.vm_resource import TpuVersion
 
 
 def get_flax_resnet_xpk_config(
-    tpu_version: TpuVersion,
-    tpu_cores: int,
-    tpu_zone: str,
     test_name: str,
-    project_name: str,
-    cluster_name: str,
+    cluster: XpkClusterConfig,
     docker_image: str,
     time_out_in_min: int,
     num_slices: int = 1,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=project_name,
-      zone=tpu_zone,
+      project_name=cluster.project,
+      zone=cluster.zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
@@ -47,11 +44,11 @@ def get_flax_resnet_xpk_config(
 
   job_test_config = test_config.TpuGkeTest(
       test_config.Tpu(
-          version=tpu_version,
-          cores=tpu_cores,
+          version=cluster.device_version,
+          cores=cluster.core_count,
       ),
       test_name=test_name,
-      cluster_name=cluster_name,
+      cluster_name=cluster.name,
       docker_image=docker_image,
       run_model_cmds=run_model_cmds,
       set_up_cmds=None,

--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ Used upon library upgrades.
 import datetime
 from airflow import models
 from dags import test_owner
-from dags.vm_resource import TpuVersion, Zone, Project, ClusterName, DockerImage
+from dags.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -37,24 +37,21 @@ with models.DAG(
   base_output_directory = "gs://maxtext-experiments-multipod"
 
   sweep_model_configs = {
-      "v5e": [("16b", 256), ("32b", 256), ("64b", 256), ("128b", 256)],
+      "v5e": ["16b", "32b", "64b", "128b"],
   }
 
   shared_task_config = {
       "test_owner": test_owner.ZHIYU_L,
-      "project_name": Project.TPU_PROD_ENV_MULTIPOD.value,
-      "cluster_name": ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
-      "tpu_zone": Zone.US_WEST4_B.value,
+      "cluster": XpkClusters.V5E_256_US_WEST_4_MULTISLICE_CLUSTER,
       "time_out_in_min": 60,
       "base_output_directory": base_output_directory,
-      "tpu_version": TpuVersion.V5E,
       "num_slices": [1, 2],
       "docker_image": DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
   }
 
   tests = []
   for tpu, models in sweep_model_configs.items():
-    for model_size, num_cores in models:
+    for model_size in models:
       run_cmds = [
           "pip show aqtp",
           f"bash MaxText/configs/{tpu}/{model_size}.sh EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} PLATFORM=gke",
@@ -63,7 +60,6 @@ with models.DAG(
       tests.extend(
           maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
               **shared_task_config,
-              tpu_cores=num_cores,
               run_name_prefix=f"bf16-{model_size}",
               base_run_model_cmds=run_cmds,
               sweep_params={
@@ -77,7 +73,6 @@ with models.DAG(
       tests.extend(
           maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
               **shared_task_config,
-              tpu_cores=num_cores,
               run_name_prefix=f"int8-aqtp061-{model_size}",
               base_run_model_cmds=["pip install aqtp==0.6.1"] + run_cmds,
               sweep_params={
@@ -91,7 +86,6 @@ with models.DAG(
       tests.extend(
           maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
               **shared_task_config,
-              tpu_cores=num_cores,
               run_name_prefix=f"int8-aqpt062-{model_size}",
               base_run_model_cmds=["pip install aqtp==0.6.2"] + run_cmds,
               sweep_params={

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ on 1xv4-128.
 import datetime
 from airflow import models
 from dags import test_owner
-from dags.vm_resource import TpuVersion, Zone, Project, ClusterName, DockerImage
+from dags.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -44,13 +44,9 @@ with models.DAG(
   maxtext_sweep_gke_test = (
       maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
           test_owner=test_owner.RAYMOND_Z,
-          project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
-          cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-          tpu_zone=Zone.US_CENTRAL2_B.value,
+          cluster=XpkClusters.V4_128_MULTISLICE_CLUSTER,
           time_out_in_min=60,
           base_output_directory=base_output_directory,
-          tpu_version=TpuVersion.V4,
-          tpu_cores=128,
           num_slices=[1],
           docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
           run_name_prefix="maxtext-16b",

--- a/dags/examples/xpk_example_dag.py
+++ b/dags/examples/xpk_example_dag.py
@@ -16,7 +16,7 @@
 
 import datetime
 from airflow import models
-from dags.vm_resource import TpuVersion, Project, Zone, ClusterName, DockerImage
+from dags.vm_resource import TpuVersion, Project, Zone, XpkClusters, DockerImage
 from dags.examples.configs import xpk_example_config as config
 from dags import test_owner
 from xlml.utils import name_format
@@ -34,23 +34,15 @@ with models.DAG(
     catchup=False,
 ) as dag:
   flax_resnet_tpu_singleslice_v4_8 = config.get_flax_resnet_xpk_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       test_name="resnet-single-slice",
-      project_name=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-      cluster_name=ClusterName.V4_8_CLUSTER.value,
+      cluster=XpkClusters.V4_8_CLUSTER,
       docker_image=DockerImage.XPK_JAX_TEST.value,
       time_out_in_min=60,
   ).run()
 
   flax_resnet_tpu_multislice_v4_128 = config.get_flax_resnet_xpk_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=128,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       test_name="resnet-multi-slice",
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
-      cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+      cluster=XpkClusters.V4_128_MULTISLICE_CLUSTER,
       docker_image=DockerImage.XPK_JAX_TEST.value,
       time_out_in_min=60,
       num_slices=2,
@@ -75,23 +67,15 @@ with models.DAG(
         test_group_id,
     )
     chained_resnet_tpu_singleslice_v4_8 = config.get_flax_resnet_xpk_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         test_name="chained-resnet-single-slice",
-        project_name=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-        cluster_name=ClusterName.V4_8_CLUSTER.value,
+        cluster=XpkClusters.V4_8_CLUSTER,
         docker_image=DockerImage.XPK_JAX_TEST.value,
         time_out_in_min=60,
     ).run(gcs_location=shared_gcs_location)
 
     chained_resnet_tpu_multislice_v4_128 = config.get_flax_resnet_xpk_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=128,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         test_name="chained-resnet-multi-slice",
-        project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
-        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
+        cluster=XpkClusters.V4_128_MULTISLICE_CLUSTER,
         docker_image=DockerImage.XPK_JAX_TEST.value,
         time_out_in_min=60,
         num_slices=2,

--- a/dags/imagegen_devx/configs/gke_config.py
+++ b/dags/imagegen_devx/configs/gke_config.py
@@ -15,38 +15,18 @@
 """Utilities to construct configs for solutionsteam_jax_bite DAG."""
 
 from xlml.apis import gcp_config, metric_config, task, test_config
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags import test_owner, gcs_bucket
-from dags.vm_resource import TpuVersion, Project, ClusterName, GpuVersion, CpuVersion, Zone
+from dags.vm_resource import TpuVersion, Project, XpkClusters, GpuVersion, CpuVersion, Zone
 from typing import Iterable
 import datetime
 
-tpu_versions = {
-    # accelerator: tpu versions
-    "v4-8": TpuVersion.V4,
-    "v4-16": TpuVersion.V4,
-    "v5-8": TpuVersion.V5P,
-    "v6e-256": TpuVersion.TRILLIUM,
-}
-cluster_names = {
+clusters = {
     # accelerator: cluster names
-    "v4-8": ClusterName.V4_8_MULTISLICE_CLUSTER,
-    "v4-16": ClusterName.V4_16_MULTISLICE_CLUSTER,
-    "v5-8": ClusterName.V5P_8_MULTISLICE_CLUSTER,
-    "v6e-256": ClusterName.BODABORG_V6E_256,
-}
-tpu_zones = {
-    # accelerator: cluster name
-    "v4-8": Zone.US_CENTRAL2_B,
-    "v4-16": Zone.US_CENTRAL2_B,
-    "v5-8": Zone.US_EAST5_A,
-    "v6e-256": Zone.US_CENTRAL2_B,
-}
-project_names = {
-    # accelerator: project names
-    "v4-8": Project.TPU_PROD_ENV_MULTIPOD,
-    "v4-16": Project.TPU_PROD_ENV_MULTIPOD,
-    "v5-8": Project.CLOUD_TPU_MULTIPOD_DEV,
-    "v6e-256": Project.TPU_PROD_ENV_LARGE_ADHOC,
+    "v4-8": XpkClusters.V4_8_MULTISLICE_CLUSTER,
+    "v4-16": XpkClusters.V4_16_MULTISLICE_CLUSTER,
+    "v5-8": XpkClusters.V5P_8_MULTISLICE_CLUSTER,
+    "v6e-256": XpkClusters.BODABORG_V6E_256,
 }
 
 
@@ -57,24 +37,20 @@ def get_current_datetime() -> str:
 
 
 def get_gke_config(
-    tpu_version: TpuVersion,
-    tpu_cores: int,
-    tpu_zone: str,
     time_out_in_min: int,
     test_name: str,
     docker_image: str,
     run_model_cmds: Iterable[str],
     test_owner: str,
-    cluster_name: str = ClusterName.V4_8_MULTISLICE_CLUSTER.value,
-    project_name: str = Project.TPU_PROD_ENV_MULTIPOD.value,
+    cluster: XpkClusterConfig = XpkClusters.V4_8_MULTISLICE_CLUSTER,
     num_slices: int = 1,
     dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=project_name,
-      zone=tpu_zone,
+      project_name=cluster.project,
+      zone=cluster.zone,
       dataset_name=dataset_name,
       dataset_project=dataset_project,
       composer_project=composer_project,
@@ -82,8 +58,8 @@ def get_gke_config(
 
   job_test_config = test_config.TpuGkeTest(
       test_config.Tpu(
-          version=tpu_version,
-          cores=tpu_cores,
+          version=cluster.device_version,
+          cores=cluster.core_count,
       ),
       test_name=test_name,
       run_model_cmds=run_model_cmds,
@@ -91,7 +67,7 @@ def get_gke_config(
       timeout=datetime.timedelta(minutes=time_out_in_min),
       task_owner=test_owner,
       num_slices=num_slices,
-      cluster_name=cluster_name,
+      cluster_name=cluster.name,
       docker_image=docker_image,
   )
 

--- a/dags/imagegen_devx/maxdiffusion_e2e.py
+++ b/dags/imagegen_devx/maxdiffusion_e2e.py
@@ -18,7 +18,7 @@
 import datetime
 from airflow import models
 from dags import composer_env, test_owner, gcs_bucket
-from dags.vm_resource import Project, TpuVersion, CpuVersion, Zone, DockerImage, GpuVersion, ClusterName
+from dags.vm_resource import Project, TpuVersion, CpuVersion, Zone, DockerImage, GpuVersion, XpkClusters
 from dags.imagegen_devx.configs import gke_config as config
 from xlml.utils import name_format
 
@@ -40,14 +40,11 @@ with models.DAG(
   current_datetime = config.get_current_datetime()
   for accelerator, slices in maxdiffusion_test_configs.items():
     cores = accelerator.rsplit("-", maxsplit=1)[-1]
+    cluster = config.clusters[accelerator]
     for slice_num in slices:
       maxdiffusion_sdxl_test = config.get_gke_config(
-          tpu_version=config.tpu_versions[accelerator],
-          tpu_cores=cores,
           num_slices=slice_num,
-          cluster_name=config.cluster_names[accelerator].value,
-          tpu_zone=config.tpu_zones[accelerator].value,
-          project_name=config.project_names[accelerator].value,
+          cluster=cluster,
           time_out_in_min=60,
           run_model_cmds=(
               f"JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true TPU_SLICE_BUILDER_DUMP_CHIP_FORCE=true TPU_SLICE_BUILDER_DUMP_ICI=true JAX_FORCE_TPU_INIT=true ENABLE_TPUNETD_CLIENT=true && "
@@ -56,7 +53,7 @@ with models.DAG(
               f"revision=refs/pr/95 activations_dtype=bfloat16 weights_dtype=bfloat16 "
               f"dataset_name=gs://jfacevedo-maxdiffusion-v5p/pokemon-datasets/pokemon-gpt4-captions_xl resolution=1024 per_device_batch_size=1 "
               f"jax_cache_dir=gs://jfacevedo-maxdiffusion/cache_dir/ max_train_steps=20 attention=flash run_name=sdxl-fsdp-v5p-64-ddp enable_profiler=True "
-              f"run_name={slice_num}slice-V{config.tpu_versions[accelerator]}_{cores}-maxdiffusion-jax-stable-stack-{current_datetime} "
+              f"run_name={slice_num}slice-V{cluster.device_version}_{cores}-maxdiffusion-jax-stable-stack-{current_datetime} "
               f"output_dir={gcs_bucket.BASE_OUTPUT_DIR}/maxdiffusion/automated/{current_datetime}",
           ),
           test_name=f"maxd-sdxl-{accelerator}-{slice_num}x",
@@ -64,18 +61,14 @@ with models.DAG(
           test_owner=test_owner.PARAM_B,
       ).run()
       maxdiffusion_sdxl_nan_test = config.get_gke_config(
-          tpu_version=config.tpu_versions[accelerator],
-          tpu_cores=cores,
           num_slices=slice_num,
-          cluster_name=config.cluster_names[accelerator].value,
-          tpu_zone=config.tpu_zones[accelerator].value,
-          project_name=config.project_names[accelerator].value,
+          cluster=cluster,
           time_out_in_min=60,
           run_model_cmds=(
               f"JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true TPU_SLICE_BUILDER_DUMP_CHIP_FORCE=true TPU_SLICE_BUILDER_DUMP_ICI=true JAX_FORCE_TPU_INIT=true ENABLE_TPUNETD_CLIENT=true && "
               f"bash end_to_end/tpu/test_sdxl_training_loss.sh "
               f"OUTPUT_DIR={gcs_bucket.BASE_OUTPUT_DIR}/maxdiffusion/automated/{current_datetime} "
-              f"RUN_NAME={slice_num}slice-V{config.tpu_versions[accelerator]}_{cores}-maxdiffusion-jax-stable-stack-{current_datetime} "
+              f"RUN_NAME={slice_num}slice-V{cluster.device_version}_{cores}-maxdiffusion-jax-stable-stack-{current_datetime} "
               f"STEPS=20 "
               f"LOSS_THRESHOLD=100",
           ),

--- a/dags/multipod/configs/legacy_unit_test.py
+++ b/dags/multipod/configs/legacy_unit_test.py
@@ -17,26 +17,23 @@
 import datetime
 import os
 from xlml.apis import gcp_config, metric_config, task, test_config
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from base64 import b64encode
 from collections.abc import Iterable
 from dags import test_owner
 from dags.multipod.configs import common
-from dags.vm_resource import TpuVersion, Project, RuntimeVersion, ClusterName
+from dags.vm_resource import TpuVersion, Project, RuntimeVersion, XpkClusters
 
 
 def get_legacy_unit_test_config(
     script_to_copy: str,
     test_cmd: Iterable,
-    tpu_version: TpuVersion,
-    tpu_cores: int,
-    tpu_zone: str,
     time_out_in_min: int,
     test_name: str,
     test_owner: str,
     docker_image: str,
     num_slices: int = 1,
-    cluster_name: str = ClusterName.V4_8_MULTISLICE_CLUSTER.value,
-    project_name: str = Project.TPU_PROD_ENV_MULTIPOD.value,
+    cluster: XpkClusterConfig = XpkClusters.V4_8_MULTISLICE_CLUSTER,
 ) -> task.XpkTask:
   """
   Run a legacy unit test script.
@@ -45,8 +42,8 @@ def get_legacy_unit_test_config(
   in the working directory.
   """
   job_gcp_config = gcp_config.GCPConfig(
-      project_name=project_name,
-      zone=tpu_zone,
+      project_name=cluster.project,
+      zone=cluster.zone,
       dataset_name=metric_config.DatasetOption.XLML_DATASET,
   )
 
@@ -65,8 +62,8 @@ def get_legacy_unit_test_config(
 
   job_test_config = test_config.TpuGkeTest(
       test_config.Tpu(
-          version=tpu_version,
-          cores=tpu_cores,
+          version=cluster.device_version,
+          cores=cluster.core_count,
       ),
       test_name=test_name,
       run_model_cmds=run_model_cmds,
@@ -74,7 +71,7 @@ def get_legacy_unit_test_config(
       timeout=datetime.timedelta(minutes=time_out_in_min),
       task_owner=test_owner,
       num_slices=num_slices,
-      cluster_name=cluster_name,
+      cluster_name=cluster.name,
       docker_image=docker_image,
   )
 

--- a/dags/multipod/configs/pytorch_config.py
+++ b/dags/multipod/configs/pytorch_config.py
@@ -12,32 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName
+from dags.vm_resource import TpuVersion, Zone, DockerImage
 from dags.multipod.configs import gke_config
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from xlml.apis import task
 from typing import List
-
-
-# TODO(jonbolin): Refactor this to cluster definition
-CLUSTER_CONFIG = {
-    ClusterName.V4_8_MULTISLICE_CLUSTER: {
-        'tpu_version': TpuVersion.V4,
-        'tpu_cores': 8,
-        'tpu_zone': Zone.US_CENTRAL2_B.value,
-    },
-    ClusterName.V4_16_MULTISLICE_CLUSTER: {
-        'tpu_version': TpuVersion.V4,
-        'tpu_cores': 16,
-        'tpu_zone': Zone.US_CENTRAL2_B.value,
-    },
-}
 
 
 def get_nightly_pytorch_config(
     test_name: str,
     test_owner: str,
     run_commands: List[str],
-    cluster: ClusterName,
+    cluster: XpkClusterConfig,
     num_slices: int,
 ) -> task.XpkTask:
   cmds = (
@@ -45,12 +31,11 @@ def get_nightly_pytorch_config(
       *run_commands,
   )
   return gke_config.get_gke_config(
-      cluster_name=cluster.value,
+      cluster=cluster,
       test_name=test_name,
       run_model_cmds=cmds,
       num_slices=num_slices,
       docker_image=DockerImage.PYTORCH_NIGHTLY.value,
       test_owner=test_owner,
       time_out_in_min=60,
-      **CLUSTER_CONFIG[cluster],
   )

--- a/dags/multipod/legacy.py
+++ b/dags/multipod/legacy.py
@@ -17,7 +17,7 @@
 import datetime
 from airflow import models
 from dags import composer_env, gcs_bucket, test_owner
-from dags.vm_resource import TpuVersion, Zone, Project, DockerImage, ClusterName
+from dags.vm_resource import TpuVersion, Zone, Project, DockerImage, XpkClusters
 from dags.multipod.configs import legacy_unit_test, gke_config
 from dags.multipod.configs.common import SetupMode, Platform
 
@@ -63,22 +63,16 @@ with models.DAG(
       legacy_unit_test.get_legacy_unit_test_config(
           script_to_copy="gpt1-like.py",
           test_cmd=("python3 gpt1-like.py",),
-          tpu_version=TpuVersion.V4,
-          tpu_cores=16,
-          tpu_zone=Zone.US_CENTRAL2_B.value,
           time_out_in_min=60,
           test_name=f"gpt1-like-{test_mode.value}",
           docker_image=DOCKER_IMAGE[test_mode].value,
           test_owner=test_owner.JON_B,
           num_slices=n_slice,
-          cluster_name=ClusterName.V4_16_MULTISLICE_CLUSTER.value,
+          cluster=XpkClusters.V4_16_MULTISLICE_CLUSTER,
       ).run()
 
     # Tests that run MaxText end_to_end tests should follow this pattern.
     gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"maxtext-decode-{test_mode.value}",
         run_model_cmds=(
@@ -90,9 +84,6 @@ with models.DAG(
 
     # v4-8 1 slice TFLOPS test
     gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"maxtext-perf-{test_mode.value}",
         run_model_cmds=(
@@ -105,16 +96,13 @@ with models.DAG(
     # v4-16 1 and 2 slice TFLOPS test
     for n_slice in [1, 2]:
       gke_config.get_gke_config(
-          tpu_version=TpuVersion.V4,
-          tpu_cores=16,
           num_slices=n_slice,
-          tpu_zone=Zone.US_CENTRAL2_B.value,
           time_out_in_min=60,
           test_name=f"maxtext-perf-{test_mode.value}",
           run_model_cmds=(
               f"bash end_to_end/tpu/test_tflops.sh xlml {tflop_thresholds['v4-16'][str(n_slice)]} gs://maxtext-xlml gs://maxtext-xlml/dataset xlml-tflops-v4-16-{n_slice}slice-{test_mode.value}",
           ),
-          cluster_name=ClusterName.V4_16_MULTISLICE_CLUSTER.value,
+          cluster=XpkClusters.V4_16_MULTISLICE_CLUSTER,
           docker_image=DOCKER_IMAGE[test_mode].value,
           test_owner=test_owner.PRIYANKA_G,
       ).run()
@@ -125,11 +113,8 @@ with models.DAG(
     base_output_directory = f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext_determinism"
     dataset_path = gcs_bucket.MAXTEXT_DIR
     maxtext_v4_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=16,
         num_slices=slice_num,
-        cluster_name=ClusterName.V4_16_MULTISLICE_CLUSTER.value,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
+        cluster=XpkClusters.V4_16_MULTISLICE_CLUSTER,
         time_out_in_min=60,
         test_name=f"maxtext-determinism-{test_mode.value}",
         run_model_cmds=(
@@ -144,33 +129,27 @@ with models.DAG(
     # v4-16 1 slice, v4-8 1 and 2 slices shardings.py test
     for cores in [8, 16]:
       if cores == 8:
-        cluster_name = ClusterName.V4_8_MULTISLICE_CLUSTER.value
+        cluster = XpkClusters.V4_8_MULTISLICE_CLUSTER
       elif cores == 16:
-        cluster_name = ClusterName.V4_16_MULTISLICE_CLUSTER.value
+        cluster = XpkClusters.V4_16_MULTISLICE_CLUSTER
       for n_slice in [1, 2]:
         if cores == 16 and n_slice == 2:  # Skip test for 2 slice v4-16
           break
         gke_config.get_gke_config(
-            tpu_version=TpuVersion.V4,
-            tpu_cores=cores,
             num_slices=n_slice,
-            tpu_zone=Zone.US_CENTRAL2_B.value,
             time_out_in_min=60,
             test_name=f"maxtext-shardings-{test_mode.value}",
             run_model_cmds=(
                 f"python pedagogical_examples/shardings.py --dcn_data_parallelism {n_slice} --ici_fsdp_parallelism {cores//2}",
             ),
-            cluster_name=cluster_name,
+            cluster=cluster,
             docker_image=DOCKER_IMAGE[test_mode].value,
             test_owner=test_owner.MOHIT_K,
         ).run()
 
   # v4-8 2 slices checkpoint resharding test
   gke_config.get_gke_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=2,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=f"maxtext-checkpoint-reshard-{SetupMode.STABLE.value}",
       run_model_cmds=(

--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -18,7 +18,7 @@ A DAG to run MaxText checkpointing tests.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner, gcs_bucket
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName
+from dags.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
@@ -44,10 +44,10 @@ with models.DAG(
       "v4-8": [1],
       "v4-16": [1, 2],
   }
-  cluster_names = {
+  clusters = {
       # accelerator: cluster name
-      "v4-8": ClusterName.V4_8_MULTISLICE_CLUSTER,
-      "v4-16": ClusterName.V4_16_MULTISLICE_CLUSTER,
+      "v4-8": XpkClusters.V4_8_MULTISLICE_CLUSTER,
+      "v4-16": XpkClusters.V4_16_MULTISLICE_CLUSTER,
   }
 
   for mode, image in docker_images:
@@ -60,11 +60,8 @@ with models.DAG(
             f" {base_output_directory} {dataset_path} true",
         )
         maxtext_v4_configs_test = gke_config.get_gke_config(
-            tpu_version=TpuVersion.V4,
-            tpu_cores=cores,
             num_slices=slice_num,
-            cluster_name=cluster_names[accelerator].value,
-            tpu_zone=Zone.US_CENTRAL2_B.value,
+            cluster=clusters[accelerator],
             time_out_in_min=60,
             test_name=f"maxtext-checkpointing-{mode.value}",
             run_model_cmds=command,

--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -18,7 +18,7 @@ A DAG to run AOT compilation tests for MaxText model configs.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import GpuVersion, TpuVersion, Zone, DockerImage, ClusterName
+from dags.vm_resource import GpuVersion, TpuVersion, Zone, DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
@@ -66,9 +66,6 @@ with models.DAG(
 
   for mode, image in docker_images:
     maxtext_v4_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"maxtext-aot-v4-{mode.value}",
         run_model_cmds=run_model_cmds_dict["v4"],
@@ -77,9 +74,6 @@ with models.DAG(
     ).run()
 
     maxtext_v5e_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"maxtext-aot-v5e-{mode.value}",
         run_model_cmds=run_model_cmds_dict["v5e"],
@@ -88,9 +82,6 @@ with models.DAG(
     ).run()
 
     maxtext_v5p_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"maxtext-aot-v5p-{mode.value}",
         run_model_cmds=run_model_cmds_dict["v5p"],
@@ -107,13 +98,11 @@ with models.DAG(
   # GPU AoT tests
   cmd = f"bash MaxText/configs/a3/llama_2_7b/16vm.sh EXECUTABLE=train_compile.py M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=16"
   stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-      accelerator_type=GpuVersion.XPK_H100,
-      gpu_zone=Zone.US_CENTRAL1_C.value,
       time_out_in_min=300,
       test_name=f"maxtext-aot-a3-stable",
       run_model_cmds=(cmd,),
       num_slices=1,
-      cluster_name=ClusterName.A3_CLUSTER.value,
+      cluster=XpkClusters.A3_CLUSTER,
       docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
       test_owner=test_owner.JON_B,
   ).run()

--- a/dags/multipod/maxtext_configs_aot_hybridsim.py
+++ b/dags/multipod/maxtext_configs_aot_hybridsim.py
@@ -18,7 +18,7 @@ A DAG to run AOT compilation and HybridSim tests for MaxText model configs on TP
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName, Project
+from dags.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters, Project
 from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 from airflow.utils.task_group import TaskGroup
@@ -44,19 +44,8 @@ with models.DAG(
   }
   num_slices = [1, 2, 4, 8]
   clusters = {
-      # accelerator: [(cluster_name, cluster_zone, cluster_project, num_cores)],
-      TpuVersion.V4: (
-          ClusterName.V4_8_MULTISLICE_CLUSTER.value,
-          Zone.US_CENTRAL2_B.value,
-          Project.TPU_PROD_ENV_MULTIPOD.value,
-          8,
-      ),
-      TpuVersion.V5E: (
-          ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
-          Zone.US_WEST4_B.value,
-          Project.TPU_PROD_ENV_MULTIPOD.value,
-          256,
-      ),
+      TpuVersion.V4: XpkClusters.V4_8_MULTISLICE_CLUSTER,
+      TpuVersion.V5E: XpkClusters.V5E_256_US_WEST_4_MULTISLICE_CLUSTER,
   }
   v5e_alt = "5e"
 
@@ -84,9 +73,6 @@ with models.DAG(
               "gsutil -m cp -r /tmp/xla_dump/ ${GCS_OUTPUT}",
           )
           maxtext_aot = gke_config.get_gke_config(
-              tpu_version=TpuVersion.V4,
-              tpu_cores=8,
-              tpu_zone=Zone.US_CENTRAL2_B.value,
               time_out_in_min=240,
               test_name=f"maxtext-{model_size}-{n}xv{tpu.value}-{num_cores}-aot",
               run_model_cmds=aot_cmd,
@@ -95,7 +81,7 @@ with models.DAG(
           ).run(gcs_location=shared_gcs_location)
 
           # Run HybridSim workload: read HLO from GCS, generate estimated step time
-          cluster_name, zone, project_name, cores = clusters[tpu]
+          cluster = clusters[tpu]
           chip_config = "default" if tpu == TpuVersion.V5E else "megacore"
           hybridsim_cmd = (
               "gsutil cp gs://cloud-hybridsim-prod/run_hybridsim.sh .",
@@ -108,11 +94,7 @@ with models.DAG(
               use_runtime_generated_gcs_folder=True,
           )
           maxtext_hybridsim = gke_config.get_gke_config(
-              tpu_version=tpu,
-              tpu_cores=cores,
-              tpu_zone=zone,
-              project_name=project_name,
-              cluster_name=cluster_name,
+              cluster=cluster,
               time_out_in_min=240,
               test_name=f"maxtext-{model_size}-{n}xv{tpu.value}-{num_cores}-hybridsim",
               run_model_cmds=hybridsim_cmd,

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -18,7 +18,7 @@ A DAG to run MaxText convergence tests for both bf16 and int8.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner, gcs_bucket
-from dags.vm_resource import ClusterName, DockerImage, Project, TpuVersion, Zone
+from dags.vm_resource import XpkClusters, DockerImage, Project, TpuVersion, Zone
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 from xlml.apis import gcp_config, metric_config, task, test_config
@@ -59,11 +59,7 @@ with models.DAG(
 
   for test_name, run_command in convergence_tests.items():
     maxtext_v4_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=128,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
-        cluster_name=ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-        project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+        cluster=XpkClusters.V4_128_MULTISLICE_CLUSTER,
         time_out_in_min=300,
         test_name=test_name,
         run_model_cmds=run_command,

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -18,7 +18,7 @@
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import ClusterName, CpuVersion, DockerImage, GpuVersion, Project, TpuVersion, Zone
+from dags.vm_resource import XpkClusters, CpuVersion, DockerImage, GpuVersion, Project, TpuVersion, Zone
 from dags.multipod.configs import gke_config
 from airflow.utils.task_group import TaskGroup
 from xlml.utils import name_format
@@ -114,9 +114,6 @@ with models.DAG(
 
   for model, test_script in test_models_tpu.items():
     stable_tpu = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"{test_name_prefix}-stable-{model}",
         run_model_cmds=(f"bash end_to_end/{test_script}.sh",),
@@ -124,9 +121,6 @@ with models.DAG(
         test_owner=test_owner.JON_B,
     ).run()
     nightly_tpu = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"{test_name_prefix}-nightly-{model}",
         run_model_cmds=(f"bash end_to_end/{test_script}.sh",),
@@ -137,46 +131,38 @@ with models.DAG(
 
   for model, (test_script, nnodes) in test_models_gpu.items():
     pinned_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        accelerator_type=GpuVersion.XPK_H100,
-        gpu_zone=Zone.US_CENTRAL1_C.value,
         time_out_in_min=300,
         test_name=f"{test_name_prefix}-pinned-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
-        cluster_name=ClusterName.A3_CLUSTER.value,
+        cluster=XpkClusters.A3_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
         test_owner=test_owner.NINA_C,
     ).run()
     stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        accelerator_type=GpuVersion.XPK_H100,
-        gpu_zone=Zone.US_CENTRAL1_C.value,
         time_out_in_min=300,
         test_name=f"{test_name_prefix}-stable-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
-        cluster_name=ClusterName.A3_CLUSTER.value,
+        cluster=XpkClusters.A3_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
         test_owner=test_owner.NINA_C,
     ).run()
     pinned_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        accelerator_type=GpuVersion.XPK_H100_MEGA,
-        gpu_zone=Zone.AUSTRALIA_SOUTHEAST1_C.value,
         time_out_in_min=300,
         test_name=f"{test_name_prefix}-pinned-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
-        cluster_name=ClusterName.A3PLUS_CLUSTER.value,
+        cluster=XpkClusters.A3PLUS_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
         test_owner=test_owner.NINA_C,
     ).run()
     stable_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        accelerator_type=GpuVersion.XPK_H100_MEGA,
-        gpu_zone=Zone.AUSTRALIA_SOUTHEAST1_C.value,
         time_out_in_min=300,
         test_name=f"{test_name_prefix}-stable-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
-        cluster_name=ClusterName.A3PLUS_CLUSTER.value,
+        cluster=XpkClusters.A3PLUS_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
         test_owner=test_owner.NINA_C,
     ).run()
@@ -186,70 +172,48 @@ with models.DAG(
       "gemma-7b": [
           {
               "script_name": "tpu/gemma/7b/1_test_gemma",
-              "cpu_device_type": CpuVersion.N2_STANDARD,
-              "cpu_zone": Zone.US_CENTRAL1_B.value,
-              "cluster_name": ClusterName.CPU_N2_STANDARD_64.value,
+              "cluster": XpkClusters.CPU_N2_STANDARD_64,
               "time_out_in_min": 60,
           },
           {
               "script_name": "tpu/gemma/7b/2_test_gemma",
-              "tpu_version": TpuVersion.V4,
-              "tpu_cores": 16,
-              "cluster_name": ClusterName.V4_16_MULTISLICE_CLUSTER.value,
-              "tpu_zone": Zone.US_CENTRAL2_B.value,
+              "cluster": XpkClusters.V4_16_MULTISLICE_CLUSTER,
               "time_out_in_min": 60,
           },
       ],
       "mixtral-8x7b": [
           {
               "script_name": "tpu/mixtral/8x7b/1_test_mixtral",
-              "cpu_device_type": CpuVersion.M1_MEGAMEM,
-              "cpu_zone": Zone.US_CENTRAL1_B.value,
-              "cluster_name": ClusterName.CPU_M1_MEGAMEM_96.value,
+              "cluster": XpkClusters.CPU_M1_MEGAMEM_96,
               "time_out_in_min": 240,
           },
           {
               "script_name": "tpu/mixtral/8x7b/2_test_mixtral",
-              "tpu_version": TpuVersion.V4,
-              "tpu_cores": 128,
-              "cluster_name": ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-              "project_name": Project.CLOUD_TPU_MULTIPOD_DEV.value,
-              "tpu_zone": Zone.US_CENTRAL2_B.value,
+              "cluster": XpkClusters.V4_128_MULTISLICE_CLUSTER,
               "time_out_in_min": 60,
           },
       ],
       "mixtral-8x22b": [
           {
               "script_name": "tpu/mixtral/8x22b/1_test_mixtral",
-              "cpu_device_type": CpuVersion.M1_MEGAMEM,
-              "cpu_zone": Zone.US_CENTRAL1_B.value,
-              "cluster_name": ClusterName.CPU_M1_MEGAMEM_96.value,
+              "cluster": XpkClusters.CPU_M1_MEGAMEM_96,
               "time_out_in_min": 360,
           },
           {
               "script_name": "tpu/mixtral/8x22b/2_test_mixtral",
-              "tpu_version": TpuVersion.V5E,
-              "tpu_cores": 256,
-              "cluster_name": ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
-              "tpu_zone": Zone.US_WEST4_B.value,
+              "cluster": XpkClusters.V5E_256_US_WEST_4_MULTISLICE_CLUSTER,
               "time_out_in_min": 60,
           },
       ],
       "llama2-70b": [
           {
               "script_name": "tpu/llama2/70b/1_test_llama2_70b",
-              "cpu_device_type": CpuVersion.M1_MEGAMEM,
-              "cpu_zone": Zone.US_CENTRAL1_B.value,
-              "cluster_name": ClusterName.CPU_M1_MEGAMEM_96.value,
+              "cluster": XpkClusters.CPU_M1_MEGAMEM_96,
               "time_out_in_min": 360,
           },
           {
               "script_name": "tpu/llama2/70b/2_test_llama2_70b",
-              "tpu_version": TpuVersion.V4,
-              "tpu_cores": 128,
-              "cluster_name": ClusterName.V4_128_MULTISLICE_CLUSTER.value,
-              "project_name": Project.CLOUD_TPU_MULTIPOD_DEV.value,
-              "tpu_zone": Zone.US_CENTRAL2_B.value,
+              "cluster": XpkClusters.V4_128_MULTISLICE_CLUSTER,
               "time_out_in_min": 60,
           },
       ],
@@ -268,21 +232,16 @@ with models.DAG(
           test_group_id,
       )
       stable_cpu = gke_config.get_maxtext_cpu_end_to_end_gke_config(
-          device_type=test_scripts_details[0]["cpu_device_type"],
-          cpu_zone=test_scripts_details[0]["cpu_zone"],
           time_out_in_min=test_scripts_details[0]["time_out_in_min"],
           test_name=f"{test_name_prefix}-stable-{model}",
           run_model_cmds=(
               f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash end_to_end/{test_scripts_details[0]['script_name']}.sh",
           ),
-          cluster_name=test_scripts_details[0]["cluster_name"],
+          cluster=test_scripts_details[0]["cluster"],
           docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
           test_owner=test_owner.ANISHA_M,
       ).run(gcs_location=shared_gcs_location)
       stable_tpu = gke_config.get_gke_config(
-          tpu_version=test_scripts_details[1]["tpu_version"],
-          tpu_cores=test_scripts_details[1]["tpu_cores"],
-          tpu_zone=test_scripts_details[1]["tpu_zone"],
           time_out_in_min=test_scripts_details[1]["time_out_in_min"],
           test_name=f"{test_name_prefix}-stable-{model}",
           run_model_cmds=(
@@ -290,7 +249,7 @@ with models.DAG(
           ),
           docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
           test_owner=test_owner.ANISHA_M,
-          cluster_name=test_scripts_details[1]["cluster_name"],
+          cluster=test_scripts_details[1]["cluster"],
       ).run(gcs_location=shared_gcs_location)
 
     test_group_id = "chained_tests" + "_" + model + "_" + "nightly"
@@ -303,21 +262,16 @@ with models.DAG(
           test_group_id,
       )
       nightly_cpu = gke_config.get_maxtext_cpu_end_to_end_gke_config(
-          device_type=test_scripts_details[0]["cpu_device_type"],
-          cpu_zone=test_scripts_details[0]["cpu_zone"],
           time_out_in_min=test_scripts_details[0]["time_out_in_min"],
           test_name=f"{test_name_prefix}-nightly-{model}",
           run_model_cmds=(
               f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash end_to_end/{test_scripts_details[0]['script_name']}.sh",
           ),
-          cluster_name=test_scripts_details[0]["cluster_name"],
+          cluster=test_scripts_details[0]["cluster"],
           docker_image=DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
           test_owner=test_owner.ANISHA_M,
       ).run(gcs_location=shared_gcs_location)
       nightly_tpu = gke_config.get_gke_config(
-          tpu_version=test_scripts_details[1]["tpu_version"],
-          tpu_cores=test_scripts_details[1]["tpu_cores"],
-          tpu_zone=test_scripts_details[1]["tpu_zone"],
           time_out_in_min=test_scripts_details[1]["time_out_in_min"],
           test_name=f"{test_name_prefix}-nightly-{model}",
           run_model_cmds=(
@@ -325,7 +279,7 @@ with models.DAG(
           ),
           docker_image=DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
           test_owner=test_owner.ANISHA_M,
-          cluster_name=test_scripts_details[1]["cluster_name"],
+          cluster=test_scripts_details[1]["cluster"],
       ).run(gcs_location=shared_gcs_location)
 
     test_group_id = "chained_tests" + "_" + model + "_" + "jax_stable_stack"

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -56,9 +56,6 @@ with models.DAG(
         "python3 MaxText/tests/profiler_test.py",
     )
     maxtext_v4_configs_test = gke_config.get_gke_config(
-        tpu_version=TpuVersion.V4,
-        tpu_cores=8,
-        tpu_zone=Zone.US_CENTRAL2_B.value,
         time_out_in_min=60,
         test_name=f"maxtext-profiling-{mode.value}",
         run_model_cmds=profiling_cmds,

--- a/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
+++ b/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
@@ -18,7 +18,7 @@ A DAG to test MaxText Automatic Profile Upload to Vertex AI Tensorboard.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner, gcs_bucket
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName
+from dags.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
@@ -46,15 +46,14 @@ with models.DAG(
       "v4-8": [1],
       "v4-16": [1, 2],
   }
-  cluster_names = {
+  clusters = {
       # accelerator: cluster name
-      "v4-8": ClusterName.V4_8_MULTISLICE_CLUSTER,
-      "v4-16": ClusterName.V4_16_MULTISLICE_CLUSTER,
+      "v4-8": XpkClusters.V4_8_MULTISLICE_CLUSTER,
+      "v4-16": XpkClusters.V4_16_MULTISLICE_CLUSTER,
   }
 
   for mode, image in docker_images:
     for accelerator, slices in test_configs.items():
-      cores = accelerator.rsplit("-", maxsplit=1)[-1]
       for slice_num in slices:
         current_time = datetime.datetime.now()
         current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
@@ -66,11 +65,8 @@ with models.DAG(
             "gsutil ls gs://cloud-ai-platform-*/tensorboard-*/$EXPERIMENT_NAME",
         )
         profiling_in_vertex_ai_tb_test = gke_config.get_gke_config(
-            tpu_version=TpuVersion.V4,
-            tpu_cores=cores,
             num_slices=slice_num,
-            cluster_name=cluster_names[accelerator].value,
-            tpu_zone=Zone.US_CENTRAL2_B.value,
+            cluster=clusters[accelerator],
             time_out_in_min=240,
             test_name=f"profiling-vertex-ai-tensorboard-{mode.value}",
             run_model_cmds=profiling_in_vertex_ai_tb_cmds,

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -18,7 +18,7 @@ A DAG to run perf tests for MaxText model configs on v5e.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, Project, ClusterName, DockerImage
+from dags.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config
@@ -50,16 +50,12 @@ with models.DAG(
       maxtext_sweep_gke_test = (
           maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
               test_owner=test_owner.RAYMOND_Z,
-              project_name=Project.TPU_PROD_ENV_LARGE_ADHOC.value,
               dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
               composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
               dataset_name=metric_config.DatasetOption.XLML_DATASET,
-              cluster_name=ClusterName.BODABORG_V6E_256.value,
-              tpu_zone=Zone.US_CENTRAL2_B.value,
+              cluster=XpkClusters.BODABORG_V6E_256,
               time_out_in_min=360,
               base_output_directory=BASE_OUTPUT_DIRECTORY,
-              tpu_version=TpuVersion.TRILLIUM,
-              tpu_cores=256,
               num_slices=[1, 2],
               docker_image=image.value,
               run_name_prefix=f"maxtext-{model}-{mode.value}",

--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -18,7 +18,7 @@ A DAG to run perf tests for MaxText model configs on v5e.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, Project, ClusterName, DockerImage
+from dags.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config
@@ -54,23 +54,21 @@ with models.DAG(
       base_run_model_cmds = [
           f"bash MaxText/configs/v5e/{model}.sh OUTPUT_PATH={BASE_OUTPUT_DIRECTORY} DATASET_PATH=gs://max-datasets-rogue",
       ]
-      maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
-          test_owner=test_owner.RAYMOND_Z,
-          project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
-          dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          dataset_name=metric_config.DatasetOption.XLML_DATASET,
-          cluster_name=ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
-          tpu_zone=Zone.US_WEST4_B.value,
-          time_out_in_min=360,
-          base_output_directory=BASE_OUTPUT_DIRECTORY,
-          tpu_version=TpuVersion.V5E,
-          tpu_cores=256,
-          num_slices=[1, 2],
-          docker_image=image.value,
-          run_name_prefix=f"maxtext-{model}-{mode.value}",
-          base_run_model_cmds=base_run_model_cmds,
-          sweep_params=QUANTIZATION_SWEEP,
+      maxtext_sweep_gke_test = (
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              test_owner=test_owner.RAYMOND_Z,
+              dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              dataset_name=metric_config.DatasetOption.XLML_DATASET,
+              cluster=XpkClusters.V5E_256_US_WEST_4_MULTISLICE_CLUSTER,
+              time_out_in_min=360,
+              base_output_directory=BASE_OUTPUT_DIRECTORY,
+              num_slices=[1, 2],
+              docker_image=image.value,
+              run_name_prefix=f"maxtext-{model}-{mode.value}",
+              base_run_model_cmds=base_run_model_cmds,
+              sweep_params=QUANTIZATION_SWEEP,
+          )
       )
 
       chain_num = 4
@@ -97,23 +95,21 @@ with models.DAG(
       base_run_model_cmds = [
           f"bash MaxText/configs/v5e/{model}.sh OUTPUT_PATH={BASE_OUTPUT_DIRECTORY} DATASET_PATH=gs://max-datasets-rogue RUN_PREFLIGHT=false",
       ]
-      maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
-          test_owner=test_owner.RAYMOND_Z,
-          project_name=Project.TPU_PROD_ENV_MULTIPOD.value,
-          dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          dataset_name=metric_config.DatasetOption.XLML_DATASET,
-          cluster_name=ClusterName.V5E_256_US_WEST_4_MULTISLICE_CLUSTER.value,
-          tpu_zone=Zone.US_WEST4_B.value,
-          time_out_in_min=360,
-          base_output_directory=BASE_OUTPUT_DIRECTORY,
-          tpu_version=TpuVersion.V5E,
-          tpu_cores=256,
-          num_slices=[1, 2],
-          docker_image=image.value,
-          run_name_prefix=f"p-maxtext-{model}-{mode.value}",
-          base_run_model_cmds=base_run_model_cmds,
-          sweep_params=QUANTIZATION_SWEEP,
+      maxtext_sweep_gke_test = (
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              test_owner=test_owner.RAYMOND_Z,
+              dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              dataset_name=metric_config.DatasetOption.XLML_DATASET,
+              cluster=XpkClusters.V5E_256_US_WEST_4_MULTISLICE_CLUSTER,
+              time_out_in_min=360,
+              base_output_directory=BASE_OUTPUT_DIRECTORY,
+              num_slices=[1, 2],
+              docker_image=image.value,
+              run_name_prefix=f"p-maxtext-{model}-{mode.value}",
+              base_run_model_cmds=base_run_model_cmds,
+              sweep_params=QUANTIZATION_SWEEP,
+          )
       )
 
       chain_num = 4

--- a/dags/multipod/mxla_gpt3_6b_nightly_gke.py
+++ b/dags/multipod/mxla_gpt3_6b_nightly_gke.py
@@ -18,7 +18,7 @@ A DAG to run MXLA MaxText tests.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName, Project
+from dags.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters, Project
 from dags.multipod.configs import gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
@@ -36,9 +36,6 @@ with models.DAG(
   default_gpt3_6b_test_name = "mxla-gpt3-6b-nightly-gke"
 
   gpt3_6b_nightly_1slice_v4_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
@@ -46,10 +43,7 @@ with models.DAG(
   ).run()
 
   gpt3_6b_nightly_2slice_v4_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=2,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
@@ -57,10 +51,7 @@ with models.DAG(
   ).run()
 
   gpt3_6b_nightly_4slice_v4_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=4,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
@@ -68,10 +59,7 @@ with models.DAG(
   ).run()
 
   gpt3_6b_nightly_8slice_v4_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
@@ -79,54 +67,38 @@ with models.DAG(
   ).run()
 
   gpt3_6b_nightly_1slice_v5p_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   gpt3_6b_nightly_2slice_v5p_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
       num_slices=2,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   gpt3_6b_nightly_4slice_v5p_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
       num_slices=4,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   gpt3_6b_nightly_8slice_v5p_8 = gke_config.get_gke_gpt3_6b_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
       num_slices=8,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_gpt3_6b_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   (

--- a/dags/multipod/mxla_maxtext_nightly_gke.py
+++ b/dags/multipod/mxla_maxtext_nightly_gke.py
@@ -18,7 +18,7 @@ A DAG to run MXLA MaxText tests.
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName, Project
+from dags.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters, Project
 from dags.multipod.configs import gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
@@ -36,9 +36,6 @@ with models.DAG(
   default_test_name = "mxla-maxtext-nightly-gke"
 
   maxtext_nightly_1slice_v4_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
@@ -46,10 +43,7 @@ with models.DAG(
   ).run()
 
   maxtext_nightly_2slice_v4_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=2,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
@@ -57,10 +51,7 @@ with models.DAG(
   ).run()
 
   maxtext_nightly_4slice_v4_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=4,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
@@ -68,10 +59,7 @@ with models.DAG(
   ).run()
 
   maxtext_nightly_8slice_v4_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V4,
-      tpu_cores=8,
       num_slices=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
@@ -79,54 +67,38 @@ with models.DAG(
   ).run()
 
   maxtext_nightly_1slice_v5p_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   maxtext_nightly_2slice_v5p_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
       num_slices=2,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   maxtext_nightly_4slice_v5p_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
       num_slices=4,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   maxtext_nightly_8slice_v5p_8 = gke_config.get_gke_maxtext_nightly_config(
-      tpu_version=TpuVersion.V5P,
-      tpu_cores=8,
       num_slices=8,
-      cluster_name=ClusterName.V5P_8_MULTISLICE_CLUSTER.value,
-      tpu_zone=Zone.US_EAST5_A.value,
+      cluster=XpkClusters.V5P_8_MULTISLICE_CLUSTER,
       time_out_in_min=60,
       test_name=default_test_name,
       docker_image=jax_nightly_image.value,
       test_owner=test_owner.TONY_C,
-      project_name=Project.CLOUD_TPU_MULTIPOD_DEV.value,
   ).run()
 
   (

--- a/dags/multipod/pytorch.py
+++ b/dags/multipod/pytorch.py
@@ -18,7 +18,7 @@ A DAG to run PyTorch multislice tests
 import datetime
 from airflow import models
 from dags import composer_env, test_owner
-from dags.vm_resource import TpuVersion, Zone, DockerImage, ClusterName
+from dags.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters
 from dags.multipod.configs import pytorch_config
 from xlml.apis import metric_config
 
@@ -33,8 +33,8 @@ with models.DAG(
     catchup=False,
     concurrency=2,
 ) as dag:
-  v4_8 = ClusterName.V4_8_MULTISLICE_CLUSTER
-  v4_16 = ClusterName.V4_16_MULTISLICE_CLUSTER
+  v4_8 = XpkClusters.V4_8_MULTISLICE_CLUSTER
+  v4_16 = XpkClusters.V4_16_MULTISLICE_CLUSTER
 
   for num_slices, cluster in [(1, v4_8), (2, v4_8), (1, v4_16)]:
     ici_chips = 4 if cluster == v4_8 else 8

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -16,6 +16,7 @@
 
 import datetime
 import enum
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 
 
 V5_NETWORKS_PREFIX = "projects/tpu-prod-env-automated"
@@ -157,25 +158,86 @@ class RuntimeVersion(enum.Enum):
   V2_ALPHA_TPUV5 = "v2-alpha-tpuv5"
 
 
-class ClusterName(enum.Enum):
-  """Common XPK cluster names."""
+class XpkClusters:
+  """Common XPK cluster configs."""
 
-  V4_8_CLUSTER = "mas-v4-8"
-  V4_32_CLUSTER = "mas-v4-32"
-  V5E_4_CLUSTER = "mas-v5e-4"
-  V5E_16_CLUSTER = "mas-v5e-16"
-  V4_8_MULTISLICE_CLUSTER = "v4-8-maxtext"
-  V4_16_MULTISLICE_CLUSTER = "v4-16-maxtext"
-  V4_128_MULTISLICE_CLUSTER = "v4-128-bodaborg-us-central2-b"
-  V5P_8_MULTISLICE_CLUSTER = "v5p-8-bodaborg-us-east5-a"
-  V5E_16_MULTISLICE_CLUSTER = "v5e-16-bodaborg"
-  V5E_256_MULTISLICE_CLUSTER = "v5e-256-bodaborg"
-  V5E_256_US_WEST_4_MULTISLICE_CLUSTER = "v5e-256-bodaborg-us-west4"
-  BODABORG_V6E_256 = "bodaborg-v6e-256"
-  A3_CLUSTER = "maxtext-a3-20n"
-  A3PLUS_CLUSTER = "a3plus-benchmark"
-  CPU_M1_MEGAMEM_96 = "m1-megamem-96-shared"
-  CPU_N2_STANDARD_64 = "shared-n2-standard-64"
+  V4_8_CLUSTER = XpkClusterConfig(
+      name="mas-v4-8",
+      device_version=TpuVersion.V4,
+      core_count=8,
+      project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+      zone=Zone.US_CENTRAL2_B.value,
+  )
+  V4_8_MULTISLICE_CLUSTER = XpkClusterConfig(
+      name="v4-8-maxtext",
+      device_version=TpuVersion.V4,
+      core_count=8,
+      project=Project.TPU_PROD_ENV_MULTIPOD.value,
+      zone=Zone.US_CENTRAL2_B.value,
+  )
+  V4_16_MULTISLICE_CLUSTER = XpkClusterConfig(
+      name="v4-16-maxtext",
+      device_version=TpuVersion.V4,
+      core_count=16,
+      project=Project.TPU_PROD_ENV_MULTIPOD.value,
+      zone=Zone.US_CENTRAL2_B.value,
+  )
+  V4_128_MULTISLICE_CLUSTER = XpkClusterConfig(
+      name="v4-128-bodaborg-us-central2-b",
+      device_version=TpuVersion.V4,
+      core_count=128,
+      project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+      zone=Zone.US_CENTRAL2_B.value,
+  )
+  V5P_8_MULTISLICE_CLUSTER = XpkClusterConfig(
+      name="v5p-8-bodaborg-us-east5-a",
+      device_version=TpuVersion.V5P,
+      core_count=8,
+      project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+      zone=Zone.US_EAST5_A.value,
+  )
+  V5E_256_US_WEST_4_MULTISLICE_CLUSTER = XpkClusterConfig(
+      name="v5e-256-bodaborg-us-west4",
+      device_version=TpuVersion.V5P,
+      core_count=256,
+      project=Project.TPU_PROD_ENV_MULTIPOD.value,
+      zone=Zone.US_WEST4_B.value,
+  )
+  BODABORG_V6E_256 = XpkClusterConfig(
+      name="bodaborg-v6e-256",
+      device_version=TpuVersion.TRILLIUM,
+      core_count=256,
+      project=Project.TPU_PROD_ENV_LARGE_ADHOC.value,
+      zone=Zone.US_CENTRAL2_B.value,
+  )
+  A3_CLUSTER = XpkClusterConfig(
+      name="maxtext-a3-20n",
+      device_version=GpuVersion.XPK_H100,
+      core_count=8,
+      project=Project.SUPERCOMPUTER_TESTING.value,
+      zone=Zone.US_CENTRAL1_C.value,
+  )
+  A3PLUS_CLUSTER = XpkClusterConfig(
+      name="a3plus-benchmark",
+      device_version=GpuVersion.XPK_H100_MEGA,
+      core_count=8,
+      project=Project.SUPERCOMPUTER_TESTING.value,
+      zone=Zone.AUSTRALIA_SOUTHEAST1_C.value,
+  )
+  CPU_M1_MEGAMEM_96 = XpkClusterConfig(
+      name="m1-megamem-96-shared",
+      device_version=CpuVersion.M1_MEGAMEM,
+      core_count=96,
+      project=Project.TPU_PROD_ENV_MULTIPOD.value,
+      zone=Zone.US_CENTRAL1_B.value,
+  )
+  CPU_N2_STANDARD_64 = XpkClusterConfig(
+      name="shared-n2-standard-64",
+      device_version=CpuVersion.N2_STANDARD,
+      core_count=64,
+      project=Project.TPU_PROD_ENV_MULTIPOD.value,
+      zone=Zone.US_CENTRAL1_B.value,
+  )
 
 
 class DockerImage(enum.Enum):

--- a/xlml/apis/xpk_cluster_config.py
+++ b/xlml/apis/xpk_cluster_config.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config file for XPK cluster."""
+
+import dataclasses
+from typing import Union
+
+
+@dataclasses.dataclass
+class XpkClusterConfig:
+  """Defines common XPK cluster attributes.
+
+  Attributes:
+    name: Name of the cluster
+    device_version: Device version of the cluster
+    core_count: Core count of the cluster
+    project: Project of the cluster
+    zone: Zone of the cluster
+  """
+
+  name: str
+  device_version: Union['GpuVersion', 'CpuVersion', 'TpuVersion']
+  core_count: int
+  project: str
+  zone: str


### PR DESCRIPTION
# Description

It is challenging and error-prone to update an XPK cluster. In https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/387, the cluster was renamed and moved regions, and subtle issues like applying the new zone to every test config were missed.

Some details are constant for each cluster, and we shouldn't need to pass them around in parallel. This change creates `XpkClusterConfig` to track the cluster config, and the single object can be used to define XPK tests.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

- Deployed to development env: https://fc137785b6c943a4af82d0671bf0ebe5-dot-us-central1.composer.googleusercontent.com/home
- Ran an example DAG: https://screenshot.googleplex.com/3dFCH5dZzWynuRb

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.