### PR TITLE
Updated stable tests to use jax stable stack image

### DIFF
--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -211,11 +211,11 @@ def run_maxtext_tests(dag: models.DAG):
     ).run_with_quarantine(quarantine_task_group)
     stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=300,
-        test_name=f"{test_name_prefix}-stable-{model}",
+        test_name=f"{test_name_prefix}-stable-stack-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     pinned_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
@@ -229,11 +229,11 @@ def run_maxtext_tests(dag: models.DAG):
     ).run_with_quarantine(quarantine_task_group)
     stable_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=300,
-        test_name=f"{test_name_prefix}-stable-{model}",
+        test_name=f"{test_name_prefix}-stable-stack-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     pinned_a3_gpu >> stable_a3_gpu >> pinned_a3plus_gpu >> stable_a3plus_gpu

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -200,15 +200,6 @@ def run_maxtext_tests(dag: models.DAG):
   )
 
   for model, (test_script, nnodes) in test_models_gpu.items():
-    pinned_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        time_out_in_min=300,
-        test_name=f"{test_name_prefix}-pinned-{model}",
-        run_model_cmds=(test_script,),
-        num_slices=nnodes,
-        cluster=XpkClusters.GPU_A3_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
-        test_owner=test_owner.YUWEI_Y,
-    ).run_with_quarantine(quarantine_task_group)
     stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=300,
         test_name=f"{test_name_prefix}-stable-stack-{model}",
@@ -216,15 +207,6 @@ def run_maxtext_tests(dag: models.DAG):
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3_CLUSTER,
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
-        test_owner=test_owner.YUWEI_Y,
-    ).run_with_quarantine(quarantine_task_group)
-    pinned_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        time_out_in_min=300,
-        test_name=f"{test_name_prefix}-pinned-{model}",
-        run_model_cmds=(test_script,),
-        num_slices=nnodes,
-        cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
         test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
     stable_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
@@ -236,7 +218,7 @@ def run_maxtext_tests(dag: models.DAG):
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.YUWEI_Y,
     ).run_with_quarantine(quarantine_task_group)
-    pinned_a3_gpu >> stable_a3_gpu >> pinned_a3plus_gpu >> stable_a3plus_gpu
+    stable_a3_gpu >> stable_a3plus_gpu
 
 
 with models.DAG(


### PR DESCRIPTION
# Description

The stable tests in maxtext_gpu_end_to_end DAG use an old image that is not updated, causing XLML tests to fail. Now that jax stable stack for gpu is released, switch to the stable stack image for tests. 

Also, removing the pinned tests since they do not use jax stable stack for tests. Moving forward, the DAG will only use JStS stable image and rely on the jax_stable_stack_gpu_e2e DAG for testing the JStS stable and nightly image.

FIXES: b/392001678

# Tests

The jax stable stack image passing tests: https://screenshot.googleplex.com/7zWC78QEWKWh6r4

Current stable image used in tests not being updated: https://screenshot.googleplex.com/7N8KMYimKUTTjzS


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.