### PR TITLE
Fix pathways v5e perf test

### DIFF
--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -103,7 +103,7 @@ with models.DAG(
   for mode, image in DOCKER_IMAGES:
     for model in MaxTextV5eModelConfigs:
       base_run_model_cmds = [
-          f"python3 benchmarks/benchmark_runner.py on-device --base_output_directory={BASE_OUTPUT_DIRECTORY} --model_name={model.value} --libtpu_type=maxtext-docker --num_steps=15",
+          f"python3 benchmarks/benchmark_runner.py on-device --base_output_directory={BASE_OUTPUT_DIRECTORY} --model_name={model.value} --libtpu_type=maxtext-docker --num_steps=15 --use_pathways=True",
       ]
       maxtext_sweep_gke_test = (
           maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(


### PR DESCRIPTION
# Description

The pathways_maxtext_v5e_configs_perf airflow test fails because JAX_PLATFORMS=proxy and JAX_BACKEND_TARGET=... environment vars are missing (Thanks to Luke for rootcausing and suggesting a fix)

Summary of the issue:
- The pathways configs were only being set up in the xpk sub-command and not on-device. ([this](https://github.com/AI-Hypercomputer/maxtext/pull/1326) PR)
- The on-device test on Airflow is not passing the use_pathways flag (THIS PR)

FIXES: b/372059783

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.
- `python3 benchmarks/benchmark_runner.py on-device --base_output_directory={OUTPUT_PATH}  --libtpu_type=maxtext-docker --num_steps=15 --use_pathways=True`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.