### PR TITLE
Removed unused and old docker images

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -328,10 +328,6 @@ class DockerImage(enum.Enum):
       "gcr.io/tpu-prod-env-multipod/maxdiffusion_jax_stable_stack:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXDIFFUSION_TPU_JAX_NIGHTLY = (
-      "gcr.io/tpu-prod-env-multipod/maxdiffusion_jax_nightly:"
-      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
-  )
   MAXDIFFUSION_TPU_STABLE_STACK_NIGHTLY_JAX = (
       "gcr.io/tpu-prod-env-multipod/maxdiffusion_stable_stack_nightly_jax:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
@@ -358,10 +354,6 @@ class DockerImage(enum.Enum):
   )
   MAXTEXT_GPU_STABLE_STACK_NIGHTLY_JAX = (
       "gcr.io/tpu-prod-env-multipod/maxtext_gpu_stable_stack_nightly_jax:"
-      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
-  )
-  MAXTEXT_GPU_JAX_NIGHTLY = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_nightly:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   CLOUD_HYBRIDSIM_NIGHTLY = (


### PR DESCRIPTION
# Description

Cleaning up old jax images that are not used in any DAGs. 

FIXES: b/399672992

# Tests

Verified that these images are old via artifact registry and that they are not used anywhere in the repo.

MAXDIFFUSION_TPU_JAX_NIGHTLY: https://screenshot.googleplex.com/8aWxrWZfDW9T4Qr
MAXTEXT_GPU_JAX_NIGHTLY: https://screenshot.googleplex.com/6NbjrhoN4JyuyWh 


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.