### PR TITLE
Pathways job completion fix

### DIFF
--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -144,6 +144,42 @@ def _list_workload_pods(
   return pods
 
 
+def _get_batch_api_client(
+    project_id: str, region: str, cluster_name: str
+) -> k8s_client.BatchV1Api:
+  """Create a batch API client for the given cluster."""
+  client = gke.get_authenticated_client(project_id, region, cluster_name)
+
+  # Initilize the client
+  batch_api = k8s_client.BatchV1Api(client)
+  logging.info(
+      "Successful initilize k8s batch api client from cluster response."
+  )
+  return batch_api
+
+
+def _get_workload_job(
+    batch_api: k8s_client.BatchV1Api, workload_id: str
+) -> k8s_client.V1Job:
+  """Get the job for a given workload."""
+  logging.info(f"Getting job for workload_id: {workload_id}")
+  jobs = batch_api.list_namespaced_job(
+      label_selector=f"jobset.sigs.k8s.io/jobset-name={workload_id}",
+      namespace="default",
+  )
+  if len(jobs.items) == 0:
+    logging.info(f"Getting job for workload_id: {workload_id}")
+    return None
+
+  if len(jobs.items) > 1:
+    logging.info(f"Got more than one job for workload_id: {workload_id}")
+    for i, job in enumerate(jobs.items):
+      logging.info(f"Job {i=}")
+      logging.info(f"{job}")
+
+  return jobs.items[0]
+
+
 @task.sensor(poke_interval=60, timeout=600, mode="reschedule")
 def wait_for_workload_start(
     workload_id: str, project_id: str, region: str, cluster_name: str
@@ -165,6 +201,27 @@ def wait_for_workload_completion(
 
   if not pods.items:
     logging.info(f"No pods found for workload selector: {workload_id}.")
+
+    # Pathways jobs delete all pods on failure so we must also check if the job
+    # is complete
+    batch_api = _get_batch_api_client(project_id, region, cluster_name)
+    job = _get_workload_job(batch_api, workload_id)
+    if job is None:
+      logging.info(
+          f"No pods or jobs were found for workload selector: {workload_id}"
+      )
+      return False
+
+    if any(condition.type == "Failed" for condition in job.status.conditions):
+      # Don't keep retrying if the job has failed
+      raise AirflowFailException('Job has condition type: "Failed"')
+
+    if any(condition.type == "Complete" for condition in job.status.conditions):
+      logging.info(
+          f"No pods found but job is complete for workload selector: {workload_id}"
+      )
+      return True
+
     return False
 
   if any(pod.status.phase in ["Pending", "Running"] for pod in pods.items):


### PR DESCRIPTION
# Description

Pathways jobs delete all pods on failure so the current `wait_for_workload_completion` does not recognize completion correctly. The new completion logic should be better than the current "check all pods" logic to determine if a workload is complete but because other logic with GPU workloads and print logs depending on the pods is colocated, I made only minimally invasive changes.

# Tests

Ran both the maxtext_v5e_config_perf and pathways_maxtext_v5e_config_perf DAGs and they are WAI.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.