### PR TITLE
Create mlcompass_maxtext_gke dag

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -9,3 +9,4 @@ jsonlines
 tensorflow-cpu
 kubernetes
 pyarrow
+apache-airflow-providers-google

--- a/dags/mlcompass/maxtext_gke.py
+++ b/dags/mlcompass/maxtext_gke.py
@@ -19,8 +19,8 @@ gcloud composer environments run ml-automation-solutions \
   --project=cloud-ml-auto-solutions \
   --location=us-central1 dags trigger \
   -- \
-  mlcompass_maxtext_single_host \
-  --conf={\\\"uuid\\\":\\\"abc\\\"}
+  mlcompass_maxtext_gke \
+  --conf={\\\"uuid\\\":\\\"abc\\\"} 70
 """
 
 import datetime
@@ -34,7 +34,7 @@ from xlml.apis import gcp_config, metric_config, task as xlml_task, test_config
 import json
 
 
-def get_single_host_config(
+def get_config_gke(
     docker_image: str,
     model_name: str,
     base_output_directory: str,
@@ -60,7 +60,6 @@ def get_single_host_config(
       ),
       test_name="maxtext",
       run_model_cmds=[
-          "bash simple_jax_test.sh",
           f"source benchmark_run.sh;run {model_name} {base_output_directory}",
       ],
       set_up_cmds=None,
@@ -77,7 +76,7 @@ def get_single_host_config(
 
 
 with models.DAG(
-    dag_id="mlcompass_maxtext_single_host",
+    dag_id="mlcompass_maxtext_gke",
     schedule=None,
     tags=["mlcompass", "maxtext"],
     start_date=datetime.datetime(2024, 9, 1),
@@ -121,8 +120,8 @@ with models.DAG(
   model_name_arg = get_model_name(xlml_state)
   base_output_directory_arg = get_base_output_directory(xlml_state)
 
-  default_benchmark = get_single_host_config(
+  default_benchmark = get_config_gke(
       docker_image=docker_image_path,
       model_name=model_name_arg,
       base_output_directory=base_output_directory_arg,
-  ).run()
+  ).run(skip_post_process=True)

--- a/dags/mlcompass/maxtext_single_host.py
+++ b/dags/mlcompass/maxtext_single_host.py
@@ -1,0 +1,114 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Simple DAG.
+
+Usage:
+gcloud composer environments run ml-automation-solutions \
+  --project=cloud-ml-auto-solutions \
+  --location=us-central1 dags trigger \
+  -- \
+  mlcompass_maxtext_single_host \
+  --conf={\\\"uuid\\\":\\\"abc\\\"}
+51
+"""
+
+import datetime
+from airflow import models
+from airflow.decorators import task
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from dags import test_owner
+from dags.vm_resource import TpuVersion, Zone, ClusterName, Project
+from xlml.apis import gcp_config, metric_config, task as xlml_task, test_config
+import json
+
+
+def get_single_host_config(
+    model_name: str,
+    docker_image: str,
+    tpu_version: TpuVersion = TpuVersion.V4,
+    tpu_cores: int = 8,
+    tpu_zone: str = Zone.US_CENTRAL2_B.value,
+    time_out_in_min: int = 60,
+    task_owner: str = test_owner.ORTI_B,
+    cluster_name: str = ClusterName.V4_8_MULTISLICE_CLUSTER.value,
+    project_name: str = Project.TPU_PROD_ENV_MULTIPOD.value,
+    num_slices: int = 1,
+    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+) -> xlml_task.XpkTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=project_name,
+      zone=tpu_zone,
+      dataset_name=dataset_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
+  )
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+      ),
+      test_name=model_name,
+      run_model_cmds=["source benchmark_run.sh;run"],
+      set_up_cmds=None,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=task_owner,
+      num_slices=num_slices,
+      cluster_name=cluster_name,
+      docker_image=docker_image,
+  )
+  return xlml_task.XpkTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+  )
+
+
+
+with models.DAG(
+    dag_id="mlcompass_maxtext_single_host",
+    schedule=None,
+    tags=["mlcompass", "maxtext"],
+    start_date=datetime.datetime(2024, 9, 1),
+    catchup=False,
+    params={
+        "uuid": "",
+    },
+    default_args={
+        "retries": 0,
+    },
+) as dag:
+
+  @task.python
+  def load_xlml_state(params: dict = None):
+    dag.log.info(params)
+    uuid = params["uuid"]
+    if not uuid:
+      raise RuntimeError("uuid is not set")
+    gcs_hook = GCSHook()
+    file_content = gcs_hook.download("mlcompass-jax-artifacts", f"xlml/{uuid}/xlml_state.json")
+    return json.loads(file_content)
+
+  @task.python
+  def get_docker_image_path(state: dict) -> str:
+    return state["docker_image_path"]
+
+  xlml_state = load_xlml_state()
+  docker_image_path = get_docker_image_path(xlml_state)
+
+  default_benchmark = get_single_host_config(
+    model_name="gpt3-6b", # TODO
+    docker_image=docker_image_path,
+  ).run()

--- a/dags/mlcompass/maxtext_single_host.py
+++ b/dags/mlcompass/maxtext_single_host.py
@@ -55,7 +55,7 @@ def get_single_host_config(
   )
   job_test_config = test_config.TpuGkeTest(
       test_config.Tpu(
-          version=cluster.version,
+          version=cluster.device_version,
           cores=cluster.core_count,
       ),
       test_name="maxtext",

--- a/dags/mlcompass/maxtext_single_host.py
+++ b/dags/mlcompass/maxtext_single_host.py
@@ -62,7 +62,10 @@ def get_single_host_config(
           cores=tpu_cores,
       ),
       test_name="maxtext",
-      run_model_cmds=["bash simple_jax_test.sh", f"source benchmark_run.sh;run {model_name} {base_output_directory}"],
+      run_model_cmds=[
+          "bash simple_jax_test.sh",
+          f"source benchmark_run.sh;run {model_name} {base_output_directory}"
+      ],
       set_up_cmds=None,
       timeout=datetime.timedelta(minutes=time_out_in_min),
       task_owner=task_owner,
@@ -97,7 +100,9 @@ with models.DAG(
     if not uuid:
       raise RuntimeError("uuid is not set")
     gcs_hook = GCSHook()
-    file_content = gcs_hook.download("mlcompass-jax-artifacts", f"xlml/{uuid}/xlml_state.json")
+    file_content = gcs_hook.download(
+        "mlcompass-jax-artifacts", f"xlml/{uuid}/xlml_state.json"
+    )
     return json.loads(file_content)
 
   @task.python
@@ -120,7 +125,7 @@ with models.DAG(
   base_output_directory_arg = get_base_output_directory(xlml_state)
 
   default_benchmark = get_single_host_config(
-    docker_image=docker_image_path,
-    model_name=model_name_arg,
-    base_output_directory=base_output_directory_arg,
+      docker_image=docker_image_path,
+      model_name=model_name_arg,
+      base_output_directory=base_output_directory_arg,
   ).run()

--- a/dags/mlcompass/maxtext_single_host.py
+++ b/dags/mlcompass/maxtext_single_host.py
@@ -64,7 +64,7 @@ def get_single_host_config(
       test_name="maxtext",
       run_model_cmds=[
           "bash simple_jax_test.sh",
-          f"source benchmark_run.sh;run {model_name} {base_output_directory}"
+          f"source benchmark_run.sh;run {model_name} {base_output_directory}",
       ],
       set_up_cmds=None,
       timeout=datetime.timedelta(minutes=time_out_in_min),

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -171,6 +171,7 @@ class XpkTask(BaseTask):
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
+      skip_post_process: bool = False,
   ) -> DAGNode:
     """Run a test job within a docker image.
 
@@ -187,7 +188,8 @@ class XpkTask(BaseTask):
       run_model, gcs_path = self.run_model(
           gcs_location, use_vertex_tensorboard, use_pathways
       )
-      run_model >> self.post_process(gcs_path)
+      if not skip_post_process:
+        run_model >> self.post_process(gcs_path)
 
     return group
 


### PR DESCRIPTION
# Description

Add Maxtext single host benchmark runner

# Tests

Tested

**Instruction and/or command lines to reproduce your tests:** ...
```
  blaze build -c opt third_party/mlcompass/executors/runners:tf_runner
  blaze-bin/third_party/mlcompass/executors/runners/tf_runner \
    --config_path=xlml/xlml_dev.pbtxt \
    --benchmark_ids=1 \
    --xlml_environment_name=orti-test \
    --xlml_dag_name=mlcompass_maxtext_single_host \
```

**List links for your tests (use go/shortn-gen for any internal link):** ...
https://a2ca3cdf681d42a3aceb01b7d66a6681-dot-us-central1.composer.googleusercontent.com/dags/mlcompass_maxtext_single_host/grid?dag_run_id=manual__2024-09-23T23%3A47%3A07%2B00%3A00&task_id=load_xlml_state

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.