### PR TITLE
Adding tests for M* workload built on top of JAX Stable Stack for GPUs

### DIFF
--- a/dags/imagegen_devx/configs/gke_config.py
+++ b/dags/imagegen_devx/configs/gke_config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Utilities to construct configs for solutionsteam_jax_bite DAG."""
-
 from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags import test_owner, gcs_bucket
@@ -69,6 +67,45 @@ def get_gke_config(
       num_slices=num_slices,
       cluster_name=cluster.name,
       docker_image=docker_image,
+  )
+
+  return task.XpkTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+  )
+
+
+def get_maxtext_end_to_end_gpu_gke_test_config(
+    time_out_in_min: int,
+    test_name: str,
+    run_model_cmds: str,
+    cluster: XpkClusterConfig,
+    test_owner: str,
+    docker_image: str,
+    num_slices: int = 1,
+) -> task.GpuCreateResourceTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=cluster.project,
+      zone=cluster.zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  job_test_config = test_config.GpuXpkTest(
+      test_config.Gpu(
+          machine_type=None,
+          image_family=None,
+          count=None,
+          accelerator_type=cluster.device_version.value,
+          runtime_version=None,
+      ),
+      test_name=test_name,
+      set_up_cmds=None,
+      run_model_cmds=run_model_cmds,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=test_owner,
+      cluster_name=cluster.name,
+      docker_image=docker_image,
+      num_slices=num_slices,
   )
 
   return task.XpkTask(

--- a/dags/imagegen_devx/configs/gke_config.py
+++ b/dags/imagegen_devx/configs/gke_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Utilities to construct configs for solutionsteam_jax_bite DAG."""
+
 from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags import test_owner, gcs_bucket

--- a/dags/imagegen_devx/jax_stable_stack_e2e.py
+++ b/dags/imagegen_devx/jax_stable_stack_e2e.py
@@ -51,7 +51,10 @@ with models.DAG(
       "steps=2 enable_checkpointing=false attention=dot_product"
   )
   test_models_gpu = {
-      "train-c4-data": (f"{train_base} run_name=runner-{current_datetime}-0", 1),
+      "train-c4-data": (
+          f"{train_base} run_name=runner-{current_datetime}-0",
+          1,
+      ),
   }
 
   for accelerator, slices in maxtext_test_configs.items():
@@ -96,21 +99,21 @@ with models.DAG(
 
   # GCP GPU Tests
   for model, (test_script, nnodes) in test_models_gpu.items():
-      stable_a3_gpu = config.get_maxtext_end_to_end_gpu_gke_test_config(
-          time_out_in_min=300,
-          test_name=f"maxtext-stable-stack-{model}",
-          run_model_cmds=(test_script,),
-          num_slices=nnodes,
-          cluster=XpkClusters.GPU_A3_CLUSTER,
-          docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
-          test_owner=test_owner.NINA_C,
-      ).run()
-      stable_a3plus_gpu = config.get_maxtext_end_to_end_gpu_gke_test_config(
-          time_out_in_min=300,
-          test_name=f"maxtext-stable-stack-{model}",
-          run_model_cmds=(test_script,),
-          num_slices=nnodes,
-          cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-          docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
-          test_owner=test_owner.NINA_C,
-      ).run()
+    stable_a3_gpu = config.get_maxtext_end_to_end_gpu_gke_test_config(
+        time_out_in_min=300,
+        test_name=f"maxtext-stable-stack-{model}",
+        run_model_cmds=(test_script,),
+        num_slices=nnodes,
+        cluster=XpkClusters.GPU_A3_CLUSTER,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
+        test_owner=test_owner.NINA_C,
+    ).run()
+    stable_a3plus_gpu = config.get_maxtext_end_to_end_gpu_gke_test_config(
+        time_out_in_min=300,
+        test_name=f"maxtext-stable-stack-{model}",
+        run_model_cmds=(test_script,),
+        num_slices=nnodes,
+        cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
+        test_owner=test_owner.NINA_C,
+    ).run()

--- a/dags/imagegen_devx/jax_stable_stack_e2e.py
+++ b/dags/imagegen_devx/jax_stable_stack_e2e.py
@@ -45,7 +45,6 @@ with models.DAG(
       "v6e-256": [1],
   }
   train_base = (
-      "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
       "python3 MaxText/train.py MaxText/configs/base.yml "
       "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
       "steps=2 enable_checkpointing=false attention=dot_product"

--- a/dags/imagegen_devx/jax_stable_stack_e2e.py
+++ b/dags/imagegen_devx/jax_stable_stack_e2e.py
@@ -33,6 +33,7 @@ with models.DAG(
     start_date=datetime.datetime(2024, 6, 7),
     catchup=False,
 ) as dag:
+  current_datetime = config.get_current_datetime()
   maxtext_test_configs = {
       # accelerator: list of slices to test
       "v4-16": [1, 2],
@@ -43,12 +44,21 @@ with models.DAG(
       "v4-8": [1],
       "v6e-256": [1],
   }
-  current_datetime = config.get_current_datetime()
+  train_base = (
+      "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
+      "python3 MaxText/train.py MaxText/configs/base.yml "
+      "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
+      "steps=2 enable_checkpointing=false attention=dot_product"
+  )
+  test_models_gpu = {
+      "train-c4-data": (f"{train_base} run_name=runner-{current_datetime}-0", 1),
+  }
+
   for accelerator, slices in maxtext_test_configs.items():
     cores = accelerator.rsplit("-", maxsplit=1)[-1]
     cluster = config.clusters[accelerator]
     for slice_num in slices:
-      maxtext_jax_ss_test = config.get_gke_config(
+      maxtext_jax_stable_stack_test = config.get_gke_config(
           num_slices=slice_num,
           cluster=cluster,
           time_out_in_min=60,
@@ -69,7 +79,7 @@ with models.DAG(
     cores = accelerator.rsplit("-", maxsplit=1)[-1]
     cluster = config.clusters[accelerator]
     for slice_num in slices:
-      maxdiffusion_jax_ss_test = config.get_gke_config(
+      maxdiffusion_jax_stable_stack_test = config.get_gke_config(
           num_slices=slice_num,
           cluster=cluster,
           time_out_in_min=60,
@@ -82,4 +92,25 @@ with models.DAG(
           test_name=f"maxdiffusion-jax-stable-stack-{accelerator}-{slice_num}x",
           docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK.value,
           test_owner=test_owner.PARAM_B,
+      ).run()
+
+  # GCP GPU Tests
+  for model, (test_script, nnodes) in test_models_gpu.items():
+      stable_a3_gpu = config.get_maxtext_end_to_end_gpu_gke_test_config(
+          time_out_in_min=300,
+          test_name=f"maxtext-stable-stack-{model}",
+          run_model_cmds=(test_script,),
+          num_slices=nnodes,
+          cluster=XpkClusters.GPU_A3_CLUSTER,
+          docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
+          test_owner=test_owner.NINA_C,
+      ).run()
+      stable_a3plus_gpu = config.get_maxtext_end_to_end_gpu_gke_test_config(
+          time_out_in_min=300,
+          test_name=f"maxtext-stable-stack-{model}",
+          run_model_cmds=(test_script,),
+          num_slices=nnodes,
+          cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
+          docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
+          test_owner=test_owner.NINA_C,
       ).run()

--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -25,6 +25,7 @@ from dags.multipod.configs.common import SetupMode
 # Run once a day at 5 am UTC (9 pm PST / 10 pm PDT)
 SCHEDULED_TIME = "0 5 * * *" if composer_env.is_prod_env() else None
 
+
 with models.DAG(
     dag_id="maxtext_configs_aot",
     schedule=SCHEDULED_TIME,
@@ -103,6 +104,6 @@ with models.DAG(
       run_model_cmds=(cmd,),
       num_slices=1,
       cluster=XpkClusters.GPU_A3_CLUSTER,
-      docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
+      docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
       test_owner=test_owner.JON_B,
   ).run()

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -122,7 +122,7 @@ with models.DAG(
         run_model_cmds=(test_script,),
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.NINA_C,
     ).run()
     pinned_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
@@ -140,7 +140,7 @@ with models.DAG(
         run_model_cmds=(test_script,),
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.NINA_C,
     ).run()
     pinned_a3_gpu >> stable_a3_gpu >> pinned_a3plus_gpu >> stable_a3plus_gpu

--- a/dags/vm_resource.py
+++ b/dags/vm_resource.py
@@ -306,8 +306,8 @@ class DockerImage(enum.Enum):
       "gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_pinned:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXTEXT_GPU_JAX_STABLE = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_stable:"
+  MAXTEXT_GPU_JAX_STABLE_STACK = (
+      "gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_stable_stack_0.4.35:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXTEXT_GPU_JAX_NIGHTLY = (


### PR DESCRIPTION
# Description

Context: 

A) We have created a new JAX Stable Stack image for GPUs with JAX version 0.4.35.
B) We have added support for creating new M* docker images in https://github.com/AI-Hypercomputer/maxtext/pull/981.

In this PR, we are: 

1. Updating the JAX Stable Stack DAG to run Maxtext on GCP GPUs with images that are built using JAX Stable Stack.
2. mportant: Changing the notion of "stable" for Maxtext GPU images — i.e., from "Stable" to "stable stack," which now points to images built using JAX Stable Stack.

# Tests
![image](https://github.com/user-attachments/assets/9d0b8160-4b4e-4744-8b4a-9785bc9c299e)
![image](https://github.com/user-attachments/assets/a8669704-17ca-4918-81d7-952302d3d67c)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.