### PR TITLE
Update 8x22b tests

### DIFF
--- a/dags/common/quarantined_tests.py
+++ b/dags/common/quarantined_tests.py
@@ -183,10 +183,10 @@ class QuarantineTests:
       "chained_tests_mixtral-8x7b_nightly": TestInfo(
           team.SPARSITY_DIFFUSION_DEVX, "2024-11-12"
       ),
-      "chained_tests_mixtral-8x22b_stable": TestInfo(
+      "maxtext_stable_mixtral-8x22b-v4-128": TestInfo(
           team.SPARSITY_DIFFUSION_DEVX, "2024-11-12"
       ),
-      "chained_tests_mixtral-8x22b_nightly": TestInfo(
+      "maxtext_nightly_mixtral-8x22b-v4-128": TestInfo(
           team.SPARSITY_DIFFUSION_DEVX, "2024-11-12"
       ),
       "chained_tests_llama2-70b_stable": TestInfo(team.LLM_DEVX, "2024-11-12"),


### PR DESCRIPTION
# Description

Context: estimate the fix of b/384580048 will take sometime to dive deep why gke workloads take longer time than gce platform (30min on gce vs. 2hours/24hours on gke). We definitely don't want to block tests by this. So extract the tests out using a dedicated ckpt first.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload and test

**List links for your tests (use go/shortn-gen for any internal link):** ...
test [link](https://screenshot.googleplex.com/46z3TQJnG4ZuTHb)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.