### PR TITLE
force llama2 spmd train on v5p use version `v2-alpha-tpuv5`

### DIFF
--- a/dags/legacy_test/tests/pytorch/r2.6/llama2-model.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.6/llama2-model.libsonnet
@@ -122,6 +122,11 @@ local utils = import 'templates/utils.libsonnet';
         sudo pip3 install -e . -c ~/hf-constraints.txt
         pip3 install datasets evaluate scikit-learn accelerate -c ~/hf-constraints.txt
 
+        echo "run uninstall libtpu"
+        pip uninstall libtpu -y
+        pip install https://storage.googleapis.com/libtpu-nightly-releases/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20250101+nightly-py3-none-linux_x86_64.whl
+        pip list | grep libtpu
+
         cd
         # 7B config
         mkdir 7B

--- a/dags/legacy_test/tests/pytorch/r2.6/llama2-model.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.6/llama2-model.libsonnet
@@ -122,11 +122,6 @@ local utils = import 'templates/utils.libsonnet';
         sudo pip3 install -e . -c ~/hf-constraints.txt
         pip3 install datasets evaluate scikit-learn accelerate -c ~/hf-constraints.txt
 
-        echo "run uninstall libtpu"
-        pip uninstall libtpu -y
-        pip install https://storage.googleapis.com/libtpu-nightly-releases/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20250101+nightly-py3-none-linux_x86_64.whl
-        pip list | grep libtpu
-
         cd
         # 7B config
         mkdir 7B
@@ -212,7 +207,7 @@ local utils = import 'templates/utils.libsonnet';
     llama2 + v4_8 + infer + timeouts.Hours(3),
     llama2 + v4_8 + spmd + timeouts.Hours(3),
     llama2 + v5p_8 + infer + timeouts.Hours(3),
-    llama2 + v5p_8 + spmd + timeouts.Hours(3),
+    llama2 + spmd + v5p_8 + timeouts.Hours(3),
     llama3_train + v5p_8 + timeouts.Hours(3),
     llama3_train + trillium_4 + timeouts.Hours(3),
   ],


### PR DESCRIPTION
# Description

force llama2 spmd train on v5p use version `v2-alpha-tpuv5`

# Tests

Airflow UI: https://dade15488e304a7dadc2e167f18721ee-dot-us-central1.composer.googleusercontent.com/dags/pytorchxla-r2-6/grid?dag_run_id=manual__2025-01-16T01%3A21%3A19.300605%2B00%3A00&task_id=pt-2-6-llama2-train-spmd-func-v5p-8-1vm.run_model

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.