### PR TITLE
Added MultiNode Test for JStS on A3Plus GPUs

### DIFF
--- a/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
@@ -46,21 +46,21 @@ with models.DAG(
   current_datetime = config.get_current_datetime()
 
   train_base = (
-    "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
-    "python3 MaxText/train.py MaxText/configs/base.yml "
-    "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
-    "steps=2 enable_checkpointing=false attention=dot_product"
+      "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
+      "python3 MaxText/train.py MaxText/configs/base.yml "
+      "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
+      "steps=2 enable_checkpointing=false attention=dot_product"
   )
 
   test_models_gpu = {
-    "train-c4-data-1node": (
-      f"{train_base} run_name=runner-{current_datetime}-0",
+      "train-c4-data-1node": (
+          f"{train_base} run_name=runner-{current_datetime}-0",
           1,
-    ),
-    "train-c4-data-2node": (
-      f"{train_base} run_name=runner-{current_datetime}-0",
+      ),
+      "train-c4-data-2node": (
+          f"{train_base} run_name=runner-{current_datetime}-0",
           2,
-    ),
+      ),
   }
 
   quarantine_task_group = TaskGroup(

--- a/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
@@ -44,17 +44,23 @@ with models.DAG(
     catchup=False,
 ) as dag:
   current_datetime = config.get_current_datetime()
+
   train_base = (
-      "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
-      "python3 MaxText/train.py MaxText/configs/base.yml "
-      "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
-      "steps=2 enable_checkpointing=false attention=dot_product"
+    "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
+    "python3 MaxText/train.py MaxText/configs/base.yml "
+    "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
+    "steps=2 enable_checkpointing=false attention=dot_product"
   )
+
   test_models_gpu = {
-      "train-c4-data": (
-          f"{train_base} run_name=runner-{current_datetime}-0",
+    "train-c4-data-1node": (
+      f"{train_base} run_name=runner-{current_datetime}-0",
           1,
-      ),
+    ),
+    "train-c4-data-2node": (
+      f"{train_base} run_name=runner-{current_datetime}-0",
+          2,
+    ),
   }
 
   quarantine_task_group = TaskGroup(


### PR DESCRIPTION
# Description

Currently, the tests for JStS on A3Plus GPUs only tests for 1 node. This PR adds another testcase for testing on a multinode conifguration. 

Once A3Ultra support is added, these testcases will be rolled over to the new GPU generation and more testcases will be added in upcoming PRs.

# Tests

Verified tests passing in Airflow.

[Link to Image] (https://screenshot.googleplex.com/9aV3xcXgegbzZ5y)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.