### PR TITLE
[PyTorch] Remove unattended-upgrades

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/common.libsonnet
@@ -94,8 +94,9 @@ local volumes = import 'templates/volumes.libsonnet';
         sudo systemctl stop unattended-upgrades || true
         sudo systemctl disable unattended-upgrades || true
         sudo killall --signal SIGKILL unattended-upgrades || true
-        sudo rm /var/lib/dpkg/lock-frontend || true
         sudo dpkg --configure -a || true
+        sudo apt purge unattended-upgrades -y || true
+        sudo rm /var/lib/dpkg/lock-frontend || true
         echo "unattended-upgrades stopped."
 
         sudo apt-get -y update

--- a/dags/legacy_test/tests/pytorch/r2.6/common.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.6/common.libsonnet
@@ -96,8 +96,9 @@ local rcVersion = 'rc9';
         sudo systemctl stop unattended-upgrades || true
         sudo systemctl disable unattended-upgrades || true
         sudo killall --signal SIGKILL unattended-upgrades || true
-        sudo rm /var/lib/dpkg/lock-frontend || true
         sudo dpkg --configure -a || true
+        sudo apt purge unattended-upgrades -y || true
+        sudo rm /var/lib/dpkg/lock-frontend || true
         echo "unattended-upgrades stopped."
 
         sudo apt-get -y update


### PR DESCRIPTION
Previously we stopped unattended-upgrades. But test runs indicated that unattended-upgrades still runs occasionally. Here we attempt to fix that by removing the binary altogether.

Tested: http://shortn/_Hr1JOwekCA