### PR TITLE
Updated M* image versions to reflect jax_stable_stack=0.4.35-rev1

### DIFF
--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -287,11 +287,11 @@ class DockerImage(enum.Enum):
       f"xla:nightly_3.10_tpuvm_{datetime.datetime.today().strftime('%Y%m%d')}"
   )
   MAXTEXT_TPU_JAX_STABLE_STACK = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack_0.4.33:"
+      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack_0.4.35:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXDIFFUSION_TPU_JAX_STABLE_STACK = (
-      "gcr.io/tpu-prod-env-multipod/maxdiffusion_jax_stable_stack_0.4.33:"
+      "gcr.io/tpu-prod-env-multipod/maxdiffusion_jax_stable_stack_0.4.35:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXDIFFUSION_TPU_JAX_NIGHTLY = (


### PR DESCRIPTION
# Description

We recently released JAX Stable Stack version 0.4.35-rev1. And modified the M* models do build their images with the latest  JAX Stable Stack. 

This change is to update the M* versions to reflect that. 

ref: 
1. https://github.com/AI-Hypercomputer/maxtext/pull/978
2. https://github.com/AI-Hypercomputer/maxdiffusion/pull/126

# Tests

Tested locally and verified that test passed on stable stack DAG

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.