### PR TITLE
Update XLML tests for MaxText on GPUs. 

### DIFF
--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -44,11 +44,11 @@ JON_B = "Jon B."
 RAYMOND_Z = "Raymond Z."
 MATT_D = "Matt D."
 PRIYANKA_G = "Priyanka G."
-NINA_C = "Nina C."
 SURBHI_J = "Surbhi J."
 ZHIYU_L = "Zhiyu L."
 MOHIT_K = "Mohit K."
 ANISHA_M = "Anisha M."
+YUWEI_Y = "Yuwei Y."
 
 # MLCompass
 ORTI_B = "Orti B."

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -253,5 +253,3 @@ with models.DAG(
     scale_down_a3_cluster()
 
   scale_up >> run_tests >> scale_down
-
-

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -32,7 +32,7 @@ from xlml.utils import gke
 SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
 
 # Number of nodes on A3 cluster to be scaled up to
-A3_NUM_NODES = 16
+A3_NUM_NODES = 10
 
 
 def configure_project_and_cluster(project: str, cluster_name: str, zone: str):

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -16,25 +16,105 @@
 
 
 import datetime
+import tempfile
+
 from airflow import models
+from airflow.decorators import task
+from airflow.hooks.subprocess import SubprocessHook
 from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, CpuVersion, DockerImage, GpuVersion, Project, TpuVersion, Zone
 from dags.multipod.configs import gke_config
-from xlml.utils import name_format
+from xlml.utils import gke
 
 # Run once a day at 4 am UTC (8 pm PST)
 SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
 
 
-with models.DAG(
-    dag_id="maxtext_gpu_end_to_end",
-    schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_onduty"],
-    start_date=datetime.datetime(2024, 1, 19),
-    catchup=False,
-) as dag:
+def configure_project_and_cluster(project: str, cluster_name: str, zone: str):
+  region = gke.zone_to_region(zone)
+
+  gcloud_command = (
+      f"gcloud config set project {project}",
+      "sudo chown -R airflow:airflow /home/airflow/composer_kube_config",
+      f"gcloud container clusters get-credentials {cluster_name}"
+      f"  --region {region}",
+  )
+  return gcloud_command
+
+
+def resize_a3_cluster(cluster_name: str, zone: str, num_nodes: int):
+  region = gke.zone_to_region(zone)
+  node_pool = f"{cluster_name}-np-0"
+
+  gcloud_command = (
+      f"gcloud container clusters resize {cluster_name}"
+      f"  --quiet --region {region}"
+      f"  --node-pool {node_pool}"
+      f"  --num-nodes {num_nodes}",
+  )
+  return gcloud_command
+
+
+def wait_for_cluster_ready():
+  kubectl_command = (
+      "kubectl wait --for=condition=Ready nodes --all --timeout=5m",
+  )
+  return kubectl_command
+
+
+@task
+def scale_up_a3_cluster():
+  with tempfile.TemporaryDirectory() as tmpdir:
+    hook = SubprocessHook()
+
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                configure_project_and_cluster(
+                    "supercomputer-testing",
+                    XpkClusters.GPU_A3_CLUSTER.name,
+                    XpkClusters.GPU_A3_CLUSTER.zone
+                )
+                + resize_a3_cluster(
+                    XpkClusters.GPU_A3_CLUSTER.name,
+                    XpkClusters.GPU_A3_CLUSTER.zone,
+                    8
+                )
+                + wait_for_cluster_ready()
+            ),
+        ],
+        cwd=tmpdir,
+    )
+    assert result.exit_code == 0, f"Command failed with code {result.exit_code}"
+
+
+@task
+def scale_down_a3_cluster():
+  with tempfile.TemporaryDirectory() as tmpdir:
+    hook = SubprocessHook()
+
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                resize_a3_cluster(
+                    XpkClusters.GPU_A3_CLUSTER.name,
+                    XpkClusters.GPU_A3_CLUSTER.zone,
+                    0
+                )
+            ),
+        ],
+        cwd=tmpdir,
+    )
+    assert result.exit_code == 0, f"Command failed with code {result.exit_code}"
+
+
+def run_maxtext_tests(dag):
   test_name_prefix = "maxtext"
 
   timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M")
@@ -148,4 +228,25 @@ with models.DAG(
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.NINA_C,
     ).run_with_quarantine(quarantine_task_group)
-    pinned_a3_gpu >> stable_a3_gpu >> pinned_a3plus_gpu >> stable_a3plus_gpu
+    pinned_a3_gpu >> stable_a3_gpu
+
+
+with models.DAG(
+    dag_id="maxtext_gpu_end_to_end",
+    schedule=SCHEDULED_TIME,
+    tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_onduty"],
+    start_date=datetime.datetime(2024, 1, 19),
+    catchup=False,
+) as dag:
+  with TaskGroup(group_id="scale_up") as scale_up:
+    scale_up_a3_cluster()
+
+  with TaskGroup(group_id="run_tests") as run_tests:
+    run_maxtext_tests(dag)
+
+  with TaskGroup(group_id="scale_down") as scale_down:
+    scale_down_a3_cluster()
+
+  scale_up >> run_tests >> scale_down
+
+

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -80,12 +80,12 @@ def scale_up_a3_cluster():
                 configure_project_and_cluster(
                     Project.SUPERCOMPUTER_TESTING.value,
                     XpkClusters.GPU_A3_CLUSTER.name,
-                    XpkClusters.GPU_A3_CLUSTER.zone
+                    XpkClusters.GPU_A3_CLUSTER.zone,
                 )
                 + resize_a3_cluster(
                     XpkClusters.GPU_A3_CLUSTER.name,
                     XpkClusters.GPU_A3_CLUSTER.zone,
-                    A3_NUM_NODES
+                    A3_NUM_NODES,
                 )
                 + wait_for_cluster_ready()
             ),
@@ -108,7 +108,7 @@ def scale_down_a3_cluster():
                 resize_a3_cluster(
                     XpkClusters.GPU_A3_CLUSTER.name,
                     XpkClusters.GPU_A3_CLUSTER.zone,
-                    0
+                    0,
                 )
             ),
         ],
@@ -244,7 +244,9 @@ with models.DAG(
   with TaskGroup(group_id="scale_up", dag=dag) as scale_up:
     scale_up_a3_cluster()
 
-  with TaskGroup(group_id="run_tests", dag=dag, prefix_group_id=False) as run_tests:
+  with TaskGroup(
+    group_id="run_tests", dag=dag, prefix_group_id=False
+  ) as run_tests:
     run_maxtext_tests(dag)
 
   with TaskGroup(group_id="scale_down", dag=dag) as scale_down:

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -78,7 +78,7 @@ def scale_up_a3_cluster():
             "-c",
             ";".join(
                 configure_project_and_cluster(
-                    Project.SUPERCOMPUTER_TESTING,
+                    Project.SUPERCOMPUTER_TESTING.value,
                     XpkClusters.GPU_A3_CLUSTER.name,
                     XpkClusters.GPU_A3_CLUSTER.zone
                 )

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -202,7 +202,7 @@ def run_maxtext_tests(dag: models.DAG):
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
-        test_owner=test_owner.NINA_C,
+        test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=300,
@@ -211,7 +211,7 @@ def run_maxtext_tests(dag: models.DAG):
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
-        test_owner=test_owner.NINA_C,
+        test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     pinned_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=300,
@@ -220,7 +220,7 @@ def run_maxtext_tests(dag: models.DAG):
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
-        test_owner=test_owner.NINA_C,
+        test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     stable_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=300,
@@ -229,7 +229,7 @@ def run_maxtext_tests(dag: models.DAG):
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
-        test_owner=test_owner.NINA_C,
+        test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     pinned_a3_gpu >> stable_a3_gpu >> pinned_a3plus_gpu >> stable_a3plus_gpu
 

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -245,7 +245,7 @@ with models.DAG(
     scale_up_a3_cluster()
 
   with TaskGroup(
-    group_id="run_tests", dag=dag, prefix_group_id=False
+      group_id="run_tests", dag=dag, prefix_group_id=False
   ) as run_tests:
     run_maxtext_tests(dag)
 

--- a/xlml/utils/gke.py
+++ b/xlml/utils/gke.py
@@ -202,5 +202,3 @@ def run_job(
 def zone_to_region(zone: str) -> str:
   zone_terms = zone.split('-')
   return zone_terms[0] + '-' + zone_terms[1]
-
-

--- a/xlml/utils/gke.py
+++ b/xlml/utils/gke.py
@@ -197,3 +197,10 @@ def run_job(
 
   name = deploy_job(gcs_location)
   wait_all_pods_ready(name) >> stream_logs(name)
+
+
+def zone_to_region(zone: str) -> str:
+  zone_terms = zone.split('-')
+  return zone_terms[0] + '-' + zone_terms[1]
+
+


### PR DESCRIPTION
# Description

There are two major changes:
1. Update the tests to scale up the A3 cluster and scale down the cluster before and after the tests run, to resolve the issue that the cluster gets automatically scaled down while it's not being used.
2. Replace the owner of the tests with Yuwei.

# Tests

**Instruction and/or command lines to reproduce your tests:**
1. Run the following commands:
$ git clone -b yangyuwei-maxtext-gpu https://github.com/GoogleCloudPlatform/ml-a
uto-solutions.git
$ cd ml-auto-solutions/
$ bash scripts/upload-tests.sh  gs://us-central1-nina-dags-fe347643-bucket/dags
2. Manually trigger `maxtext_gpu_end_to_end` DAG on the UI: https://540cef12d3da42ce97b48a97401b6c83-dot-us-central1.composer.googleusercontent.com/home

**List links for your tests (use go/shortn-gen for any internal link):** https://540cef12d3da42ce97b48a97401b6c83-dot-us-central1.composer.googleusercontent.com/dags/maxtext_gpu_end_to_end/grid?task_id=scale_down.scale_down_a3_cluster

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ Y ] I have performed a self-review of my code.
- [ Y ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ Y ] I have run one-shot tests and provided workload links above if applicable. 
- [ Y ] I have made or will make corresponding changes to the doc if needed.