### PR TITLE
Quarantine flaky tests

### DIFF
--- a/dags/quarantined_tests.py
+++ b/dags/quarantined_tests.py
@@ -1,0 +1,183 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lists all currently broken tests."""
+
+from dags.test_owner import Team as team
+
+
+class QuarantineTests:
+
+  @staticmethod
+  def test_info(owner, date_added, details=None):
+    return {
+        "owner": owner,
+        "date_added": date_added,
+        "details": details,
+    }
+
+  tests = {
+      # DAG: maxtext_gpu_end_to_end
+      "maxtext-pinned-train-c4-data-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-c4-data-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-train-c4-data-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-synthetic-data-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-synthetic-data-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-train-synthetic-data-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-flash-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-flash-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-train-flash-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-quarter-batch-size-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-quarter-batch-size-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-train-quarter-batch-size-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-int8-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-int8-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-train-int8-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-fp8-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-train-fp8-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-train-fp8-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-decode-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-decode-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-decode-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-decode-quarter-batch-size-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-decode-quarter-batch-size-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-decode-quarter-batch-size-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-generate-param-only-checkpoint-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-generate-param-only-checkpoint-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-generate-param-only-checkpoint-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-generate-param-only-checkpoint-int8-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-generate-param-only-checkpoint-int8-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-generate-param-only-checkpoint-int8-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-grain-checkpoint-determinism-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-grain-checkpoint-determinism-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-grain-checkpoint-determinism-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-checkpoint-compatibility-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-checkpoint-compatibility-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-checkpoint-compatibility-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-checkpoint-compatibility-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-llama2-7b-train-1node-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-llama2-7b-train-1node-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-llama2-7b-train-1node-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-llama2-7b-train-1node-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-llama2-7b-train-2node-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-llama2-7b-train-2node-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-llama2-7b-train-2node-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-llama2-7b-train-2node-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-llama2-7b-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-llama2-7b-h100-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-pinned-llama2-7b-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+      "maxtext-stable-llama2-7b-h100-mega-80gb-8": test_info(
+          team.LLM_DEVX, "2024-11-11"
+      ),
+  }
+
+  @staticmethod
+  def is_quarantined(test_name) -> bool:
+    return test_name in QuarantineTests.tests

--- a/dags/test_owner.py
+++ b/dags/test_owner.py
@@ -25,6 +25,10 @@ class Team(enum.Enum):
   IMAGEGEN_DEVX = "imagegen_devx"
   INFERENCE = "inference"
   FRAMEWORK = "framework3p"
+  LLM_DEVX = "llm_devx"
+  SPARCITY_DIFFUSION_DEVX = "sparcity_diffusion_devx"
+  PERFORMANCE = "performance"
+  PRODUCTIVITY = "productivity"
 
 
 # XLML - TensorFlow


### PR DESCRIPTION
We would like to isolate flaky tests from mostly-green tests, so that we notice any further regressions. This PR creates a list of flaky tests, and puts them in a separate quarantined sub-group within each DAG. We do this for one initial DAG.

Checklist
Before submitting this PR, please make sure (put X in square brackets):

X I have performed a self-review of my code.
X I have necessary comments in my code, particularly in hard-to-understand areas.
X I have run one-shot tests and provided workload links above if applicable.
X I have made or will make corresponding changes to the doc if needed.
