### PR TITLE
add v5p for PyTorch/XLA nightly CI

### DIFF
--- a/dags/legacy_test/templates/tpus.libsonnet
+++ b/dags/legacy_test/templates/tpus.libsonnet
@@ -78,5 +78,6 @@ local base = import 'base.libsonnet';
   v5litepod_64: self.TpuSpec { version: 5, variant: 'litepod', size: 64 },
   v5litepod_128: self.TpuSpec { version: 5, variant: 'litepod', size: 128 },
   v5litepod_256: self.TpuSpec { version: 5, variant: 'litepod', size: 256 },
+  v5p_8: self.TpuSpec { version: 5, variant: 'p', size: 8 },
   trillium_4: self.TpuSpec {version: 6, variant: 'e', size: 4},
 }

--- a/dags/legacy_test/tests/pytorch/nightly/ci.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/ci.libsonnet
@@ -34,6 +34,14 @@ local tpus = import 'templates/tpus.libsonnet';
     accelerator: tpus.v5litepod_4,
   },
 
+  local v5p_8 = self.v5p_8,
+  v5p_8:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv5',
+    },
+    accelerator: tpus.v5p_8,
+  },
+
   local trillium_4 = self.trillium_4,
   trillium_4:: {
     tpuSettings+: {
@@ -44,6 +52,7 @@ local tpus = import 'templates/tpus.libsonnet';
 
   configs: [
     ci + v5litepod_4 + pjrt,
+    ci + pjrt + v5p_8,
     ci + pjrt + trillium_4,
   ],
 }

--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -17,24 +17,33 @@ from airflow.decorators import task_group
 from airflow import models
 from xlml.apis import gcp_config, metric_config, task, test_config
 from dags import composer_env
-from dags.vm_resource import Project, Zone, V5_NETWORKS, V5E_SUBNETWORKS, V6E_SUBNETWORKS
+from dags.vm_resource import Project, Zone, V5_NETWORKS, V5E_SUBNETWORKS, V5P_SUBNETWORKS, V6E_SUBNETWORKS
 
 
 # Run once a day at 2 pm UTC (6 am PST)
 SCHEDULED_TIME = "0 14 * * *" if composer_env.is_prod_env() else None
+
 US_CENTRAL1_C = gcp_config.GCPConfig(
     Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     Zone.US_CENTRAL1_C.value,
     metric_config.DatasetOption.XLML_DATASET,
 )
+
 US_CENTRAL2_B = gcp_config.GCPConfig(
     Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     Zone.US_CENTRAL2_B.value,
     metric_config.DatasetOption.XLML_DATASET,
 )
+
 US_EAST1_D = gcp_config.GCPConfig(
     Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     Zone.US_EAST1_D.value,
+    metric_config.DatasetOption.XLML_DATASET,
+)
+
+US_EAST5_A_CLOUD_ML_AUTO_SOLUTIONS = gcp_config.GCPConfig(
+    Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    Zone.US_EAST5_A.value,
     metric_config.DatasetOption.XLML_DATASET,
 )
 
@@ -208,4 +217,13 @@ with models.DAG(
           subnetwork=V6E_SUBNETWORKS,
       ),
       US_CENTRAL2_B_TPU_PROD_ENV,
+  )
+
+  ci_v5p_8 = task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-ci-func-v5p-8-1vm",
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+      ),
+      US_EAST5_A_CLOUD_ML_AUTO_SOLUTIONS,
   )


### PR DESCRIPTION
# Description

Enable v5p for PyTorch/XLA nightly CI.

# Tests
<img width="705" alt="image" src="https://github.com/user-attachments/assets/37ad214e-7d70-4fc8-8b03-b192c04a58ae">

https://60bb71acc6784780b3bbdbae4ffa636f-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-nightly/grid?dag_run_id=manual__2024-10-10T20%3A43%3A28.314559%2B00%3A00&task_id=pt-nightly-ci-func-v5p-8-1vm.provision.initialize.generate_tpu_name

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.