### PR TITLE
Update MoE test config

### DIFF
--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -57,7 +57,7 @@ with models.DAG(
           {
               "script_name": "tpu/mixtral/8x7b/2_test_mixtral",
               "cluster": XpkClusters.TPU_V4_128_CLUSTER,
-              "time_out_in_min": 60,
+              "time_out_in_min": 90,
           },
       ],
       "mixtral-8x22b": [
@@ -68,7 +68,7 @@ with models.DAG(
           },
           {
               "script_name": "tpu/mixtral/8x22b/2_test_mixtral",
-              "cluster": XpkClusters.TPU_V5E_256_CLUSTER,
+              "cluster": XpkClusters.TPU_V4_128_CLUSTER,
               "time_out_in_min": 60,
           },
       ],


### PR DESCRIPTION
# Description

Update MoE test config:
* Update 8x22b test to the same cluster as 8x7b
* With more tests ([PR](https://github.com/AI-Hypercomputer/maxtext/pull/1069)), add extra 30 min to the timeout.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Test on v4 cluster

**List links for your tests (use go/shortn-gen for any internal link):** ...
* Test 8x22b - [link](https://pantheon.corp.google.com/kubernetes/service/us-central2/v4-128-bodaborg-us-central2-b/default/ranran-nightly-mixtral-8x22b-v4-3/logs?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)
* Test 8x7b - [link](https://pantheon.corp.google.com/kubernetes/service/us-central2/v4-128-bodaborg-us-central2-b/default/ranran-nightly-mixtral-8x7b-v4-6/logs?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.