### PR TITLE
Relax some timeouts in framework_microbenchmark

### DIFF
--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -20,7 +20,7 @@ with models.DAG(
       tpu_version=vm_resource.TpuVersion.V4,
       tpu_cores=8,
       tpu_zone=vm_resource.Zone.US_CENTRAL2_B,
-      time_out_in_min=60,
+      time_out_in_min=120,
       runtime_version=vm_resource.RuntimeVersion.TPU_UBUNTU2204_BASE,
       project=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS,
   )
@@ -29,7 +29,7 @@ with models.DAG(
       tpu_version=vm_resource.TpuVersion.V4,
       tpu_cores=16,
       tpu_zone=vm_resource.Zone.US_CENTRAL2_B,
-      time_out_in_min=60,
+      time_out_in_min=120,
       runtime_version=vm_resource.RuntimeVersion.TPU_UBUNTU2204_BASE,
       project=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS,
   )
@@ -80,7 +80,7 @@ with models.DAG(
       tpu_version=vm_resource.TpuVersion.V5E,
       tpu_cores=4,
       tpu_zone=vm_resource.Zone.US_EAST1_C,
-      time_out_in_min=60,
+      time_out_in_min=120,
       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5_LITE,
       project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
       network=vm_resource.V5_NETWORKS,


### PR DESCRIPTION
# Description

Some tests are failing due to hitting the default 60 minute timeout. Relax them to 120 minutes.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.