### PR TITLE
Clean up xpk workloads after runs

### DIFF
--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -278,7 +278,19 @@ class XpkTask(BaseTask):
           cluster_name=self.task_test_config.cluster_name,
       )
 
-      (workload_id, gcs_path) >> launch_workload >> wait_for_workload_completion
+      clean_up_workload = xpk.clean_up_workload(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+      )
+
+      (
+          (workload_id, gcs_path)
+          >> launch_workload
+          >> wait_for_workload_completion
+          >> clean_up_workload
+      )
       return group, gcs_path
 
   def launch_workload(


### PR DESCRIPTION
# Description

Directly clean up xpk workloads after runs:
* This helps 1) clean up finished workloads to avoid perf regression to new workloads; 2) unblock other workloads in queue after Airflow timeout
* set all-done condition, so no matter the status of previous tasks, the workload will be cleaned-up
* remove the workload link (it will disappear), so update it to logging link
* to fix b/369152200

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Upload to airflow and test funcitonality

**List links for your tests (use go/shortn-gen for any internal link):** ...
* Test log link works fine on TPU - [link](https://screenshot.googleplex.com/6thyH5cQARydPXm), [logs](https://cloudlogging.app.goo.gl/LhLqUR7EdrSfqcrXA)
* Test log link works fine on GPU - [link](https://screenshot.googleplex.com/4JR4YzNTEwU9nXX)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.