### PR TITLE
Switch to a newly created A3 GKE cluster.

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -267,7 +267,7 @@ class XpkClusters:
   )
 
   GPU_A3_CLUSTER = XpkClusterConfig(
-      name="ninacai-maxtext-a3",
+      name="maxtext-a3-gke",
       device_version=GpuVersion.XPK_H100,
       core_count=8,
       project=Project.SUPERCOMPUTER_TESTING.value,

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -32,7 +32,7 @@ from xlml.utils import gke
 SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
 
 # Number of nodes on A3 cluster to be scaled up to
-A3_NUM_NODES = 10
+A3_NUM_NODES = 2
 
 
 def configure_project_and_cluster(project: str, cluster_name: str, zone: str):


### PR DESCRIPTION
# Description

Switch to a newly created A3 GKE cluster to fix some MaxText GPU test failures.

# Tests

**Instruction and/or command lines to reproduce your tests:**
1. Run the following commands:
$ git clone https://github.com/GoogleCloudPlatform/ml-auto-solutions.git
$ cd ml-auto-solutions/
$ bash scripts/upload-tests.sh gs://us-central1-nina-dags-fe347643-bucket/dags

2. Manually trigger maxtext_gpu_end_to_end DAG on the UI: https://540cef12d3da42ce97b48a97401b6c83-dot-us-central1.composer.googleusercontent.com/home

**List links for your tests (use go/shortn-gen for any internal link):**
This new GKE cluster was created with an old GKE version (b/392001678) and it helped fix some of the XLML tests for MaxText on A3: http://shortn/_V6AgE5mO1w.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.