### PR TITLE
Reduce MaxText profiling tests

### DIFF
--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -48,12 +48,6 @@ with models.DAG(
         f" run_name=$RUN_NAME base_output_directory={base_output_directory}"
         f" dataset_path={dataset_path} profiler=xplane steps=20",
         f"gsutil cp -R {base_output_directory}/$RUN_NAME/tensorboard .",
-        "pip3 uninstall -y tbp-nightly",
-        "pip3 uninstall -y tensorboard_plugin_profile",
-        "pip3 uninstall -y tensorflow",
-        "pip3 install tf-nightly",
-        "pip3 install tbp-nightly",
-        "python3 end_to_end/test_profiler.py",
     )
     maxtext_v4_configs_test = gke_config.get_gke_config(
         time_out_in_min=60,

--- a/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
+++ b/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
@@ -23,20 +23,12 @@ from dags.common.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
-# Run once a day at 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = None
 
 with models.DAG(
     dag_id="maxtext_profiling_vertex_ai_tensorboard",
     schedule=SCHEDULED_TIME,
-    tags=[
-        "multipod_team",
-        "mlscale_onduty",
-        "maxtext",
-        "stable",
-        "nightly",
-        "vertex_ai",
-    ],
+    tags=[],
     start_date=datetime.datetime(2024, 6, 1),
     catchup=False,
     concurrency=2,


### PR DESCRIPTION
# Description

* Disable the MaxText/Vertex TB integration test
* Reduce the scope of the MaxText profiling test
  * Only check that the XPlane is saved to GCS instead of running assertions on the profile itself

The reason for this change is that the profiling work is not owned by us anymore. Note that we will likely come back and remove the Vertex DAG completely. But for now, we will just stop it from being scheduled.

# Tests

Will rely on the next Airflow run since these tests are already failing and aren't urgently needed

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.