### PR TITLE
Added project_bite_tpu_unittests and associated config to test axlear…

### DIFF
--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -84,3 +84,4 @@ GUNJAN_J = "Gunjan J."
 
 # Bite
 Maggie_Z = "Maggie Z."
+Andrew_S = "Andrew S."

--- a/dags/sparsity_diffusion_devx/configs/project_bite_config.py
+++ b/dags/sparsity_diffusion_devx/configs/project_bite_config.py
@@ -108,9 +108,10 @@ def get_bite_tpu_unittests_config(
       "pip install -U --pre libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
       "pip install --pre -U jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html",
       "pip install git+https://github.com/google/jax",
+      "pip freeze",
       # create configuration files needed
       """cat > Dockerfile_CI <<EOF
-FROM cimg/python:3.10
+FROM python:3.10-slim
 WORKDIR /workspace
 COPY run_tpu_tests.sh /workspace/
 RUN git clone https://github.com/apple/axlearn.git

--- a/dags/sparsity_diffusion_devx/configs/project_bite_config.py
+++ b/dags/sparsity_diffusion_devx/configs/project_bite_config.py
@@ -114,6 +114,8 @@ def get_bite_tpu_unittests_config(
 FROM python:3.10-slim
 WORKDIR /workspace
 COPY run_tpu_tests.sh /workspace/
+RUN apt update -y
+RUN apt install -y git
 RUN git clone https://github.com/apple/axlearn.git
 WORKDIR /workspace/axlearn
 RUN pip install --upgrade pip

--- a/dags/sparsity_diffusion_devx/configs/project_bite_config.py
+++ b/dags/sparsity_diffusion_devx/configs/project_bite_config.py
@@ -93,6 +93,7 @@ def get_bite_tpu_config(
       task_gcp_config=job_gcp_config,
   )
 
+
 def get_bite_tpu_unittests_config(
     tpu_version: TpuVersion,
     tpu_cores: int,
@@ -155,7 +156,7 @@ EOF
           runtime_version=runtime_version,
           reserved=is_tpu_reserved,
       ),
-      test_name='bite_unittests',
+      test_name="bite_unittests",
       set_up_cmds=unittest_setupcmds,
       run_model_cmds=unittest_runcmds,
       timeout=datetime.timedelta(minutes=time_out_in_min),
@@ -165,4 +166,4 @@ EOF
   return task.run_queued_resource_test(
       task_test_config=tpu_unittests_test_config,
       task_gcp_config=job_gcp_config,
-    )
+  )

--- a/dags/sparsity_diffusion_devx/configs/project_bite_config.py
+++ b/dags/sparsity_diffusion_devx/configs/project_bite_config.py
@@ -92,3 +92,79 @@ def get_bite_tpu_config(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
   )
+
+def get_bite_tpu_unittests_config(
+    tpu_version: TpuVersion,
+    tpu_cores: int,
+    tpu_zone: str,
+    runtime_version: str,
+    time_out_in_min: int,
+    task_owner: str,
+    is_tpu_reserved: bool = False,
+    pinned_version: Optional[str] = None,
+):
+  unittest_setupcmds = (
+      # Need to install drivers in the TPU VM as well as in the docker image
+      "pip install -U --pre libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
+      "pip install --pre -U jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html",
+      "pip install git+https://github.com/google/jax",
+      # create configuration files needed
+      """cat > Dockerfile_CI <<EOF
+FROM cimg/python:3.10
+WORKDIR /workspace
+COPY run_tpu_tests.sh /workspace/
+RUN git clone https://github.com/apple/axlearn.git
+WORKDIR /workspace/axlearn
+RUN pip install --upgrade pip
+RUN pip install -e '.[core,dev,gcp]'
+RUN pip install grain
+RUN pip install google-cloud-aiplatform
+RUN pip install -U --pre libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+RUN pip install --pre -U jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
+RUN pip install git+https://github.com/google/jax
+RUN pip freeze
+EOF
+""",
+      # create script to run the tests inside of the container
+      # incluedes a basic sanity check python script which prints out TPU env info for reference
+      """cat > run_tpu_tests.sh <<EOF
+set -x
+echo '#### Starting TPU JAX Tests'
+pip freeze
+JAX_PLATFORMS='tpu' python -c 'import jax; jax.print_environment_info() ; print(f"Global device count: {jax.device_count()}")'
+cd /workspace/axlearn
+pytest --no-header -v axlearn/common/flash_attention/
+EOF
+""",
+      "chmod +x run_tpu_tests.sh",
+      "sudo docker build -f Dockerfile_CI -t ml-auto-solutions/tpu_unittests .",
+  )
+  # Run the unittest as non-root user, ulimit param req to mmap TPUs inside docker (default limit is 8192)
+  unittest_runcmds = (
+      "echo '#### Start docker image - tpu_unittests'",
+      "sudo docker run --network=host --privileged --ulimit memlock=-1:-1  ml-auto-solutions/tpu_unittests  /bin/bash -c '/workspace/run_tpu_tests.sh'",
+  )
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+      zone=tpu_zone,
+      dataset_name=metric_config.DatasetOption.XLML_DATASET,
+  )
+
+  tpu_unittests_test_config = test_config.TpuVmTest(
+      test_config.Tpu(
+          version=tpu_version,
+          cores=tpu_cores,
+          runtime_version=runtime_version,
+          reserved=is_tpu_reserved,
+      ),
+      test_name='bite_unittests',
+      set_up_cmds=unittest_setupcmds,
+      run_model_cmds=unittest_runcmds,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=task_owner,
+      gcs_subfolder=f"{GCS_SUBFOLDER_PREFIX}/jax",
+  )
+  return task.run_queued_resource_test(
+      task_test_config=tpu_unittests_test_config,
+      task_gcp_config=job_gcp_config,
+    )

--- a/dags/sparsity_diffusion_devx/configs/project_bite_config.py
+++ b/dags/sparsity_diffusion_devx/configs/project_bite_config.py
@@ -104,11 +104,6 @@ def get_bite_tpu_unittests_config(
     pinned_version: Optional[str] = None,
 ):
   unittest_setupcmds = (
-      # Need to install drivers in the TPU VM as well as in the docker image
-      "pip install -U --pre libtpu-nightly -f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
-      "pip install --pre -U jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html",
-      "pip install git+https://github.com/google/jax",
-      "pip freeze",
       # create configuration files needed
       """cat > Dockerfile_CI <<EOF
 FROM python:3.10-slim

--- a/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
@@ -64,3 +64,29 @@ with models.DAG(
       time_out_in_min=180,
       task_owner=test_owner.Maggie_Z,
   )
+
+default_unittest_args = {
+    "retries": 0,
+}
+
+with models.DAG(
+    dag_id="project_bite_tpu_unittests",
+    schedule=SCHEDULED_TIME,
+    tags=[
+        "sparsity_diffusion_devx",
+        "tpu",
+        "axlearn",
+        "bite",
+    ],
+    start_date=datetime.datetime(2025, 2, 24),
+    catchup=False,
+    default_args=default_unittest_args,
+) as dag:
+  unittests = config.get_bite_tpu_unittests_config(
+      tpu_version=TpuVersion.TRILLIUM,
+      tpu_cores=4,
+      tpu_zone=Zone.EUROPE_WEST4_A.value,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV6.value,
+      time_out_in_min=180,
+      task_owner=test_owner.Andrew_S,
+  )


### PR DESCRIPTION
…n framework with v6e TPUs

- Currently only runs tests in axlearn/common/flash_attention/

# Description

Added code to automated test runs of some of the unit tests in the Axlearn framework on a v6e TPU VM to help diagnose any issues arising from changes in Jax, TPU framework etc.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

On a v6e TPU VM, checkout axlearn (https://github.com/apple/axlearn ), configure the dependencies, and run:
  pytest --no-header -v axlearn/common/flash_attention/
from within the axlearn repo.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.