### PR TITLE
Add separate tags for devx and perfx

### DIFF
--- a/dags/multipod/jax_functional_tests.py
+++ b/dags/multipod/jax_functional_tests.py
@@ -27,7 +27,7 @@ SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="jax_functional_tests",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "jax", "mlscale_onduty"],
+    tags=["multipod_team", "jax", "mlscale_devx"],
     start_date=datetime.datetime(2024, 10, 23),
     catchup=False,
 ) as dag:

--- a/dags/multipod/legacy.py
+++ b/dags/multipod/legacy.py
@@ -55,7 +55,7 @@ with models.DAG(
         "legacy",
         "stable",
         "nightly",
-        "mlscale_onduty",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 1, 10),
     catchup=False,

--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -29,7 +29,13 @@ SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="maxtext_checkpointing",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "mlscale_onduty", "maxtext", "stable", "nightly"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
     start_date=datetime.datetime(2024, 3, 1),
     catchup=False,
     concurrency=2,

--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -31,7 +31,13 @@ SCHEDULED_TIME = "0 5 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="maxtext_configs_aot",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "mlscale_onduty", "maxtext", "stable", "nightly"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
     start_date=datetime.datetime(2024, 2, 19),
     catchup=False,
     concurrency=2,

--- a/dags/multipod/maxtext_configs_aot_hybridsim.py
+++ b/dags/multipod/maxtext_configs_aot_hybridsim.py
@@ -85,7 +85,12 @@ def hybridsim_compile_and_run(test_group_id):
 with models.DAG(
     dag_id="maxtext_configs_aot_hybridsim",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "nightly", "mlscale_onduty"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "nightly",
+        "mlscale_perfx",
+    ],
     start_date=datetime.datetime(2024, 2, 19),
     catchup=False,
     concurrency=10,

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -30,7 +30,12 @@ SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="maxtext_convergence",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "stable", "mlscale_onduty"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "mlscale_devx",
+    ],
     start_date=datetime.datetime(2024, 3, 1),
     catchup=False,
     concurrency=2,

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -33,7 +33,13 @@ HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 with models.DAG(
     dag_id="maxtext_end_to_end",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_onduty"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
     start_date=datetime.datetime(2024, 1, 19),
     catchup=False,
 ) as dag:

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -242,7 +242,13 @@ def run_maxtext_tests(dag: models.DAG):
 with models.DAG(
     dag_id="maxtext_gpu_end_to_end",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_onduty"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
     start_date=datetime.datetime(2024, 1, 19),
     catchup=False,
 ) as dag:

--- a/dags/multipod/maxtext_multi_tier_checkpointing.py
+++ b/dags/multipod/maxtext_multi_tier_checkpointing.py
@@ -30,7 +30,6 @@ with models.DAG(
     schedule=SCHEDULED_TIME,
     tags=[
         "multipod_team",
-        "mlscale_onduty",
         "maxtext",
         "muti_tier_checkpointing",
         "nightly",

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -29,7 +29,13 @@ SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="maxtext_profiling",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "mlscale_onduty", "maxtext", "stable", "nightly"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
     start_date=datetime.datetime(2024, 3, 1),
     catchup=False,
     concurrency=2,

--- a/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
+++ b/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
@@ -31,11 +31,11 @@ with models.DAG(
     schedule=SCHEDULED_TIME,
     tags=[
         "multipod_team",
-        "mlscale_onduty",
         "maxtext",
         "stable",
         "nightly",
         "vertex_ai",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 6, 1),
     catchup=False,

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -37,7 +37,13 @@ BASE_OUTPUT_DIRECTORY = "gs://runner-maxtext-logs"
 with models.DAG(
     dag_id="maxtext_trillium_configs_perf",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "mlscale_onduty", "maxtext", "stable", "nightly"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_perfx",
+    ],
     start_date=datetime.datetime(2024, 2, 19),
     catchup=False,
 ) as dag:

--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -38,7 +38,13 @@ BASE_OUTPUT_DIRECTORY = "gs://runner-maxtext-logs"
 with models.DAG(
     dag_id="maxtext_v5e_configs_perf",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_onduty"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_perfx",
+    ],
     start_date=datetime.datetime(2024, 2, 19),
     catchup=False,
 ) as dag:
@@ -87,7 +93,7 @@ PATHWAYS_SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="pathways_maxtext_v5e_configs_perf",
     schedule=None,
-    tags=["multipod_team", "maxtext", "stable", "nightly"],
+    tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_perfx"],
     start_date=datetime.datetime(2024, 2, 19),
     catchup=False,
 ) as dag:

--- a/dags/multipod/mxla_collective_nightly.py
+++ b/dags/multipod/mxla_collective_nightly.py
@@ -29,7 +29,12 @@ SCHEDULED_TIME = "0 8 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="mxla_collective_nightly",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "mlscale_onduty", "mxla_collective", "nightly"],
+    tags=[
+        "multipod_team",
+        "mxla_collective",
+        "nightly",
+        "mlscale_perfx",
+    ],
     start_date=datetime.datetime(2024, 2, 7),
     catchup=False,
 ) as dag:

--- a/dags/multipod/mxla_gpt3_6b_nightly_gke.py
+++ b/dags/multipod/mxla_gpt3_6b_nightly_gke.py
@@ -32,11 +32,11 @@ with models.DAG(
     schedule=SCHEDULED_TIME,
     tags=[
         "multipod_team",
-        "mlscale_onduty",
         "maxtext",
         "gke",
         "nightly",
         "gpt_6b",
+        "mlscale_perfx",
     ],
     start_date=datetime.datetime(2024, 3, 18),
     catchup=False,

--- a/dags/multipod/mxla_maxtext_nightly_gke.py
+++ b/dags/multipod/mxla_maxtext_nightly_gke.py
@@ -29,7 +29,13 @@ SCHEDULED_TIME = "0 9 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="mxla_maxtext_nightly_gke",
     schedule=SCHEDULED_TIME,
-    tags=["multipod_team", "mlscale_onduty", "maxtext", "gke", "nightly"],
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "gke",
+        "nightly",
+        "mlscale_perfx",
+    ],
     start_date=datetime.datetime(2024, 3, 12),
     catchup=False,
 ) as dag:

--- a/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_stable_stack_gpu_e2e.py
@@ -35,10 +35,10 @@ with models.DAG(
     tags=[
         "sparsity_diffusion_devx",
         "multipod_team",
-        "mlscale_onduty",
         "maxtext",
         "gpu",
         "jax-stable-stack",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 6, 7),
     catchup=False,

--- a/dags/sparsity_diffusion_devx/jax_stable_stack_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_stable_stack_tpu_e2e.py
@@ -35,12 +35,12 @@ with models.DAG(
     tags=[
         "sparsity_diffusion_devx",
         "multipod_team",
-        "mlscale_onduty",
         "maxtext",
         "maxdiffusion",
         "axlearn",
         "tpu",
         "jax-stable-stack",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 6, 7),
     catchup=False,

--- a/dags/sparsity_diffusion_devx/maxdiffusion_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxdiffusion_e2e.py
@@ -34,8 +34,8 @@ with models.DAG(
     tags=[
         "sparsity_diffusion_devx",
         "multipod_team",
-        "mlscale_onduty",
         "maxdiffusion",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 9, 12),
     catchup=False,

--- a/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
@@ -81,7 +81,7 @@ with models.DAG(
         "gpu",
         "stable",
         "nightly",
-        "mlscale_onduty",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 12, 11),
     catchup=False,

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -39,7 +39,7 @@ with models.DAG(
         "tpu",
         "stable",
         "nightly",
-        "mlscale_onduty",
+        "mlscale_devx",
     ],
     start_date=datetime.datetime(2024, 11, 14),
     catchup=False,


### PR DESCRIPTION
# Description

Deprecate `mlscale_onduty` tag, and add separate tags for devx and perfx - [ref](https://docs.google.com/spreadsheets/d/1Wqjjvi7PKLhULjd9w_apxx9Lyr1W0ZYGACthcTWt50U/edit?resourcekey=0-DeDJI_AxJMWyvH7HHb4D8Q&gid=0#gid=0)
* 21 DAGs in total
* devx as `mlscale_devx`
* perfx as `mlscale_perfx`

# Tests

Manually review


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.