### PR TITLE
Increase the default run model timeout

### DIFF
--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -118,7 +118,7 @@ def create_queued_resource(
     if task_test_config.timeout:
       run_model_timeout_in_sec = int(task_test_config.timeout.total_seconds())
     else:
-      run_model_timeout_in_sec = 0
+      run_model_timeout_in_sec = 7200  # Assume a default timeout of 2 hours
     # Time to live (ttl) is combination of:
     # 1) tpu provision timeout
     # 2) tpu run model timeout


### PR DESCRIPTION
# Description

If a PyTorch/XLA DAG does not specify a timeout, the create_queued_resource function assumes that the timeout is 0 seconds, which is too short. We increase it to 2 hours.

The direct motivation is that CI DAGs have been timing out as they hit the 1 hour buffer time.

# Tests

Verified that created VMs (e.g. http://shortn/_iGiaLzNSQ3) have a 2+1=3 hour TTL.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.