### PR TITLE
Removes aqtp version install, reduces parallel maxtext inf jobs

### DIFF
--- a/dags/inference/configs/jetstream_benchmark_serving_gce_config.py
+++ b/dags/inference/configs/jetstream_benchmark_serving_gce_config.py
@@ -65,7 +65,6 @@ def get_config(
       f"cd maxtext && bash setup.sh MODE={test_mode.value} && cd ..",
       "cd JetStream && pip install -e . && cd benchmarks && pip install -r requirements.in",
       "pip install torch --index-url https://download.pytorch.org/whl/cpu",
-      "pip install aqtp==0.7.5",
   )
 
   additional_metadata_dict = {

--- a/dags/inference/maxtext_inference.py
+++ b/dags/inference/maxtext_inference.py
@@ -613,7 +613,7 @@ with models.DAG(
             dags.append(jetstream_benchmark_serving_kv_cache_layout)
 
   # Cap the number of simultaneously requested v5e-8 due to resource contraints
-  n_parallel_jobs = 10
+  n_parallel_jobs = 4
   chunks = np.array_split(dags, n_parallel_jobs)
   for chunk in chunks:
     for i in range(1, len(chunk)):


### PR DESCRIPTION
# Description

These are related to failed workflows for MaxText + JetStream that stem from 
1. A dependence on a specific aqtp version that is no longer needed
2. Possible issues caused by too many parallel jobs.

# Tests

Ran locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.