### PR TITLE
Fix maxtext_profiling import error by using tf-nightly

### DIFF
--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -50,9 +50,8 @@ with models.DAG(
         f"gsutil cp -R {base_output_directory}/$RUN_NAME/tensorboard .",
         "pip3 uninstall -y tbp-nightly",
         "pip3 uninstall -y tensorboard_plugin_profile",
-        "pip3 install tensorboard_plugin_profile",
-        "python3 MaxText/tests/profiler_test.py",
-        "pip3 uninstall -y tensorboard_plugin_profile",
+        "pip3 uninstall -y tensorflow",
+        "pip3 install tf-nightly",
         "pip3 install tbp-nightly",
         "python3 MaxText/tests/profiler_test.py",
     )


### PR DESCRIPTION
# Description

In Nov. 2024, tensorflow has moved the profile plugin to a separate module (http://shortn/_JAWuKDskvf). However, this change was not included in the stable tensorflow release 2.18.0 in Oct. 2024, causing the ```_pywrap_profile_plugin``` import error in [b/381786481](https://b.corp.google.com/issues/381786481). This can be fixed using tf-nightly. Since the latest profiler has caught up with this change, we should consider switching back to stable tensorflow when the above change is included in the release.

# Tests

Tested on my composer environment and previous import error was resolved. 

http://screen/BTFyNkfBBbkN7nv

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.