### PR TITLE
Fixit: Removing redundant tests

### DIFF
--- a/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
@@ -68,15 +68,6 @@ with models.DAG(
 
   for model, (test_script, nnodes) in test_models_gpu.items():
     for mode, image in docker_images:
-      stable_a3_gpu = config.get_gpu_gke_test_config(
-          time_out_in_min=300,
-          test_name=f"maxtext-stable-stack-{mode.value}-{model}",
-          run_model_cmds=(test_script,),
-          num_slices=nnodes,
-          cluster=XpkClusters.GPU_A3_CLUSTER,
-          docker_image=image.value,
-          test_owner=test_owner.PARAM_B,
-      ).run_with_quarantine(quarantine_task_group)
       stable_a3plus_gpu = config.get_gpu_gke_test_config(
           time_out_in_min=300,
           test_name=f"maxtext-stable-stack-{mode.value}-{model}",

--- a/dags/sparsity_diffusion_devx/project_bite_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/project_bite_gpu_e2e.py
@@ -44,7 +44,6 @@ with models.DAG(
 
   axlearn_test_configs = {
       # accelerator: list of slices to test
-      "a3": [1],
       "a3plus": [1, 2],
   }
 


### PR DESCRIPTION
# Description

https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/556 introduced logic to spin up and down the A3 cluster. Given this additional layer to run tests on A3, this PR removes redundant tests that are:
a) Absorbed by the tests in MaxText end-to-end GPU DAG (MaxText JSTs)
b) Currently not relevant given the presence of JSTs for future A3Mega and beyond generation (AxLearn)

# Tests

Verified locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.