### PR TITLE
 Migrate vLLM:TPU XLML Test from Python Setup to Docker with Latest Dependencies

### DIFF
--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -152,7 +152,7 @@ def get_tpu_vllm_benchmark_cmds(
       "num_accelerators": num_chips,
   }
   for request_rate in request_rates:
-    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save '{additional_metadata}''"
+    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c \"export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save '{additional_metadata}'\""
 
     benchmark_cmds = [
         # Run benchmark inside the container
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata).replace('"', '\\"'),
+            additional_metadata=json.dumps(metadata).replace('"', '\"'),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -171,7 +171,8 @@ def get_tpu_vllm_benchmark_cmds(
 
   run_cmds.extend([
       # Copy metrics
-      f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl {metric_config.SshEnvVars.GCS_OUTPUT.value}'",
+      gcs_destination = metric_config.SshEnvVars.GCS_OUTPUT.value
+      f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl {gcs_destination}'",
       # Stop the container
       "sudo docker stop $CONTAINER_NAME",
   ])

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -152,7 +152,7 @@ def get_tpu_vllm_benchmark_cmds(
       "num_accelerators": num_chips,
   }
   for request_rate in request_rates:
-    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save {additional_metadata}'"
+    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model \'{model_id}\' --tokenizer \'{model_id}\' --request-rate {request_rate} --additional-metadata-metrics-to-save \'{additional_metadata}\''"
 
     benchmark_cmds = [
         # Run benchmark inside the container
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata).replace('"', '\\"'),
+            additional_metadata=json.dumps(metadata),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata),
+            additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -177,7 +177,7 @@ def get_tpu_vllm_benchmark_cmds(
   print(f"DEBUG: GCS Destination: {gcs_destination}")
   run_cmds.extend([
       # Copy metrics
-      f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl \"{gcs_destination}\"'",
+      f"sudo docker exec -e GCS=\"{gcs_destination}\" $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl $GCS'",
       # Stop the container
       "sudo docker stop $CONTAINER_NAME",
   ])

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -164,7 +164,7 @@ def get_tpu_vllm_benchmark_cmds(
             additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
-       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\\\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",
+       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\\$(find . -name \\$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \\$NF}}') && cat \\$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \\$BENCHMARK_OUTPUT\"",
        "sudo docker exec $CONTAINER_NAME /bin/bash -c \"echo '' >> metric_report.jsonl\"",
     ]
     run_cmds.extend(benchmark_cmds)

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -169,9 +169,10 @@ def get_tpu_vllm_benchmark_cmds(
     ]
     run_cmds.extend(benchmark_cmds)
 
+  # Get the GCS destination path *before* constructing the command.  OUTSIDE the list.
+  gcs_destination = metric_config.SshEnvVars.GCS_OUTPUT.value
   run_cmds.extend([
       # Copy metrics
-      gcs_destination = metric_config.SshEnvVars.GCS_OUTPUT.value
       f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl {gcs_destination}'",
       # Stop the container
       "sudo docker stop $CONTAINER_NAME",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -164,7 +164,7 @@ def get_tpu_vllm_benchmark_cmds(
             additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
-       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",
+       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\\\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",
        "sudo docker exec $CONTAINER_NAME /bin/bash -c \"echo '' >> metric_report.jsonl\"",
     ]
     run_cmds.extend(benchmark_cmds)

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -152,7 +152,7 @@ def get_tpu_vllm_benchmark_cmds(
       "num_accelerators": num_chips,
   }
   for request_rate in request_rates:
-    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model \'{model_id}\' --tokenizer \'{model_id}\' --request-rate {request_rate} --additional-metadata-metrics-to-save \'{additional_metadata}\''"
+    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save '{additional_metadata}''"
 
     benchmark_cmds = [
         # Run benchmark inside the container

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata).replace('"', '\"'),
+            additional_metadata=json.dumps(metadata),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata),
+            additional_metadata=json.dumps(metadata).replace('"', '\"'),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -67,6 +67,7 @@ def get_vllm_tpu_setup_cmds():
       "sudo docker exec $CONTAINER_NAME /bin/bash -c 'echo \"deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main\" > /etc/apt/sources.list.d/google-cloud-sdk.list'",
       "sudo docker exec $CONTAINER_NAME /bin/bash -c 'curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -'",
       "sudo docker exec $CONTAINER_NAME /bin/bash -c 'apt-get update && apt-get install -y google-cloud-sdk'",
+      "sudo docker exec $CONTAINER_NAME /bin/bash -c 'apt-get -y install jq'",
   )
 
   return setup_cmds

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -31,6 +31,7 @@ RUNTIME_IMAGE = RuntimeVersion.TPU_UBUNTU2204_BASE.value
 GCS_SUBFOLDER_PREFIX = test_owner.Team.SOLUTIONS_TEAM.value
 HF_TOKEN = Variable.get("HF_TOKEN", None)
 VLLM_TPU_DOCKER_IMAGE = "gcr.io/cloud-tpu-v2-images/vllm-tpu-nightly:latest"
+VLLM_TPU_CONTAINER = "vllm-tpu-container"
 
 
 def get_vllm_gpu_setup_cmds():
@@ -52,10 +53,10 @@ def get_vllm_gpu_setup_cmds():
   return setup_cmds
 
 
-def get_vllm_tpu_setup_cmds(test_run_id: str):
+def get_vllm_tpu_setup_cmds():
   setup_cmds = (
       # Download and start the vLLM TPU Docker container
-      f"export CONTAINER_NAME=vllm-tpu-container-{test_run_id}",
+      f"export CONTAINER_NAME={VLLM_TPU_CONTAINER}",
       f"sudo docker run --name $CONTAINER_NAME -d --privileged --network host -v /dev/shm:/dev/shm {VLLM_TPU_DOCKER_IMAGE} tail -f /dev/null",
       # Download dataset inside the container
       "sudo docker exec $CONTAINER_NAME /bin/bash -c 'wget --no-verbose https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json'",
@@ -138,7 +139,7 @@ def get_tpu_vllm_benchmark_cmds(
   num_prompts = 1000
 
   run_cmds = [
-      f"export CONTAINER_NAME=vllm-tpu-container-{test_run_id}",
+      f"export CONTAINER_NAME={VLLM_TPU_CONTAINER}",
       # Start vllm in the background and wait for server to come up
       f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && vllm serve {model_id} --swap-space 16  --disable-log-requests --tensor_parallel_size={num_chips} --max-model-len=2048 --num-scheduler-steps=4 & sleep 600'",
   ]

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -271,7 +271,7 @@ def get_tpu_vllm_gce_config(
       dataset_name=metric_config.DatasetOption.BENCHMARK_DATASET,
   )
 
-  set_up_cmds = get_vllm_tpu_setup_cmds(test_run_id=test_run_id)
+  set_up_cmds = get_vllm_tpu_setup_cmds()
   model_configs["instance_type"] = tpu_version.value
 
   run_model_cmds = get_tpu_vllm_benchmark_cmds(

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -164,7 +164,7 @@ def get_tpu_vllm_benchmark_cmds(
             additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
-       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\\$(find . -name \\$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \\$NF}}') && cat \\$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \\$BENCHMARK_OUTPUT\"",
+       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\\$(find . -name \\$OUTPUT_FORMAT -type f -printf \\\"%T@ %Tc %p\n\\\" | sort -n | head -1 | awk 'NF>1{{print \\$NF}}') && cat \\$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \\$BENCHMARK_OUTPUT\"",
        "sudo docker exec $CONTAINER_NAME /bin/bash -c \"echo '' >> metric_report.jsonl\"",
     ]
     run_cmds.extend(benchmark_cmds)

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -72,8 +72,9 @@ def get_vllm_tpu_setup_cmds():
 
   return setup_cmds
 
+
 def _get_vllm_benchmark_parameters(
-  model_id: str, num_chips: int, test_run_id: str, model_configs: Dict = {}
+    model_id: str, num_chips: int, test_run_id: str, model_configs: Dict = {}
 ):
   base_model_id = model_id.split("/")[-1]
   request_rates = model_configs["request_rates"].split(",")
@@ -96,10 +97,22 @@ def _get_vllm_benchmark_parameters(
 
   return base_model_id, request_rates, num_prompts, metadata, gcs_destination
 
+
 def get_gpu_vllm_benchmark_cmds(
     model_id: str, num_chips: int, test_run_id: str, model_configs: Dict = {}
 ):
-  base_model_id, request_rates, num_prompts, metadata, gcs_destination = _get_vllm_benchmark_parameters(model_id=model_id, num_chips=num_chips, test_run_id=test_run_id, model_configs=model_configs)
+  (
+      base_model_id,
+      request_rates,
+      num_prompts,
+      metadata,
+      gcs_destination,
+  ) = _get_vllm_benchmark_parameters(
+      model_id=model_id,
+      num_chips=num_chips,
+      test_run_id=test_run_id,
+      model_configs=model_configs,
+  )
 
   run_cmds = [
       "export PATH=$PATH:/home/cloud-ml-auto-solutions/vllm:/home/cloud-ml-auto-solutions/.local/bin",
@@ -145,10 +158,22 @@ def get_gpu_vllm_benchmark_cmds(
 
   return tuple(run_cmds)
 
+
 def get_tpu_vllm_benchmark_cmds(
     model_id: str, num_chips: int, test_run_id: str, model_configs: Dict = {}
 ):
-  base_model_id, request_rates, num_prompts, metadata, gcs_destination = _get_vllm_benchmark_parameters(model_id=model_id, num_chips=num_chips, test_run_id=test_run_id, model_configs=model_configs)
+  (
+      base_model_id,
+      request_rates,
+      num_prompts,
+      metadata,
+      gcs_destination,
+  ) = _get_vllm_benchmark_parameters(
+      model_id=model_id,
+      num_chips=num_chips,
+      test_run_id=test_run_id,
+      model_configs=model_configs,
+  )
 
   run_cmds = [
       f"export CONTAINER_NAME={VLLM_TPU_CONTAINER}",
@@ -168,9 +193,9 @@ def get_tpu_vllm_benchmark_cmds(
             request_rate=request_rate,
             additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
-       # Process result json files inside the container
-       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\\$(find . -name \\$OUTPUT_FORMAT -type f -printf \\\"%T@ %Tc %p\n\\\" | sort -n | head -1 | awk 'NF>1{{print \\$NF}}') && cat \\$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \\$BENCHMARK_OUTPUT\"",
-       "sudo docker exec $CONTAINER_NAME /bin/bash -c \"echo '' >> metric_report.jsonl\"",
+        # Process result json files inside the container
+        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\\$(find . -name \\$OUTPUT_FORMAT -type f -printf \\\"%T@ %Tc %p\n\\\" | sort -n | head -1 | awk 'NF>1{{print \\$NF}}') && cat \\$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \\$BENCHMARK_OUTPUT\"",
+        "sudo docker exec $CONTAINER_NAME /bin/bash -c \"echo '' >> metric_report.jsonl\"",
     ]
     run_cmds.extend(benchmark_cmds)
 
@@ -184,6 +209,7 @@ def get_tpu_vllm_benchmark_cmds(
   ])
 
   return tuple(run_cmds)
+
 
 def get_gpu_vllm_gce_config(
     machine_version: MachineVersion,

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -176,6 +176,8 @@ def get_tpu_vllm_benchmark_cmds(
   # Debug Print
   print(f"DEBUG: GCS Destination: {gcs_destination}")
   run_cmds.extend([
+      # Kill background process
+      "sudo docker exec $CONTAINER_NAME /bin/bash -c 'pkill vllm'",
       # Copy metrics
       f"sudo docker exec -e GCS=\"{gcs_destination}\" $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl $GCS'",
       # Stop the container

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -155,6 +155,7 @@ def get_tpu_vllm_benchmark_cmds(
     benchmark_cmds = [
         # Run benchmark inside the container
         benchmark_cmd_fmt.format(
+            HF_TOKEN=HF_TOKEN,
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -169,11 +169,15 @@ def get_tpu_vllm_benchmark_cmds(
     ]
     run_cmds.extend(benchmark_cmds)
 
-  # Get the GCS destination path *before* constructing the command.  OUTSIDE the list.
+  # Get the GCS destination path *before* constructing the command, OUTSIDE the list.
   gcs_destination = metric_config.SshEnvVars.GCS_OUTPUT.value
+  if not gcs_destination:
+    raise ValueError("GCS_OUTPUT environment variable is not set or is empty.")
+  # Debug Print
+  print(f"DEBUG: GCS Destination: {gcs_destination}")
   run_cmds.extend([
       # Copy metrics
-      f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl {gcs_destination}'",
+      f"sudo docker exec $CONTAINER_NAME /bin/bash -c 'gsutil cp metric_report.jsonl \"{gcs_destination}\"'",
       # Stop the container
       "sudo docker stop $CONTAINER_NAME",
   ])

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -152,7 +152,7 @@ def get_tpu_vllm_benchmark_cmds(
       "num_accelerators": num_chips,
   }
   for request_rate in request_rates:
-    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save '{additional_metadata}''"
+    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c 'export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save {additional_metadata}'"
 
     benchmark_cmds = [
         # Run benchmark inside the container
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata).replace('"', '\"'),
+            additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -164,7 +164,7 @@ def get_tpu_vllm_benchmark_cmds(
             additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
-       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",
+       f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",
        "sudo docker exec $CONTAINER_NAME /bin/bash -c \"echo '' >> metric_report.jsonl\"",
     ]
     run_cmds.extend(benchmark_cmds)

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -152,7 +152,7 @@ def get_tpu_vllm_benchmark_cmds(
       "num_accelerators": num_chips,
   }
   for request_rate in request_rates:
-    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c \"export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model '{model_id}' --tokenizer '{model_id}' --request-rate {request_rate} --additional-metadata-metrics-to-save '{additional_metadata}'\""
+    benchmark_cmd_fmt = "sudo docker exec $CONTAINER_NAME /bin/bash -c \"export HF_TOKEN={HF_TOKEN} && python inference-benchmark/benchmark_serving.py --host localhost --port 8000 --num-prompts {num_prompts} --max-input-length 1024 --max-output-length 1024 --dataset ShareGPT_V3_unfiltered_cleaned_split.json --save-json-results --model {model_id} --tokenizer {model_id} --request-rate {request_rate} --additional-metadata-metrics-to-save '{additional_metadata}'\""
 
     benchmark_cmds = [
         # Run benchmark inside the container
@@ -161,7 +161,7 @@ def get_tpu_vllm_benchmark_cmds(
             num_prompts=num_prompts,
             model_id=model_id,
             request_rate=request_rate,
-            additional_metadata=json.dumps(metadata),
+            additional_metadata=json.dumps(metadata).replace('"', '\\"'),
         ),
        # Process result json files inside the container
        f"sudo docker exec $CONTAINER_NAME /bin/bash -c \"export OUTPUT_FORMAT='*vllm*{base_model_id}*' && export BENCHMARK_OUTPUT=\$(find . -name \$OUTPUT_FORMAT -type f -printf \"%T@ %Tc %p\n\" | sort -n | head -1 | awk 'NF>1{{print \$NF}}') && cat \$BENCHMARK_OUTPUT >> metric_report.jsonl && rm \$BENCHMARK_OUTPUT\"",

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -62,7 +62,7 @@ def get_vllm_tpu_setup_cmds():
       "pip install --upgrade google-cloud-storage",
       "rm -rf inference-benchmark && git clone https://github.com/AI-Hypercomputer/inference-benchmark",
       # Download Google Cloud SDK, which is needed for the gsutil command.
-      'echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list'，
+      'echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list',
       "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -",
       "apt-get update && apt-get install -y google-cloud-sdk",
   )


### PR DESCRIPTION
# Description

This PR migrates the vLLM:TPU XLML test from a Python-based setup to a Docker-based setup. The Docker image uses the latest (unpinned) dependencies, allowing for proactive identification of dependency-related regressions and automating the vLLM:TPU benchmarking process.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.
1. Manually run the commands on Cloud TPU VMs
2. Run XLML test in my dev environment

**Instruction and/or command lines to reproduce your tests:** Upload local changes to the dev Composer environment, and manually trigger the DAG 

**List links for your tests (use go/shortn-gen for any internal link):** https://069305c1662446849f63d550fbf4868f-dot-us-central1.composer.googleusercontent.com/dags/solutionsteam_vllm_benchmark/grid?search=solutionsteam_vllm_benchmark&dag_run_id=manual__2025-01-29T07%3A33%3A29.575632%2B00%3A00&task_id=solutionsteam-vllm-benchmark-tpu-nightly-llama3-8b-vllm-v5litepod-8.run_model&tab=logs

After addressing Round 1 comments: https://069305c1662446849f63d550fbf4868f-dot-us-central1.composer.googleusercontent.com/dags/solutionsteam_vllm_benchmark/grid?search=solutionsteam_vllm_benchmark&dag_run_id=manual__2025-01-29T23%3A06%3A10.118887%2B00%3A00&task_id=solutionsteam-vllm-benchmark-tpu-nightly-llama3-8b-vllm-v5litepod-8.run_model&tab=logs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.