### PR TITLE
[PyTorch/XLA] Add Stable Diffusion 2 training tests

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/stable-diffusion-2.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/stable-diffusion-2.libsonnet
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local stable_diffusion_2_train = self.stable_diffusion_2_train,
+  stable_diffusion_2_train:: common.PyTorchTest + common.Functional + common.PyTorchTpuVmMixin {
+    modelName: 'stable-diffusion-2-train',
+    command: [
+      'python',
+      'diffusers/examples/text_to_image/train_text_to_image_xla.py',
+      '--pretrained_model_name_or_path=stabilityai/stable-diffusion-2-base',
+      '--dataset_name=lambdalabs/naruto-blip-captions',
+      '--resolution=512',
+      '--center_crop',
+      '--random_flip',
+      '--train_batch_size=8',
+      '--max_train_steps=20',
+      '--learning_rate=1e-06',
+      '--mixed_precision=bf16',
+      '--output_dir=/tmp/output',
+      '--dataloader_num_workers=8',
+      '--loader_prefetch_size=4',
+      '--device_prefetch_size=4',
+      '--loader_prefetch_factor=4',
+    ],
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export PJRT_DEVICE=TPU
+        export XLA_USE_SPMD=1
+      |||,
+      tpuVmExtraSetup: |||
+        cat > ~/hf-constraints.txt << 'HF_CONSTRAINTS_EOF'
+        %s
+        HF_CONSTRAINTS_EOF
+
+        git clone https://github.com/pytorch-tpu/diffusers.git
+
+        cd diffusers
+        sudo pip3 install -e . -c ~/hf-constraints.txt
+        pip3 install -r examples/text_to_image/requirements.txt -c ~/hf-constraints.txt
+        pip3 install 'torch_xla[pallas]' -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+      ||| % common.HuggingfacePipVersionConstraints,
+    },
+  },
+
+  local v4_8 = self.v4_8,
+  v4_8:: {
+    accelerator: tpus.v4_8,
+  },
+
+  local v5p_8 = self.v5p_8,
+  v5p_8:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv5',
+    },
+    accelerator: tpus.v5p_8,
+  },
+
+  local trillium_4 = self.trillium_4,
+  trillium_4:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv6e',
+    },
+    accelerator: tpus.trillium_4,
+  },
+
+  configs: [
+    stable_diffusion_2_train + v4_8 + timeouts.Hours(3),
+    stable_diffusion_2_train + v5p_8 + timeouts.Hours(3),
+    stable_diffusion_2_train + trillium_4 + timeouts.Hours(3),
+  ],
+}

--- a/dags/legacy_test/tests/pytorch/nightly/targets.jsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/targets.jsonnet
@@ -18,6 +18,7 @@ local hfBert = import 'hf-bert.libsonnet';
 local llama2 = import 'llama2-model.libsonnet';
 local mnist = import 'mnist.libsonnet';
 local resnet50_mp = import 'resnet50-mp.libsonnet';
+local stable_diffusion_2 = import 'stable-diffusion-2.libsonnet';
 
 // Add new models here
 std.flattenArrays([
@@ -27,4 +28,5 @@ std.flattenArrays([
   mnist.configs,
   resnet50_mp.configs,
   llama2.configs,
+  stable_diffusion_2.configs,
 ])

--- a/dags/legacy_test/tests/pytorch/r2.6/stable-diffusion-2.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.6/stable-diffusion-2.libsonnet
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local stable_diffusion_2_train = self.stable_diffusion_2_train,
+  stable_diffusion_2_train:: common.PyTorchTest + common.Functional + common.PyTorchTpuVmMixin {
+    modelName: 'stable-diffusion-2-train',
+    command: [
+      'python',
+      'diffusers/examples/text_to_image/train_text_to_image_xla.py',
+      '--pretrained_model_name_or_path=stabilityai/stable-diffusion-2-base',
+      '--dataset_name=lambdalabs/naruto-blip-captions',
+      '--resolution=512',
+      '--center_crop',
+      '--random_flip',
+      '--train_batch_size=8',
+      '--max_train_steps=20',
+      '--learning_rate=1e-06',
+      '--mixed_precision=bf16',
+      '--output_dir=/tmp/output',
+      '--dataloader_num_workers=8',
+      '--loader_prefetch_size=4',
+      '--device_prefetch_size=4',
+      '--loader_prefetch_factor=4',
+    ],
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export PJRT_DEVICE=TPU
+        export XLA_USE_SPMD=1
+      |||,
+      tpuVmExtraSetup: |||
+        cat > ~/hf-constraints.txt << 'HF_CONSTRAINTS_EOF'
+        %s
+        HF_CONSTRAINTS_EOF
+
+        git clone https://github.com/pytorch-tpu/diffusers.git
+
+        cd diffusers
+        sudo pip3 install -e . -c ~/hf-constraints.txt
+        pip3 install -r examples/text_to_image/requirements.txt -c ~/hf-constraints.txt
+        pip3 install 'torch_xla[pallas]' -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+      ||| % common.HuggingfacePipVersionConstraints,
+    },
+  },
+
+  local v4_8 = self.v4_8,
+  v4_8:: {
+    accelerator: tpus.v4_8,
+  },
+
+  local v5p_8 = self.v5p_8,
+  v5p_8:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv5',
+    },
+    accelerator: tpus.v5p_8,
+  },
+
+  local trillium_4 = self.trillium_4,
+  trillium_4:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv6e',
+    },
+    accelerator: tpus.trillium_4,
+  },
+
+  configs: [
+    stable_diffusion_2_train + v4_8 + timeouts.Hours(3),
+    stable_diffusion_2_train + v5p_8 + timeouts.Hours(3),
+    stable_diffusion_2_train + trillium_4 + timeouts.Hours(3),
+  ],
+}

--- a/dags/legacy_test/tests/pytorch/r2.6/targets.jsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.6/targets.jsonnet
@@ -18,6 +18,7 @@ local hfBert = import 'hf-bert.libsonnet';
 local llama2 = import 'llama2-model.libsonnet';
 local mnist = import 'mnist.libsonnet';
 local resnet50_mp = import 'resnet50-mp.libsonnet';
+local stable_diffusion_2 = import 'stable-diffusion-2.libsonnet';
 
 // Add new models here
 std.flattenArrays([
@@ -27,4 +28,5 @@ std.flattenArrays([
   mnist.configs,
   resnet50_mp.configs,
   llama2.configs,
+  stable_diffusion_2.configs,
 ])

--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -164,6 +164,31 @@ def huggingface():
       US_CENTRAL2_B,
   )
 
+  # Stable Diffusion 2
+  task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-stable-diffusion-2-train-func-v6e-4-1vm",
+          network=V5_NETWORKS,
+          subnetwork=V6E_SUBNETWORKS,
+      ),
+      US_CENTRAL2_B_TPU_PROD_ENV,
+  )
+  task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-stable-diffusion-2-train-func-v5p-8-1vm",
+          reserved=True,
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+      ),
+      US_EAST5_A_TPU_PROD_ENV_AUTOMATED,
+  )
+  task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-stable-diffusion-2-train-func-v4-8-1vm"
+      ),
+      US_CENTRAL2_B,
+  )
+
 
 @task_group(prefix_group_id=False)
 def llama():

--- a/dags/pytorch_xla/r2_6.py
+++ b/dags/pytorch_xla/r2_6.py
@@ -162,6 +162,31 @@ def huggingface():
       US_CENTRAL2_B,
   )
 
+  # Stable Diffusion 2
+  task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-2-6-stable-diffusion-2-train-func-v6e-4-1vm",
+          network=V5_NETWORKS,
+          subnetwork=V6E_SUBNETWORKS,
+      ),
+      US_CENTRAL2_B_TPU_PROD_ENV,
+  )
+  task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-2-6-stable-diffusion-2-train-func-v5p-8-1vm",
+          reserved=True,
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+      ),
+      US_EAST5_A_TPU_PROD_ENV_AUTOMATED,
+  )
+  task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-2-6-stable-diffusion-2-train-func-v4-8-1vm"
+      ),
+      US_CENTRAL2_B,
+  )
+
 
 @task_group(prefix_group_id=False)
 def llama():
@@ -225,7 +250,7 @@ with models.DAG(
   huggingface()
   llama()
 
-  resnet_v5lp_4 = task.run_queued_resource_test(
+  ci_v5lp_4 = task.run_queued_resource_test(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-2-6-ci-func-v5litepod-4-1vm",
           network=V5_NETWORKS,


### PR DESCRIPTION
# Description

This change fixes https://github.com/pytorch/xla/issues/8542. See the linked proposal.

I referenced https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/training/trillium/Diffusion-2-PyTorch when creating this test.

# Tests

Tested in staging: http://shortn/_3B0clNTUmy

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.