### PR TITLE
More reliably get rid of unattended-upgr

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -91,12 +91,13 @@ local volumes = import 'templates/volumes.libsonnet';
       tpuVmPytorchSetup: |||
         pip3 install -U 'setuptools>=70.0.0,<71.0.0'
         # `unattended-upgr` blocks us from installing apt dependencies
-        if systemctl is-active --quiet unattended-upgrades; then
-          sudo systemctl stop unattended-upgrades
-          echo "unattended-upgrades stopped."
-        else
-          echo "unattended-upgrades is not running."
-        fi
+        sudo systemctl stop unattended-upgrades || true
+        sudo systemctl disable unattended-upgrades || true
+        sudo killall --signal SIGKILL unattended-upgrades || true
+        sudo rm /var/lib/dpkg/lock-frontend || true
+        sudo dpkg --configure -a || true
+        echo "unattended-upgrades stopped."
+
         sudo apt-get -y update
         sudo apt install -y libopenblas-base
         # for huggingface tests

--- a/dags/legacy_test/tests/pytorch/r2.5.1/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.5.1/common.libsonnet
@@ -91,12 +91,13 @@ local volumes = import 'templates/volumes.libsonnet';
       tpuVmPytorchSetup: |||
         pip3 install -U 'setuptools>=70.0.0,<71.0.0'
         # `unattended-upgr` blocks us from installing apt dependencies
-        if systemctl is-active --quiet unattended-upgrades; then
-          sudo systemctl stop unattended-upgrades
-          echo "unattended-upgrades stopped."
-        else
-          echo "unattended-upgrades is not running."
-        fi
+        sudo systemctl stop unattended-upgrades || true
+        sudo systemctl disable unattended-upgrades || true
+        sudo killall --signal SIGKILL unattended-upgrades || true
+        sudo rm /var/lib/dpkg/lock-frontend || true
+        sudo dpkg --configure -a || true
+        echo "unattended-upgrades stopped."
+
         sudo apt-get -y update
         sudo apt install -y libopenblas-base
         # for huggingface tests


### PR DESCRIPTION
# Description

The existing code checks if unattended-upgr is active, then stops it. However, that has a race condition: unattended-upgr could have started running right after the check. As a result, our tasks still fail from time to time.

Here, we change the code to unconditionally stop unattended-upgr and disable the service, preventing it from running again. It will also forcefully remove the lock file.

# Tests

~I can't start internal tests because the test composer instance can't schedule any jobs (http://shortn/_LSKNYM0gt7).
I'll monitor the status of airflow jobs after this PR is merged, and we can revert if it breaks things.~

Re-triggered the test: [test link](https://60bb71acc6784780b3bbdbae4ffa636f-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-nightly/grid?dag_run_id=manual__2024-10-29T05%3A53%3A07.834812%2B00%3A00&tab=graph).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.