### PR TITLE
Existing v6e cluster got deallocated. Changed to point to new cluster

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -259,7 +259,7 @@ class XpkClusters:
       zone=Zone.US_CENTRAL2_B.value,
   )
   TPU_V6E_256_MLPERF_CLUSTER = XpkClusterConfig(
-      name="bodaborg-v6e-256-dnd-yucmhab",
+      name="bodaborg-v6e-256-dnd-yucmhab-new",
       device_version=TpuVersion.TRILLIUM,
       core_count=256,
       project=Project.TPU_PROD_ENV_ONE_VM.value,


### PR DESCRIPTION
# Description

Tests are failing dure to v6e cluster being deallocated. Changed the xpk cluster to point to the new one.

# Tests



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.