### PR TITLE
Update bite training tests to use v5p and v6e [DRAFT]

### DIFF
--- a/dags/sparsity_diffusion_devx/configs/common.py
+++ b/dags/sparsity_diffusion_devx/configs/common.py
@@ -18,6 +18,8 @@ from typing import Tuple
 
 
 UPGRADE_PIP = "pip install --upgrade pip"
+UPGRADE_SETUPTOOLS = "python -m pip install --upgrade setuptools"
+UPGRADE_PACKAGING = "python -m pip install --upgrade packaging"
 
 
 def set_up_nightly_jax() -> Tuple[str]:

--- a/dags/sparsity_diffusion_devx/configs/project_bite_config.py
+++ b/dags/sparsity_diffusion_devx/configs/project_bite_config.py
@@ -35,15 +35,13 @@ def set_up_axlearn(pinned_version) -> Tuple[str]:
 
   return (
       common.UPGRADE_PIP,
+      common.UPGRADE_SETUPTOOLS,
+      common.UPGRADE_PACKAGING,
       "git clone https://github.com/apple/axlearn.git",
       reset_version,
       "python -m pip install ./axlearn[core]",
       *common.set_up_nightly_jax(),
-      "pip install tensorflow_text==2.16.1",
-      "pip install tensorflow==2.16.1",
-      "pip install ml-dtypes==0.4.0",
   )
-
 
 def get_bite_tpu_config(
     tpu_version: TpuVersion,

--- a/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
@@ -41,6 +41,7 @@ with models.DAG(
 ) as dag:
   # AXLearn head against JAX head
   # Runs Fuji training on v5p-8
+  # TODO(andrewsal): Use another project's v5p capacity
   jax_fuji_v5p_8 = config.get_bite_tpu_config(
       tpu_version=TpuVersion.V5P,
       tpu_cores=8,

--- a/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
@@ -40,27 +40,40 @@ with models.DAG(
     catchup=False,
 ) as dag:
   # AXLearn head against JAX head
-  jax_fuji_v4_8 = config.get_bite_tpu_config(
-      tpu_version=TpuVersion.V4,
+  # Runs Fuji training on v5p-8
+  jax_fuji_v5p_8 = config.get_bite_tpu_config(
+      tpu_version=TpuVersion.V5P,
       tpu_cores=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
-      runtime_version=RuntimeVersion.TPU_UBUNTU2204_BASE.value,
+      tpu_zone=Zone.US_EAST5_A.value,
+      runtime_version=RuntimeVersion.TPU_VM_TF_V5P_ALPHA.value,
+      model_config="fuji-test-v1",
+      time_out_in_min=180,
+      task_owner=test_owner.Maggie_Z,
+  )
+
+  # AXLearn head against JAX head
+  # Runs Fuji training on v6e-8
+  jax_fuji_v6e_8 = config.get_bite_tpu_config(
+      tpu_version=TpuVersion.TRILLIUM,
+      tpu_cores=8,
+      tpu_zone=Zone.US_EAST5_B.value,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV6.value,
       model_config="fuji-test-v1",
       time_out_in_min=180,
       task_owner=test_owner.Maggie_Z,
   )
 
   # AXLearn pinned version against JAX head
-  # pinned_version commit: e918d7c219d067dfcace8a25e619d90c5a54c36b
-  # pinned_version PR: https://github.com/apple/axlearn/pull/752
-  # pinned_version date: Oct 16, 2024
-  jax_pinned_fuji_v4_8 = config.get_bite_tpu_config(
-      tpu_version=TpuVersion.V4,
+  # pinned_version commit: 35a189c15bdd06416be743cecde272693363ce3c
+  # pinned_version PR: https://github.com/apple/axlearn/pull/1033
+  # pinned_version date: March 6, 2025 (test succeeds at this commit)
+  jax_pinned_fuji_v6e_8 = config.get_bite_tpu_config(
+      tpu_version=TpuVersion.TRILLIUM,
       tpu_cores=8,
-      tpu_zone=Zone.US_CENTRAL2_B.value,
-      runtime_version=RuntimeVersion.TPU_UBUNTU2204_BASE.value,
+      tpu_zone=Zone.US_EAST5_B.value,
+      runtime_version=RuntimeVersion.V2_ALPHA_TPUV6.value,
       model_config="fuji-test-v1",
-      pinned_version="e918d7c219d067dfcace8a25e619d90c5a54c36b",
+      pinned_version="35a189c15bdd06416be743cecde272693363ce3c",
       time_out_in_min=180,
       task_owner=test_owner.Maggie_Z,
   )


### PR DESCRIPTION
# Description

Changed `project_bite_tpu_e2e.py` to run 3 tests:
1. JAX nightly + AXLearn HEAD: fuji training, v5p-8
2. JAX nightly + AXLearn HEAD: fuji training, v6e-8
3. JAX nightly + AXLearn pinned version: fuji training, v6e-8

Updated (3) pinned version to a more recent commit (March 6, 2025) with the most recent successful run.

**Note:** This PR can stay a draft until we figure out v5p capacity and have at least 1 successful run. Tests (2) and (3) are tested.

# Tests

TODO

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [ ] I have made or will make corresponding changes to the doc if needed.