### PR TITLE
Add `mlscale_onduty` tag and ungroup tests

### DIFF
--- a/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
@@ -18,7 +18,6 @@
 import datetime
 
 from airflow import models
-from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, DockerImage
@@ -82,13 +81,9 @@ with models.DAG(
         "gpu",
         "stable",
         "nightly",
+        "mlscale_onduty",
     ],
     start_date=datetime.datetime(2024, 12, 11),
     catchup=False,
 ) as dag:
-  with TaskGroup(
-      group_id="run_tests", dag=dag, prefix_group_id=False
-  ) as run_tests:
-    run_maxtext_tests()
-
-  run_tests
+  run_maxtext_tests()


### PR DESCRIPTION
# Description

This PR adds `mlscale_onduty` tag to `maxtext_moe_gpu_e2e` DAG. It also ungroups the tests in the DAG


# Tests

https://shortn.corp.google.com/add.py

http://shortn/_mji0MjBro6

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.