### PR TITLE
Short term fix xpk dependency

### DIFF
--- a/deployment/modules/composer_env/main.tf
+++ b/deployment/modules/composer_env/main.tf
@@ -20,7 +20,7 @@ resource "google_composer_environment" "example_environment" {
         google-cloud-tpu                  = ">=1.16.0"
         jsonlines                         = ""
         ray                               = "[default]"
-        ruamel.yaml                       = ""
+        dacite                            = ""
         # These packages are already in the default composer environment.
         # See https://cloud.google.com/composer/docs/concepts/versioning/composer-versions
         # google-cloud-bigquery             = ""

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -84,6 +84,7 @@ def run_workload(
     cmds = [
         "set -xue",
         f"git clone https://github.com/google/xpk {tmpdir}/xpk",
+        "pip install ruamel.yaml docker",
     ]
     if accelerator_type == GpuVersion.XPK_H100_MEGA.value:
       workload_create_cmd += " --scheduler=gke.io/topology-aware-auto"


### PR DESCRIPTION
# Description

Short term fix xpk dependency (please see more details in issues for long-term fix: b/381315769)

We don't need to add dependency at infra level, but just install it before triggering xpk workload, so removing the unnecessary dependencies at terraform template.
* remove unneeded `ruamel.yaml`
* add `dacite` dependency (I see it has manually added into the prof env, we should keep them consistent, otherwise it will be overwrite if we apply terraform template)


# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload and test

**List links for your tests (use go/shortn-gen for any internal link):** ...

Test it in dev env: [link](https://screenshot.googleplex.com/4FjRhCDYMADt3CG)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.