### PR TITLE
make mantaray_gcs_bucket a param

### DIFF
--- a/xlml/utils/mantaray.py
+++ b/xlml/utils/mantaray.py
@@ -36,11 +36,13 @@ def load_file_from_gcs(gs_file_path):
 
 
 @task
-def run_workload(workload_file_name: str):
+def run_workload(
+    workload_file_name: str, mantaray_gcs_bucket: str = MANTARAY_G3_GS_BUCKET
+):
   with tempfile.TemporaryDirectory() as tmpdir:
     cmds = (
         f"cd {tmpdir}",
-        f"gsutil -m cp -r {MANTARAY_G3_GS_BUCKET} .",
+        f"gsutil -m cp -r {mantaray_gcs_bucket} .",
         "sudo apt-get update && sudo apt-get install -y rsync",  # Install rsync
         f"cd mantaray && pip install -e .",
         f"python xlml_jobs/{workload_file_name}",  # Run the workload


### PR DESCRIPTION

This allows users to pass in their personal gs bucket path when creating the Mantaray XLML job, during development. E.g. 

```
# Run this in the DEV environment

# First run gsutil cp cmcs-benchmark-automation/mantaray gs://BUCKET_NAME
MANTARAY_GCS_BUCKET="gs://BUCKET_NAME" # your own gs bucket hosting mantaray code
TEST_MANTARAY_JOB="mantaray_job.py" # Your job file inside mantaray/xlml_jobs
with models.DAG(
    dag_id=TEST_MANTARAY_JOB,
    schedule=None,
    tags=["mantaray"],
    start_date=datetime.datetime(2024, 4, 22),
    catchup=False,
) as dag:
  run_workload = mantaray.run_workload(
      workload_file_name=TEST_MANTARAY_JOB,
      mantaray_gcs_bucket=MANTARAY_GCS_BUCKET,
  )
run_workload
# You will see the DAG in the Airflow UI
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.