### PR TITLE
Update test_profiler.py path in maxtext_profiling

### DIFF
--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -53,7 +53,7 @@ with models.DAG(
         "pip3 uninstall -y tensorflow",
         "pip3 install tf-nightly",
         "pip3 install tbp-nightly",
-        "python3 MaxText/tests/profiler_test.py",
+        "python3 end_to_end/test_profiler.py",
     )
     maxtext_v4_configs_test = gke_config.get_gke_config(
         time_out_in_min=60,


### PR DESCRIPTION
# Description

In https://github.com/AI-Hypercomputer/maxtext/pull/1156, test_profiler.py was moved to the end_to_end folder in maxtext. This PR updates the path to reflect that change.

Fixes: [b/388640587](https://buganizer.corp.google.com/issues/388640587)

# Tests

Local tests run with success. Need to wait one extra day for the Maxtext docker image to catch up.
![image](https://github.com/user-attachments/assets/1144a8d6-2cc1-4ad2-ba45-40b8d64bd992)


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.