### PR TITLE
Fix command in maxtext_checkpointing

### DIFF
--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -60,7 +60,7 @@ with models.DAG(
           command = (
               "bash end_to_end/test_checkpointing.sh"
               f" checkpointing-{mode.value}-{slice_num}x-{accelerator}-{chkpt_mode}"
-              f" {base_output_directory} {dataset_path} true tfds autoselected {async_checkpointing}"
+              f" {base_output_directory} {dataset_path} true tfds autoselected {async_checkpointing}",
           )
           maxtext_v4_configs_test = gke_config.get_gke_config(
               num_slices=slice_num,


### PR DESCRIPTION
# Description
Change in formatting of `run_model_cmds` variable in https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/118 is causing the command in `dags/multipod/maxtext_checkpointing.py` to be formatted in this way: `set -xue;b;a;s;h; ;e;n;d;;t;o;;e;n;d;/;t;e;s;t;;c;h;e;c;k;p;o;i;n;t;i;n;g;.;s;h; ;c;h;e;c;k;p;o;i;n;t;i;n;g;-;s;t;a;b;l;e;-;1;x;-;v;4;-;8;-;a;s;y;n;c;`. As a result, the command is not able to execute as expected.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Tested on local airflow.

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.