### PR TITLE
Fix oncall test `tf_dlrm_criteo-v5p-8`

### DIFF
--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -229,7 +229,10 @@ def get_tf_dlrm_v1_config(
       set_up_cmds += common.set_up_se()
     else:
       set_up_cmds += common.set_up_pjrt()
-  set_up_cmds += ("sudo apt-get -y update", "sudo apt-get install numactl",)
+  set_up_cmds += (
+      "sudo apt-get -y update",
+      "sudo apt-get install numactl",
+  )
   params_override = {
       "runtime": {"distribution_strategy": "tpu"},
       "task": {

--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -229,7 +229,7 @@ def get_tf_dlrm_v1_config(
       set_up_cmds += common.set_up_se()
     else:
       set_up_cmds += common.set_up_pjrt()
-  set_up_cmds += ("sudo apt-get install numactl",)
+  set_up_cmds += ("sudo apt-get -y update", "sudo apt-get install numactl",)
   params_override = {
       "runtime": {"distribution_strategy": "tpu"},
       "task": {


### PR DESCRIPTION
# Description

Fix oncall test `tf_dlrm_criteo-v5p-8` by running `sudo apt-get -y update` before installing packages. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.