### PR TITLE
Add a multi-slice llama training test

### DIFF
--- a/dags/legacy_test/tests/pytorch/nightly/llama2-model.libsonnet
+++ b/dags/legacy_test/tests/pytorch/nightly/llama2-model.libsonnet
@@ -130,14 +130,114 @@ local utils = import 'templates/utils.libsonnet';
       ||| % common.HuggingfacePipVersionConstraints,
     },
   },
+  local llama3_train = self.llama3_train,
+  llama3_train:: common.PyTorchTest + common.Functional + common.PyTorchTpuVmMixin {
+    modelName: 'llama3-train',
+    command: [
+      'python',
+      'transformers/examples/pytorch/language-modeling/run_clm.py',
+      '--dataset_name=wikitext',
+      '--dataset_config_name=wikitext-2-raw-v1',
+      '--per_device_train_batch_size=4',
+      '--do_train',
+      '--output_dir=./tmp/test-clm',
+      '--overwrite_output_dir',
+      '--config_name=./llama_3/config.json',
+      '--cache_dir=./cache',
+      '--tokenizer_name=./llama_3/tokenizer/',
+      '--block_size=8192',
+      '--optim=adafactor',
+      '--save_strategy=no',
+      '--logging_strategy=no',
+      '--fsdp=full_shard',
+      '--fsdp_config=./llama_3/fsdp_config.json',
+      '--torch_dtype=bfloat16',
+      '--dataloader_drop_last=yes',
+      '--flash_attention',
+      '--max_steps=10',
+    ],
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export PJRT_DEVICE=TPU
+        export XLA_USE_SPMD=1
+      |||,
+      tpuVmExtraSetup: |||
+        cat > ~/hf-constraints.txt << 'HF_CONSTRAINTS_EOF'
+        %s
+        HF_CONSTRAINTS_EOF
+
+        git clone -b flash_attention https://github.com/pytorch-tpu/transformers.git
+
+        # install tokenizer model
+        curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+        tar -xf google-cloud-cli-linux-x86_64.tar.gz
+        yes | ./google-cloud-sdk/install.sh
+        google-cloud-sdk/bin/gsutil cp -r gs://pytorch-airflow/llama_3/ .
+
+        cd transformers
+        sudo pip3 install -e . -c ~/hf-constraints.txt
+        pip3 install 'torch_xla[pallas]' -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+        pip3 install datasets evaluate scikit-learn accelerate -c ~/hf-constraints.txt
+      ||| % common.HuggingfacePipVersionConstraints,
+    },
+  },
+
+  local llama3_train_2_slice = self.llama3_train_2_slice,
+  llama3_train_2_slice:: llama3_train {
+    modelName: 'llama3-train-2-slice',
+    command: [
+      'python',
+      'transformers/examples/pytorch/language-modeling/run_clm.py',
+      '--dataset_name=wikitext',
+      '--dataset_config_name=wikitext-2-raw-v1',
+      '--per_device_train_batch_size=8',
+      '--do_train',
+      '--output_dir=./tmp/test-clm',
+      '--overwrite_output_dir',
+      '--config_name=./llama_3/config.json',
+      '--cache_dir=./cache',
+      '--tokenizer_name=./llama_3/tokenizer/',
+      '--block_size=8192',
+      '--optim=adafactor',
+      '--save_strategy=no',
+      '--logging_strategy=no',
+      '--fsdp=full_shard',
+      '--fsdp_config=./llama_3/fsdp_config.json',
+      '--torch_dtype=bfloat16',
+      '--dataloader_drop_last=yes',
+      '--flash_attention',
+      '--max_steps=10',
+    ]
+  },
 
   local v4_8 = self.v4_8,
   v4_8:: {
     accelerator: tpus.v4_8,
   },
 
+  local v5p_8 = self.v5p_8,
+  v5p_8:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv5',
+    },
+    accelerator: tpus.v5p_8,
+  },
+
+  local trillium_4 = self.trillium_4,
+  trillium_4:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha-tpuv6e',
+    },
+    accelerator: tpus.trillium_4,
+  },
+
   configs: [
     llama2 + infer + v4_8 + timeouts.Hours(3),
     llama2 + spmd + v4_8 + timeouts.Hours(3),
+    llama2 + infer + v5p_8 + timeouts.Hours(3),
+    llama2 + spmd + v5p_8 + timeouts.Hours(3),
+    llama3_train + v5p_8 + timeouts.Hours(3),
+    llama3_train + trillium_4 + timeouts.Hours(3),
+    llama3_train_2_slice + v5p_8 + timeouts.Hours(3),
   ],
 }

--- a/dags/legacy_test/tests/pytorch/r2.6/llama2-model.libsonnet
+++ b/dags/legacy_test/tests/pytorch/r2.6/llama2-model.libsonnet
@@ -138,7 +138,7 @@ local utils = import 'templates/utils.libsonnet';
       'transformers/examples/pytorch/language-modeling/run_clm.py',
       '--dataset_name=wikitext',
       '--dataset_config_name=wikitext-2-raw-v1',
-      '--per_device_train_batch_size=2',
+      '--per_device_train_batch_size=4',
       '--do_train',
       '--output_dir=./tmp/test-clm',
       '--overwrite_output_dir',
@@ -182,6 +182,34 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
+  local llama3_train_2_slice = self.llama3_train_2_slice,
+  llama3_train_2_slice:: llama3_train {
+    modelName: 'llama3-train-2-slice',
+    command: [
+      'python',
+      'transformers/examples/pytorch/language-modeling/run_clm.py',
+      '--dataset_name=wikitext',
+      '--dataset_config_name=wikitext-2-raw-v1',
+      '--per_device_train_batch_size=8',
+      '--do_train',
+      '--output_dir=./tmp/test-clm',
+      '--overwrite_output_dir',
+      '--config_name=./llama_3/config.json',
+      '--cache_dir=./cache',
+      '--tokenizer_name=./llama_3/tokenizer/',
+      '--block_size=8192',
+      '--optim=adafactor',
+      '--save_strategy=no',
+      '--logging_strategy=no',
+      '--fsdp=full_shard',
+      '--fsdp_config=./llama_3/fsdp_config.json',
+      '--torch_dtype=bfloat16',
+      '--dataloader_drop_last=yes',
+      '--flash_attention',
+      '--max_steps=10',
+    ]
+  },
+
   local v4_8 = self.v4_8,
   v4_8:: {
     accelerator: tpus.v4_8,
@@ -210,5 +238,6 @@ local utils = import 'templates/utils.libsonnet';
     llama2 + spmd + v5p_8 + timeouts.Hours(3),
     llama3_train + v5p_8 + timeouts.Hours(3),
     llama3_train + trillium_4 + timeouts.Hours(3),
+    llama3_train_2_slice + v5p_8 + timeouts.Hours(3),
   ],
 }

--- a/dags/pytorch_xla/nightly.py
+++ b/dags/pytorch_xla/nightly.py
@@ -204,6 +204,33 @@ def llama():
       ),
       US_CENTRAL2_B,
   )
+  llama_3_train_trillium = task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-llama3-train-func-v6e-4-1vm",
+          network=V5_NETWORKS,
+          subnetwork=V6E_SUBNETWORKS,
+      ),
+      US_CENTRAL2_B_TPU_PROD_ENV,
+  )
+  llama_3_train_v5p_2_slices = task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-llama3-train-2-slice-func-v5p-8-1vm",
+          reserved=True,
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+          num_slices=2,
+      ),
+      US_EAST5_A_TPU_PROD_ENV_AUTOMATED,
+  )
+  llama_3_train_v5p_8 = task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-nightly-llama3-train-func-v5p-8-1vm",
+          reserved=True,
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+      ),
+      US_EAST5_A_TPU_PROD_ENV_AUTOMATED,
+  )
 
 
 with models.DAG(

--- a/dags/pytorch_xla/r2_6.py
+++ b/dags/pytorch_xla/r2_6.py
@@ -230,6 +230,16 @@ def llama():
       ),
       US_CENTRAL2_B_TPU_PROD_ENV,
   )
+  llama_3_train_v5p_2_slices = task.run_queued_resource_test(
+      test_config.JSonnetTpuVmTest.from_pytorch(
+          "pt-2-6-llama3-train-2-slice-func-v5p-8-1vm",
+          reserved=True,
+          network=V5_NETWORKS,
+          subnetwork=V5P_SUBNETWORKS,
+          num_slices=2,
+      ),
+      US_EAST5_A_TPU_PROD_ENV_AUTOMATED,
+  )
   llama_3_train_v5p_8 = task.run_queued_resource_test(
       test_config.JSonnetTpuVmTest.from_pytorch(
           "pt-2-6-llama3-train-func-v5p-8-1vm",

--- a/xlml/apis/test_config.py
+++ b/xlml/apis/test_config.py
@@ -396,6 +396,7 @@ class JSonnetTpuVmTest(TestConfig[Tpu]):
       reserved: bool,
       network: str,
       subnetwork: str,
+      num_slices: int = 1,
   ):
     return JSonnetTpuVmTest(
         test_name=test['testName'],
@@ -414,6 +415,7 @@ class JSonnetTpuVmTest(TestConfig[Tpu]):
         exports=exports,
         test_command=test_command,
         timeout=datetime.timedelta(seconds=test['timeout']),
+        num_slices=num_slices,
     )
 
   @staticmethod
@@ -442,6 +444,7 @@ class JSonnetTpuVmTest(TestConfig[Tpu]):
       reserved: bool = False,
       network='default',
       subnetwork='default',
+      num_slices: int = 1,
   ):
     """Parses a compiled legacy JSonnet test config from `tests/pytorch`."""
     test = _load_compiled_jsonnet(test_name)
@@ -455,6 +458,7 @@ class JSonnetTpuVmTest(TestConfig[Tpu]):
         reserved=reserved,
         network=network,
         subnetwork=subnetwork,
+        num_slices=num_slices,
     )
 
   @property


### PR DESCRIPTION
Specifically, two slices of v5p-8.

This is to ensure that both r2.6 and ptxla nightly continue to work in multi-slice (DCN networking involved) environments.

I noticed that we are not testing llama3 in nightly so I added that too, copying from our release tests.

# Test

http://shortn/_q9gzUMfboD

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.