### PR TITLE
Updated MaxDiffusion Docker Images to Proper Nightly and Stable Stack Repositories

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -329,7 +329,7 @@ class DockerImage(enum.Enum):
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXDIFFUSION_TPU_STABLE_STACK_NIGHTLY_JAX = (
-      "gcr.io/tpu-prod-env-multipod/maxdiffusion_stable_stack_nightly_jax:"
+      "gcr.io/tpu-prod-env-multipod/maxdiffusion_jax_nightly:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXDIFFUSION_TPU_JAX_STABLE_STACK_CANDIDATE = (

--- a/dags/sparsity_diffusion_devx/jax_stable_stack_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_stable_stack_tpu_e2e.py
@@ -73,7 +73,7 @@ with models.DAG(
   maxdiffusion_docker_images = [
       (
           SetupMode.STABLE,
-          DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK_CANDIDATE,
+          DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK,
       ),
       (
           SetupMode.NIGHTLY,


### PR DESCRIPTION
# Description

The MaxDiffusion docker images used in XLML tests were pointing to old repositories that haven't been updated since end of January. This means that the tests were not running on true nightly builds. This commit updates the docker images such that they point to the right nightly and stable stack maxdiffusion builds.

FIXES: b/407771770

Testing:

Verified that the repo being updated is the one which maxdiffusion does nightly builds to. 

https://screenshot.googleplex.com/366FCiBBhfscH8Z 

Stable Stack Build: https://screenshot.googleplex.com/BqN4Qcjc2kFrAXg
Nightly Build: https://screenshot.googleplex.com/7WiV9EBrtd8yBMG

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.