### PR TITLE
Update v6e cluster name

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -259,7 +259,7 @@ class XpkClusters:
       zone=Zone.US_CENTRAL2_B.value,
   )
   TPU_V6E_256_MLPERF_CLUSTER = XpkClusterConfig(
-      name="bodaborg-v6e-256-dnd-yucmhab",
+      name="bodaborg-v6e-256-dnd-yucmhab-new",
       device_version=TpuVersion.TRILLIUM,
       core_count=256,
       project=Project.TPU_PROD_ENV_ONE_VM.value,


### PR DESCRIPTION
# Description

Update v6e [cluster name](https://pantheon.corp.google.com/kubernetes/clusters/details/us-east5/bodaborg-v6e-256-dnd-yucmhab-new/details?project=tpu-prod-env-one-vm&e=13803378&mods=allow_workbench_image_override&invt=AbtB2w) due to capacity migration. b/406305961

# Tests

Manually check

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.