### PR TITLE
Add internal benchmarking runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ tmp
 
 # Build artifacts
 *.whl
+
+
+**/map_reproducibility/helm-charts/*
+**/map_reproducibility/scripts/*
+**/map_reproducibility/values/*
+**/map_reproducibility/recipes/*

--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
@@ -18,7 +18,7 @@ import datetime
 
 from airflow import models
 from dags.map_reproducibility.utils.constants import Schedule
-from dags.map_reproducibility.utils.aotc_workload import run_aotc_workload
+from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_aotc_workload
 
 
 TEST_RUN = False
@@ -26,8 +26,21 @@ TURN_ON_SCHEDULE = False
 
 # List of configuration setups as a dictionary with schedule times
 config_yamls = {
-    "recipes/a3mega/a3mega_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY, # < 5mins
-    # Add more config paths as needed
+    # a3mega_llama3.1-8b
+    "recipes/a3mega/a3mega_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,  # < 5mins
+    "recipes/a3mega/a3mega_llama3.1-8b_8gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    "recipes/a3mega/a3mega_llama3.1-8b_16gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    "recipes/a3mega/a3mega_llama3.1-8b_16gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # a3mega_mixtral-8x7 image issue
+    # "recipes/a3mega/a3mega_mixtral-8x7b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3mega/a3mega_mixtral-8x7b_8gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3mega/a3mega_mixtral-8x7b_16gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3mega/a3mega_mixtral-8x7b_16gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # a3mega_llama3.1-70b
+    "recipes/a3mega/a3mega_llama3.1-70b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
+    "recipes/a3mega/a3mega_llama3.1-70b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
+    # a3mega_llama3.1-405b image issue
+    # "recipes/a3mega/a3mega_llama3.1-405b_512gpus_bf16_maxtext.yaml": Schedule.DAILY_7PM_EXCEPT_THURSDAY,
 }
 
 # Define common tags
@@ -38,26 +51,28 @@ common_tags = [
     "v1.9",
     "internal",
     "regressiontests",
-    "a3ultra",
+    "a3mega",
 ]
 
 # Create a DAG for each config
 for relative_config_yaml_path, schedule_time in config_yamls.items():
-    # Extract config name for the DAG ID
-    config_yaml_name = relative_config_yaml_path.rsplit('/', maxsplit=1)[-1].replace(".yaml", "")
-    
-    dag_id = f"new_internal_{config_yaml_name}"
-    actual_schedule = schedule_time if TURN_ON_SCHEDULE else None
-    
-    # Define the DAG
-    with models.DAG(
-        dag_id=dag_id,
-        schedule=actual_schedule,  # Use the specific schedule time
-        tags=common_tags,
-        start_date=datetime.datetime(2025, 3, 15),
-        catchup=False,
-        is_paused_upon_creation=True if TEST_RUN else False
-    ) as dag:
-        # Create the workload for this specific config
-        run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path, test_run=TEST_RUN)
-        # run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path)
+  # Extract config name for the DAG ID
+  config_yaml_name = relative_config_yaml_path.rsplit("/", maxsplit=1)[
+      -1
+  ].replace(".yaml", "")
+
+  dag_id = f"new_internal_{config_yaml_name}"
+  actual_schedule = schedule_time if TURN_ON_SCHEDULE else None
+
+  # Define the DAG
+  with models.DAG(
+      dag_id=dag_id,
+      schedule=actual_schedule,  # Use the specific schedule time
+      tags=common_tags,
+      start_date=datetime.datetime(2025, 3, 15),
+      catchup=False,
+  ) as dag:
+    # Create the workload for this specific config
+    run_internal_aotc_workload(
+        relative_config_yaml_path=relative_config_yaml_path, test_run=TEST_RUN
+    )

--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DAGs to run Aotc reproducibility benchmarks."""
+
+import datetime
+
+from airflow import models
+from dags.map_reproducibility.utils.constants import Schedule
+from dags.map_reproducibility.utils.aotc_workload import run_aotc_workload
+
+
+TEST_RUN = False
+TURN_ON_SCHEDULE = False
+
+# List of configuration setups as a dictionary with schedule times
+config_yamls = {
+    "recipes/a3mega/a3mega_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY, # < 5mins
+    # Add more config paths as needed
+}
+
+# Define common tags
+common_tags = [
+    "reproducibility",
+    "experimental",
+    "xlml",
+    "v1.9",
+    "internal",
+    "regressiontests",
+    "a3ultra",
+]
+
+# Create a DAG for each config
+for relative_config_yaml_path, schedule_time in config_yamls.items():
+    # Extract config name for the DAG ID
+    config_yaml_name = relative_config_yaml_path.rsplit('/', maxsplit=1)[-1].replace(".yaml", "")
+    
+    dag_id = f"new_internal_{config_yaml_name}"
+    actual_schedule = schedule_time if TURN_ON_SCHEDULE else None
+    
+    # Define the DAG
+    with models.DAG(
+        dag_id=dag_id,
+        schedule=actual_schedule,  # Use the specific schedule time
+        tags=common_tags,
+        start_date=datetime.datetime(2025, 3, 15),
+        catchup=False,
+        is_paused_upon_creation=True if TEST_RUN else False
+    ) as dag:
+        # Create the workload for this specific config
+        run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path, test_run=TEST_RUN)
+        # run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path)

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,44 +17,38 @@
 import datetime
 
 from airflow import models
+from dags.map_reproducibility.utils.constants import Schedule
 from dags.map_reproducibility.utils.aotc_workload import run_aotc_workload
 
 
-# List of configuration setups
-config_yamls = [
-    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_bf16_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_bf16_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_fp8_maxtext.yaml",
+# List of configuration setups as a dictionary with schedule times
+config_yamls = {
+    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY, # < 5mins
+    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
 
-    "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_bf16_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_fp8_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
+    "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
 
-    "recipes/a3ultra/a3ultra_mixtral8x7b_8gpus_bf16_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_mixtral8x7b_8gpus_fp8_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_mixtral8x7b_16gpus_bf16_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_mixtral8x7b_16gpus_fp8_maxtext.yaml",
-
-    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_fp8_maxtext.yaml",
-    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_bf16_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_7PM_EXCEPT_THURSDAY, # 20mins for the run
+    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_7_30PM_EXCEPT_THURSDAY, # 40mins
     # Add more config paths as needed
-]
-
-SCHEDULED_TIME = None
+}
 
 # Define common tags
 common_tags = [
     "reproducibility",
     "experimental",
     "xlml",
-    "v1.7"
+    "v1.8",  # Fixed missing comma
     "internal",
     "regressiontests",
     "a3ultra",
 ]
 
 # Create a DAG for each config
-for relative_config_yaml_path in config_yamls:
+for relative_config_yaml_path, schedule_time in config_yamls.items():
     # Extract config name for the DAG ID
     config_yaml_name = relative_config_yaml_path.rsplit('/', maxsplit=1)[-1].replace(".yaml", "")
     
@@ -63,7 +57,7 @@ for relative_config_yaml_path in config_yamls:
     # Define the DAG
     with models.DAG(
         dag_id=dag_id,
-        schedule=SCHEDULED_TIME,
+        schedule=schedule_time,  # Use the specific schedule time
         tags=common_tags,
         start_date=datetime.datetime(2025, 3, 15),
         catchup=False,

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -1,0 +1,73 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DAGs to run Aotc reproducibility benchmarks."""
+
+import datetime
+
+from airflow import models
+from dags.map_reproducibility.utils.aotc_workload import run_aotc_workload
+
+
+# List of configuration setups
+config_yamls = [
+    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_bf16_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_bf16_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_fp8_maxtext.yaml",
+
+    "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_bf16_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_fp8_maxtext.yaml",
+
+    "recipes/a3ultra/a3ultra_mixtral8x7b_8gpus_bf16_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_mixtral8x7b_8gpus_fp8_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_mixtral8x7b_16gpus_bf16_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_mixtral8x7b_16gpus_fp8_maxtext.yaml",
+
+    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_fp8_maxtext.yaml",
+    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_bf16_maxtext.yaml",
+    # Add more config paths as needed
+]
+
+SCHEDULED_TIME = None
+
+# Define common tags
+common_tags = [
+    "reproducibility",
+    "experimental",
+    "xlml",
+    "v1.7"
+    "internal",
+    "regressiontests",
+    "a3ultra",
+]
+
+# Create a DAG for each config
+for relative_config_yaml_path in config_yamls:
+    # Extract config name for the DAG ID
+    config_yaml_name = relative_config_yaml_path.rsplit('/', maxsplit=1)[-1].replace(".yaml", "")
+    
+    dag_id = f"new_internal_{config_yaml_name}"
+    
+    # Define the DAG
+    with models.DAG(
+        dag_id=dag_id,
+        schedule=SCHEDULED_TIME,
+        tags=common_tags,
+        start_date=datetime.datetime(2025, 3, 15),
+        catchup=False,
+    ) as dag:
+        # Create the workload for this specific config
+        # run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path, test_run=True)
+        run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path)

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -21,18 +21,19 @@ from dags.map_reproducibility.utils.constants import Schedule
 from dags.map_reproducibility.utils.aotc_workload import run_aotc_workload
 
 
+TEST_RUN = False
+TURN_ON_SCHEDULE = False
+
 # List of configuration setups as a dictionary with schedule times
 config_yamls = {
-    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY, # < 5mins
+    "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,  # < 5mins
     "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
     "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
     "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
-
     "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
     "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
-
-    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_7PM_EXCEPT_THURSDAY, # 20mins for the run
-    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_7_30PM_EXCEPT_THURSDAY, # 40mins
+    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_7PM_EXCEPT_THURSDAY,  # 30mins for the run
+    "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_7_30PM_EXCEPT_THURSDAY,  # 50mins
     # Add more config paths as needed
 }
 
@@ -41,7 +42,7 @@ common_tags = [
     "reproducibility",
     "experimental",
     "xlml",
-    "v1.8",  # Fixed missing comma
+    "v1.13",
     "internal",
     "regressiontests",
     "a3ultra",
@@ -49,19 +50,23 @@ common_tags = [
 
 # Create a DAG for each config
 for relative_config_yaml_path, schedule_time in config_yamls.items():
-    # Extract config name for the DAG ID
-    config_yaml_name = relative_config_yaml_path.rsplit('/', maxsplit=1)[-1].replace(".yaml", "")
-    
-    dag_id = f"new_internal_{config_yaml_name}"
-    
-    # Define the DAG
-    with models.DAG(
-        dag_id=dag_id,
-        schedule=schedule_time,  # Use the specific schedule time
-        tags=common_tags,
-        start_date=datetime.datetime(2025, 3, 15),
-        catchup=False,
-    ) as dag:
-        # Create the workload for this specific config
-        # run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path, test_run=True)
-        run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path)
+  # Extract config name for the DAG ID
+  config_yaml_name = relative_config_yaml_path.rsplit("/", maxsplit=1)[
+      -1
+  ].replace(".yaml", "")
+  actual_schedule = schedule_time if TURN_ON_SCHEDULE else None
+  dag_id = f"new_internal_{config_yaml_name}"
+
+  # Define the DAG
+  with models.DAG(
+      dag_id=dag_id,
+      schedule=actual_schedule,  # Use the specific schedule time
+      tags=common_tags,
+      start_date=datetime.datetime(2025, 3, 15),
+      catchup=False,
+  ) as dag:
+    # Create the workload for this specific config
+    run_aotc_workload(
+        relative_config_yaml_path=relative_config_yaml_path, test_run=TEST_RUN
+    )
+    # run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path)

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -18,7 +18,7 @@ import datetime
 
 from airflow import models
 from dags.map_reproducibility.utils.constants import Schedule
-from dags.map_reproducibility.utils.aotc_workload import run_aotc_workload
+from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_aotc_workload
 
 
 TEST_RUN = False
@@ -26,12 +26,21 @@ TURN_ON_SCHEDULE = False
 
 # List of configuration setups as a dictionary with schedule times
 config_yamls = {
+    # a3ultra_llama3.1-8b
     "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,  # < 5mins
     "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_bf16_maxtext_pgle.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
     "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
     "recipes/a3ultra/a3ultra_llama3.1-8b_16gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # a3ultra_mixtral-8x7 image issue
+    # "recipes/a3ultra/a3ultra_mixtral-8x7b_8gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3ultra/a3ultra_mixtral-8x7b_8gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3ultra/a3ultra_mixtral-8x7b_16gpus_bf16_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # "recipes/a3ultra/a3ultra_mixtral-8x7b_16gpus_fp8_maxtext.yaml": Schedule.DAILY_6PM_EXCEPT_THURSDAY,
+    # a3ultra_llama3.1-70b
     "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
     "recipes/a3ultra/a3ultra_llama3.1-70b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_6_30PM_EXCEPT_THURSDAY,
+    # a3ultra_llama3.1-405b
     "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_fp8_maxtext.yaml": Schedule.DAILY_7PM_EXCEPT_THURSDAY,  # 30mins for the run
     "recipes/a3ultra/a3ultra_llama3.1-405b_256gpus_bf16_maxtext.yaml": Schedule.DAILY_7_30PM_EXCEPT_THURSDAY,  # 50mins
     # Add more config paths as needed
@@ -42,7 +51,7 @@ common_tags = [
     "reproducibility",
     "experimental",
     "xlml",
-    "v1.13",
+    "v1.15",
     "internal",
     "regressiontests",
     "a3ultra",
@@ -66,7 +75,6 @@ for relative_config_yaml_path, schedule_time in config_yamls.items():
       catchup=False,
   ) as dag:
     # Create the workload for this specific config
-    run_aotc_workload(
+    run_internal_aotc_workload(
         relative_config_yaml_path=relative_config_yaml_path, test_run=TEST_RUN
     )
-    # run_aotc_workload(relative_config_yaml_path=relative_config_yaml_path)

--- a/dags/map_reproducibility/utils/aotc_workload.py
+++ b/dags/map_reproducibility/utils/aotc_workload.py
@@ -40,7 +40,6 @@ from dags.map_reproducibility.utils.common_utils import copy_bucket_cmds_maxtext
 from dags.map_reproducibility.utils.common_utils import parse_internal_config_filename
 from dags.map_reproducibility.utils.common_utils import parse_internal_config_content
 from dags.map_reproducibility.utils.constants import OPTIMIZER, KUEUE_NAME, NUM_STEPS
-from dags.map_reproducibility.utils.gcs_utils import list_files_and_dirs
 
 
 @task
@@ -87,7 +86,6 @@ def run_aotc_workload(relative_config_yaml_path, test_run=False):
     full_config_yaml_path = f"{internal_recipe_repo_root}/{relative_config_yaml_path}"
     print(f"values_file_path is {values_file_path}")
     print(f"full_config_yaml_path is {full_config_yaml_path}")
-    # list_files_and_dirs(internal_recipe_repo_root)
     
     # Parse the config content now that we have the file path
     more_config = parse_internal_config_content(full_config_yaml_path)

--- a/dags/map_reproducibility/utils/aotc_workload.py
+++ b/dags/map_reproducibility/utils/aotc_workload.py
@@ -1,0 +1,156 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Workload functions for AOTC reproducibility benchmarks."""
+
+import os
+import tempfile
+
+from airflow.decorators import task
+from airflow.hooks.subprocess import SubprocessHook
+from dags.map_reproducibility.utils.common_utils import configure_project_and_cluster
+from dags.map_reproducibility.utils.common_utils import install_helm_cmds
+from dags.map_reproducibility.utils.common_utils import namespace_cmds
+from dags.map_reproducibility.utils.common_utils import wait_for_jobs_cmds
+from dags.map_reproducibility.utils.common_utils import cleanup_cmds
+from dags.map_reproducibility.utils.common_utils import git_cookie_authdaemon
+from dags.map_reproducibility.utils.common_utils import clone_recipes_gob, clone_internal_recipes_gob
+from dags.map_reproducibility.utils.common_utils import helm_apply_cmds_internal_run
+from dags.map_reproducibility.utils.common_utils import get_bq_writer_repo
+from dags.map_reproducibility.utils.benchmarkdb_utils import write_run
+from dags.map_reproducibility.utils.common_utils import get_internal_pre_workload_cmds
+from dags.map_reproducibility.utils.common_utils import get_gpu_recipe_cmd
+from dags.map_reproducibility.utils.common_utils import get_bq_writer_path
+from dags.map_reproducibility.utils.common_utils import get_recipe_repo_path, get_internal_recipe_repo_path
+from dags.map_reproducibility.utils.common_utils import get_cluster
+from dags.map_reproducibility.utils.common_utils import get_internal_docker_image
+from dags.map_reproducibility.utils.common_utils import calculate_maxtext_metrics
+from dags.map_reproducibility.utils.common_utils import copy_bucket_cmds_maxtext
+from dags.map_reproducibility.utils.common_utils import parse_internal_config_filename
+from dags.map_reproducibility.utils.common_utils import parse_internal_config_content
+from dags.map_reproducibility.utils.constants import OPTIMIZER, KUEUE_NAME, NUM_STEPS
+from dags.map_reproducibility.utils.gcs_utils import list_files_and_dirs
+
+
+@task
+def run_aotc_workload(relative_config_yaml_path, test_run=False):
+  """Runs the AOTC workload benchmark.
+  
+  Args:
+    relative_config_yaml_path: Path to the config YAML relative to the repo root
+  """
+  # Parse config from filename
+  config_yaml_name = relative_config_yaml_path.rsplit('/', maxsplit=1)[-1].replace(".yaml", "")
+  config = parse_internal_config_filename(config_yaml_name)
+  
+  # Get derived configuration
+  cluster, cluster_region = get_cluster(config.HYPERCOMPUTER)
+  docker_image = get_internal_docker_image(config.HYPERCOMPUTER, config.FRAMEWORK)
+  values_name = f"{config.HYPERCOMPUTER}_{config.FRAMEWORK}_values"
+  
+  with tempfile.TemporaryDirectory() as tmpdir:
+    hook = SubprocessHook()
+
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                git_cookie_authdaemon()
+                + clone_recipes_gob()
+                + (() if test_run else clone_internal_recipes_gob())
+                + get_bq_writer_repo()
+            ),
+        ],
+        cwd=tmpdir,
+    )
+
+    recipe_repo_root = get_recipe_repo_path(tmpdir)
+    bq_writer_repo_root = get_bq_writer_path(tmpdir)
+
+    # Update paths now that we have the repo paths
+    internal_recipe_repo_root = "/home/airflow/gcs/dags/dags/map_reproducibility"
+    if not test_run:
+        internal_recipe_repo_root = get_internal_recipe_repo_path(tmpdir)
+    values_file_path = f"{internal_recipe_repo_root}/values/{values_name}.yaml"
+    full_config_yaml_path = f"{internal_recipe_repo_root}/{relative_config_yaml_path}"
+    print(f"values_file_path is {values_file_path}")
+    print(f"full_config_yaml_path is {full_config_yaml_path}")
+    # list_files_and_dirs(internal_recipe_repo_root)
+    
+    # Parse the config content now that we have the file path
+    more_config = parse_internal_config_content(full_config_yaml_path)
+    
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                configure_project_and_cluster(cluster, cluster_region)
+                + get_gpu_recipe_cmd(
+                    config.HYPERCOMPUTER, config.MODEL_ID, config.FRAMEWORK, recipe_repo_root
+                )
+                + install_helm_cmds()
+                + namespace_cmds()
+                + get_internal_pre_workload_cmds(config.HELM_NAME_MODEL_ID, config.FRAMEWORK)
+                + helm_apply_cmds_internal_run(
+                    config.FRAMEWORK,
+                    config.HYPERCOMPUTER,
+                    full_config_yaml_path,
+                    recipe_repo_root,
+                    values_file_path,
+                    docker_image,
+                    cluster_name=cluster,
+                    kueue_name=KUEUE_NAME,
+                    additional_cmds=f" --set workload.gpus={config.NUM_GPUS} "
+                )
+                + wait_for_jobs_cmds()
+                + copy_bucket_cmds_maxtext(
+                    tmpdir, recipe_repo_root=recipe_repo_root
+                )
+                + cleanup_cmds()
+            ),
+        ],
+        cwd=tmpdir,
+    )
+    assert result.exit_code == 0, f"Command failed with code {result.exit_code}"
+
+    log_location = os.path.join(tmpdir, "tflog/metrics")
+
+    mfu, step_time = calculate_maxtext_metrics(log_location, config.HYPERCOMPUTER)
+
+    print(f"mfu: {mfu}")
+    print(f"step_time: {step_time}")
+
+    write_run(
+        model_id=config.HELM_NAME_MODEL_ID,
+        hardware_id=config.HYPERCOMPUTER,
+        software_id=config.SOFTWARE_ID,
+        number_of_nodes=config.NUM_GPUS / 8,
+        number_of_chips=config.NUM_GPUS,
+        container_image_name=docker_image,
+        global_batch_size=more_config.BATCH_SIZE_PER_DEVICE * config.NUM_GPUS,
+        precision=config.PRECISION,
+        optimizer=OPTIMIZER,
+        seq_length=more_config.SEQUENCE_LENGTH,
+        median_step_time=step_time,
+        e2e_time=step_time * NUM_STEPS,
+        number_of_steps=NUM_STEPS,
+        mfu=mfu,
+        tokens_per_second=1,
+        writer_path=bq_writer_repo_root,
+        topology="",
+        comment="internal recipes regression tests",
+        is_test=False,
+    )

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -515,11 +515,11 @@ def get_internal_docker_image(hardware: str, framework: str):
   image_map = {
       "a3ultra": {
           "nemo": "us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-gpu-nemo-nccl:nemo24.07-gib1.0.3-A3U",
-          "maxtext": "gcr.io/supercomputer-testing/lance_0314",
+          "maxtext": "gcr.io/supercomputer-testing/jax3p_nightly:0310",
       },
       "a3mega": {
           "nemo": "us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-gpu-nemo:nemo24.07-A3Mega",
-          "maxtext": "gcr.io/supercomputer-testing/lance_0314",
+          "maxtext": "gcr.io/supercomputer-testing/jax3p_nightly:0310",
       },
   }
 

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -53,6 +53,15 @@ def clone_recipes_gob():
   return gob_clone_cmds
 
 
+def clone_internal_recipes_gob():
+  gob_clone_cmds = (
+      "echo 'trying to clone internal GoB repo'",
+      "git clone https://jax3p-gpu-benchmarking.googlesource.com/"
+      "internal-gpu-recipes",
+  )
+  return gob_clone_cmds
+
+
 def get_bq_writer_repo():
   gob_clone_cmds = (
       "echo 'trying to clone GoB bq writer repo'",
@@ -86,6 +95,14 @@ def get_pre_workload_cmds(model_id, framework):
   prepare_workload_cmds = (
       "NOW=$(date +%s)",
       f"export JOB_NAME=imo-team-regr-test-{model_id}-$NOW-{framework}",
+  )
+  return prepare_workload_cmds
+
+
+def get_internal_pre_workload_cmds(model_id, framework):
+  prepare_workload_cmds = (
+      "NOW=$(date +%s)",
+      f"export JOB_NAME=internal-reg-{model_id}-$NOW-{framework}",
   )
   return prepare_workload_cmds
 
@@ -155,6 +172,54 @@ def helm_apply_cmds(
       f"{additional_cmds}"
       f" $JOB_NAME {recipe_repo_root}/src/helm-charts/{hypercomputer}/{framework}-training",
   )
+  return helm_cmds
+
+
+def helm_apply_cmds_internal_run(
+    framework: str,
+    hypercomputer: str,
+    config_file,
+    recipe_repo_root,
+    values_file_path,
+    docker_image,
+    aotc: bool = False,
+    cluster_name: str = "a3plus-benchmark",
+    kueue_name: str = "a3-ultra",
+    additional_cmds: str = "",
+):
+  gcs_cmd = ""
+  if hypercomputer == "a3ultra":
+    if framework != "maxtext":
+      gcs_cmd = f" --set queue={kueue_name}"
+    gcs_cmd += f" --set volumes.gcsMounts[0].bucketName={BUCKET_NAME}"
+  else:
+    gcs_cmd = f" --set workload.gcsBucketForDataCataPath={BUCKET_NAME}"
+
+  cluster_cmd = ""
+  if framework == "nemo" and hypercomputer == "a3ultra":
+    cluster_cmd = f" --set clusterName={cluster_name}"
+
+  run_name_cmd = ""
+  if framework == "maxtext":
+    run_name_cmd = "--set workload.run_name=$JOB_NAME"
+
+  set_aotc = ""
+  if aotc:
+    set_aotc = " --set-string workload.aotc=true "
+  helm_cmds = (
+      f" helm install -f {values_file_path} "
+      "--namespace default "
+      "--set namespace=default"
+      f" --set-file {framework}_config"
+      f"={config_file}"
+      " --set workload.image"
+      f"={docker_image} "
+      f"{cluster_cmd} {run_name_cmd} {gcs_cmd} {set_aotc}"
+      f"{additional_cmds}"
+      f" $JOB_NAME {recipe_repo_root}/src/helm-charts/{hypercomputer}/{framework}-training",
+  )
+  print("*******helm cmd is*******")
+  print(helm_cmds)
   return helm_cmds
 
 
@@ -330,6 +395,13 @@ def get_recipe_repo_path(tmpdir):
   return recipe_repo_root
 
 
+def get_internal_recipe_repo_path(tmpdir):
+  recipe_repo_root = os.path.join(
+      tmpdir, "internal-gpu-recipes"
+  )
+  return recipe_repo_root
+
+
 def get_cluster(hardware: str = "a3ultra"):
   if hardware == "a3mega":
     return "a3plus-benchmark", "australia-southeast1"
@@ -428,8 +500,117 @@ def get_docker_image(hardware: str, framework: str):
   return None  # Return None if no image is found for the given combination
 
 
+def get_internal_docker_image(hardware: str, framework: str):
+  """
+  Returns the appropriate Docker image based on the given hardware, model, and framework.
+
+  Args:
+      hardware: The hardware type (e.g., "a3ultra", "a3mega").
+      framework: The framework (e.g., "nemo", "maxtext").
+
+  Returns:
+      A Docker image string or None if no image is defined for the given combination.
+  """
+
+  image_map = {
+      "a3ultra": {
+          "nemo": "us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-gpu-nemo-nccl:nemo24.07-gib1.0.3-A3U",
+          "maxtext": "gcr.io/supercomputer-testing/lance_0314",
+      },
+      "a3mega": {
+          "nemo": "us-central1-docker.pkg.dev/deeplearning-images/reproducibility/pytorch-gpu-nemo:nemo24.07-A3Mega",
+          "maxtext": "gcr.io/supercomputer-testing/lance_0314",
+      },
+  }
+
+  if hardware in image_map:
+    if framework in image_map[hardware]:
+      return image_map[hardware][framework]
+
+  return None  # Return None if no image is found for the given combination
+
 def get_two_node_cmds(hypercomputer: str = "a3ultra"):
   cmd = ' --set workload.arguments="{trainer.max_steps=1}"  --set workload.gpus=16 '
   if hypercomputer == "a3mega":
     cmd += '--set workload.arguments="{model.pipeline_model_parallel_size=2}"'
   return cmd
+
+
+def parse_internal_config_filename(filename):
+  """
+  Parse a config filename to extract config values.
+  
+  Args:
+      filename (str): Config filename like 'a3ultra_llama3.1-70b_256gpus_bf16_maxtext.yaml'
+      
+  Returns:
+      object: Config values accessible via dot notation
+  """
+  # Simple dot notation class
+  class Config:
+    def __init__(self, **kwargs):
+      self.__dict__.update(kwargs)
+  
+  # Remove file extension and split by underscore
+  parts = filename.split('.yaml')[0].split('_')
+  
+  # Extract components
+  hypercomputer = parts[0]
+  model_id_raw = parts[1]
+  model_id = model_id_raw.replace('llama', 'llama-')
+  num_gpus = int(parts[2].replace('gpus', ''))
+  precision = parts[3]
+  framework = parts[4]
+  
+  # Create software ID based on framework
+  software_id = f"{'jax' if framework == 'maxtext' else 'pytorch'}_{framework}"
+  
+  # Return config object with dot notation access
+  return Config(
+      MODEL_ID=model_id,
+      HELM_NAME_MODEL_ID=model_id_raw.replace('.', '-'),
+      PRECISION=precision,
+      HYPERCOMPUTER=hypercomputer,
+      FRAMEWORK=framework,
+      SOFTWARE_ID=software_id,
+      NUM_GPUS=num_gpus
+  )
+
+
+def parse_internal_config_content(yaml_path):
+  """
+  Parse the internal content of a config YAML file.
+  
+  Args:
+      yaml_path (str): Path to the YAML file
+      
+  Returns:
+      object: Config values accessible via dot notation
+  """
+  import yaml
+  
+  # Simple dot notation class with dictionary-like representation
+  class Config:
+    def __init__(self, **kwargs):
+      self.__dict__.update(kwargs)
+    
+    def __repr__(self):
+      return repr(self.__dict__)
+    
+    def __str__(self):
+      return str(self.__dict__)
+  
+  try:
+    # Open and read the YAML file
+    with open(yaml_path, 'r') as file:
+      result = yaml.safe_load(file)
+    
+    # Return config object with dot notation access
+    return Config(
+        SEQUENCE_LENGTH=result.get("max_target_length", None),
+        BATCH_SIZE_PER_DEVICE=result.get("per_device_batch_size", None)
+        # Add other mappings here as needed
+    )
+  except Exception as e:
+    print(f"Unexpected error: {e}")
+    raise e

--- a/dags/map_reproducibility/utils/constants.py
+++ b/dags/map_reproducibility/utils/constants.py
@@ -1,0 +1,3 @@
+KUEUE_NAME =  "a3-ultra"
+OPTIMIZER = "adam"
+NUM_STEPS = 30

--- a/dags/map_reproducibility/utils/constants.py
+++ b/dags/map_reproducibility/utils/constants.py
@@ -1,3 +1,10 @@
 KUEUE_NAME =  "a3-ultra"
 OPTIMIZER = "adam"
-NUM_STEPS = 30
+NUM_STEPS = 20
+
+class Schedule:
+    """Class containing schedule cron expressions."""
+    DAILY_6PM_EXCEPT_THURSDAY = "0 18 * * 0,1,2,3,5,6"
+    DAILY_6_30PM_EXCEPT_THURSDAY = "30 18 * * 0,1,2,3,5,6"
+    DAILY_7PM_EXCEPT_THURSDAY = "0 19 * * 0,1,2,3,5,6"
+    DAILY_7_30PM_EXCEPT_THURSDAY = "30 19 * * 0,1,2,3,5,6"

--- a/dags/map_reproducibility/utils/constants.py
+++ b/dags/map_reproducibility/utils/constants.py
@@ -1,10 +1,17 @@
-KUEUE_NAME =  "a3-ultra"
+KUEUE_NAME = "a3-ultra"
 OPTIMIZER = "adam"
 NUM_STEPS = 20
 
+
+class Optimizer:
+  ADAM = "adam"
+  ADAMW = "adamw"
+
+
 class Schedule:
-    """Class containing schedule cron expressions."""
-    DAILY_6PM_EXCEPT_THURSDAY = "0 18 * * 0,1,2,3,5,6"
-    DAILY_6_30PM_EXCEPT_THURSDAY = "30 18 * * 0,1,2,3,5,6"
-    DAILY_7PM_EXCEPT_THURSDAY = "0 19 * * 0,1,2,3,5,6"
-    DAILY_7_30PM_EXCEPT_THURSDAY = "30 19 * * 0,1,2,3,5,6"
+  """Class containing schedule cron expressions."""
+
+  DAILY_6PM_EXCEPT_THURSDAY = "0 18 * * 0,1,2,3,5,6"
+  DAILY_6_30PM_EXCEPT_THURSDAY = "30 18 * * 0,1,2,3,5,6"
+  DAILY_7PM_EXCEPT_THURSDAY = "0 19 * * 0,1,2,3,5,6"
+  DAILY_7_30PM_EXCEPT_THURSDAY = "30 19 * * 0,1,2,3,5,6"

--- a/dags/map_reproducibility/utils/internal_aotc_workload.py
+++ b/dags/map_reproducibility/utils/internal_aotc_workload.py
@@ -43,7 +43,7 @@ from dags.map_reproducibility.utils.constants import Optimizer, KUEUE_NAME, NUM_
 
 
 @task
-def run_aotc_workload(relative_config_yaml_path, test_run=False):
+def run_internal_aotc_workload(relative_config_yaml_path, test_run=False):
   """Runs the AOTC workload benchmark.
 
   Args:
@@ -113,7 +113,9 @@ def run_aotc_workload(relative_config_yaml_path, test_run=False):
                 + install_helm_cmds()
                 + namespace_cmds()
                 + get_internal_pre_workload_cmds(
-                    config.HELM_NAME_MODEL_ID, config.FRAMEWORK
+                    config.HELM_NAME_MODEL_ID,
+                    config.FRAMEWORK,
+                    config.IS_PGLE,
                 )
                 + helm_apply_cmds_internal_run(
                     config.FRAMEWORK,


### PR DESCRIPTION
# Description
Added a3u internal benchmarking run dags and utils. Recipes are stored in internal gob repo [here](https://jax3p-gpu-benchmarking-review.git.corp.google.com/c/internal-gpu-recipes/+/1040).

# Tests
Please describe the tests that you ran on Cloud VM to verify changes.
tested new_internal_a3ultra_llama3.1-8b_8gpus_bf16_maxtext run on test xlml env called: yujun-zou-test1
**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** 
a3u successful run:
https://screenshot.googleplex.com/4Q8mjf2nXAuCs7C

a3plus successful run: 
https://screenshot.googleplex.com/9MFmEF7E9wquyKs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.