### PR TITLE
Reduce the number of request_rates

### DIFF
--- a/dags/solutions_team/solutionsteam_vllm_benchmarks.py
+++ b/dags/solutions_team/solutionsteam_vllm_benchmarks.py
@@ -42,7 +42,7 @@ with models.DAG(
           "backend": ["vllm"],
           "model_id": ["meta-llama/Meta-Llama-3.1-8B"],
           "dataset": "ShareGPT_V3_unfiltered_cleaned_split.json",
-          "request_rates": "1,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32",
+          "request_rates": "1,2,4,8,16,32",
           "num_prompts": 1000,
           "max_output_length": 1024,
           "max_cache_length": 2048,


### PR DESCRIPTION
# Description

Recent vLLM tests failed, potentially due to timeouts exceeding one hour.  Richard suggests reducing the number of request_rates tested to decrease overall test time. We only need to test powers of 2 (1, 2, 4, 8, 16, 32) for request_rates.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** I tested it in my dev environment. 

**List links for your tests (use go/shortn-gen for any internal link):**  https://069305c1662446849f63d550fbf4868f-dot-us-central1.composer.googleusercontent.com/dags/solutionsteam_vllm_benchmark/grid?search=solutionsteam_vllm_benchmark&dag_run_id=manual__2025-01-16T20%3A54%3A52.258412%2B00%3A00

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.