### PR TITLE
Update the dags for the microbenchmarks to fix failed XLML test

### DIFF
--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -44,7 +44,7 @@ def get_microbenchmark_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
-      "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git  ",
+      "git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git  ",
       "cd accelerator-microbenchmarks ",
       "pip install -r requirements.txt ",
       # Run the benchmark script
@@ -121,7 +121,7 @@ def get_microbenchmark_xpk_config(
 
   # Initial commands
   run_model_cmds = set_up_cmds + (
-      "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git ",
+      "git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git ",
       # Create the output directory
       "mkdir -p /tmp/microbenchmarks/outputs ",
       # Remove any existing metrics report

--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -47,12 +47,12 @@ def get_microbenchmark_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
-      # TODO(qinyiyan): Clone the project from google repo when ready.
-      (f"if [ -d /tmp/maxtext ]; then " f"rm -rf /tmp/maxtext; " "fi "),
-      "git clone https://github.com/qinyiyan/maxtext.git /tmp/maxtext ",
-      # Run the benchmark script (either all_reduce or all_gather)
-      f"python3 /tmp/maxtext/microbenchmarks/run_benchmark.py "
-      f"--config=/tmp/maxtext/microbenchmarks/configs/{benchmark_config}",
+      "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git ~/ ",
+      "cd ~/accelerator-microbenchmarks ",
+      "pip install -r requirements.txt ",
+      # Run the benchmark script
+      f"python3 src/run_benchmark.py "
+      f"--config=configs/{benchmark_config} ",
   )
 
   # Check if the metrics report exists, and if so, upload it to GCS
@@ -127,9 +127,7 @@ def get_microbenchmark_xpk_config(
       "pip install jsonlines ",
       "pip install ray[default] ",
       "JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true ",
-      # TODO(qinyiyan): clone from Google's maxtext when code is merged.
-      (f"if [ -d /tmp/maxtext ]; then " f"rm -rf /tmp/maxtext; " "fi "),
-      "git clone https://github.com/qinyiyan/maxtext.git /tmp/maxtext ",
+      "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git ",
       # Create the output directory
       "mkdir -p /tmp/microbenchmarks/outputs ",
       # Remove any existing metrics report
@@ -138,9 +136,11 @@ def get_microbenchmark_xpk_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
-      # Run the benchmark script (either all_reduce or all_gather)
-      f"python3 /tmp/maxtext/microbenchmarks/run_benchmark.py "
-      f"--config=/tmp/maxtext/microbenchmarks/configs/{benchmark_config} ",
+      "cd ~/accelerator-microbenchmarks ",
+      "pip install -r requirements.txt ",
+      # Run the benchmark script
+      f"python3 src/run_benchmark.py "
+      f"--config=configs/{benchmark_config} ",
   )
 
   # Check if the metrics report exists, and if so, upload it to GCS

--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -47,7 +47,7 @@ def get_microbenchmark_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
-      "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git ~/ ",
+      "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git  ",
       "cd ~/accelerator-microbenchmarks ",
       "pip install -r requirements.txt ",
       # Run the benchmark script

--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -28,9 +28,6 @@ def get_microbenchmark_config(
           "pip install jax[tpu] -f"
           " https://storage.googleapis.com/jax-releases/libtpu_releases.html"
       ),
-      "pip install --upgrade clu tensorflow tensorflow-datasets ",
-      "pip install jsonlines ",
-      "pip install ray[default] ",
       "JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true ",
   )
 
@@ -48,7 +45,7 @@ def get_microbenchmark_config(
   # Run the benchmark tests.
   run_model_cmds += (
       "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git  ",
-      "cd ~/accelerator-microbenchmarks ",
+      "cd accelerator-microbenchmarks ",
       "pip install -r requirements.txt ",
       # Run the benchmark script
       f"python3 src/run_benchmark.py "
@@ -124,9 +121,6 @@ def get_microbenchmark_xpk_config(
 
   # Initial commands
   run_model_cmds = set_up_cmds + (
-      "pip install jsonlines ",
-      "pip install ray[default] ",
-      "JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true ",
       "git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git ",
       # Create the output directory
       "mkdir -p /tmp/microbenchmarks/outputs ",
@@ -136,8 +130,9 @@ def get_microbenchmark_xpk_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
-      "cd ~/accelerator-microbenchmarks ",
+      "cd accelerator-microbenchmarks ",
       "pip install -r requirements.txt ",
+      "JAX_PLATFORMS=cpu ENABLE_PJRT_COMPATIBILITY=true ",
       # Run the benchmark script
       f"python3 src/run_benchmark.py "
       f"--config=configs/{benchmark_config} ",

--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -114,16 +114,9 @@ with models.DAG(
       test_name="framework-microbenchmark-v6e-256",
       docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
       test_owner=test_owner.QINY_Y,
-      cluster=vm_resource.XpkClusters.TPU_V6E_256_CLUSTER,
+      cluster=vm_resource.XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
   ).run()
 
-  microbenchmarks_v4_128 = get_microbenchmark_xpk_config(
-      time_out_in_min=60,
-      test_name="framework-microbenchmark-v4-128",
-      docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
-      test_owner=test_owner.QINY_Y,
-      cluster=vm_resource.XpkClusters.TPU_V4_128_CLUSTER,
-  ).run()
 
 
 # Test dependency: run in parallel

--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -57,17 +57,6 @@ with models.DAG(
       subnetwork=vm_resource.V5P_SUBNETWORKS,
   )
 
-  microbenchmarks_v5p_256 = get_microbenchmark_config(
-      tpu_version=vm_resource.TpuVersion.V5P,
-      tpu_cores=256,
-      tpu_zone=vm_resource.Zone.US_EAST5_A,
-      time_out_in_min=60,
-      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5,
-      project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
-      network=vm_resource.V5_NETWORKS,
-      subnetwork=vm_resource.V5P_SUBNETWORKS,
-  )
-
   microbenchmarks_v5e_4 = get_microbenchmark_config(
       tpu_version=vm_resource.TpuVersion.V5E,
       tpu_cores=4,
@@ -90,21 +79,19 @@ with models.DAG(
       subnetwork=vm_resource.V5E_SUBNETWORKS,
   )
 
-  microbenchmarks_v6e_4 = get_microbenchmark_config(
-      tpu_version=vm_resource.TpuVersion.TRILLIUM,
-      tpu_cores=4,
-      tpu_zone=vm_resource.Zone.US_EAST5_C,
-      time_out_in_min=60,
-      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV6,
-      project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
-      network=vm_resource.V5_NETWORKS,
-      subnetwork=vm_resource.V6E_SUBNETWORKS,
-  )
+#   microbenchmarks_v6e_4 = get_microbenchmark_config(
+#       tpu_version=vm_resource.TpuVersion.TRILLIUM,
+#       tpu_cores=4,
+#       tpu_zone=vm_resource.Zone.US_EAST5_C,
+#       time_out_in_min=60,
+#       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV6,
+#       project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
+#   )
 
   microbenchmarks_v5e_256 = get_microbenchmark_xpk_config(
       time_out_in_min=60,
       test_name="framework-microbenchmark-v5e-256",
-      docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
+      docker_image=vm_resource.DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
       test_owner=test_owner.QINY_Y,
       cluster=vm_resource.XpkClusters.TPU_V5E_256_CLUSTER,
   ).run()
@@ -112,7 +99,7 @@ with models.DAG(
   microbenchmarks_v6e_256 = get_microbenchmark_xpk_config(
       time_out_in_min=60,
       test_name="framework-microbenchmark-v6e-256",
-      docker_image=vm_resource.DockerImage.XPK_JAX_TEST.value,
+      docker_image=vm_resource.DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
       test_owner=test_owner.QINY_Y,
       cluster=vm_resource.XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
   ).run()

--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -34,14 +34,6 @@ with models.DAG(
       project=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS,
   )
 
-  microbenchmarks_v4_64 = get_microbenchmark_config(
-      tpu_version=vm_resource.TpuVersion.V4,
-      tpu_cores=64,
-      tpu_zone=vm_resource.Zone.US_CENTRAL2_B,
-      time_out_in_min=60,
-      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5,
-      project=vm_resource.Project.CLOUD_ML_AUTO_SOLUTIONS,
-  )
 
   microbenchmarks_v5p_8 = get_microbenchmark_config(
       tpu_version=vm_resource.TpuVersion.V5P,

--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -57,6 +57,17 @@ with models.DAG(
       subnetwork=vm_resource.V5P_SUBNETWORKS,
   )
 
+  microbenchmarks_v5p_256 = get_microbenchmark_config(
+      tpu_version=vm_resource.TpuVersion.V5P,
+      tpu_cores=256,
+      tpu_zone=vm_resource.Zone.US_EAST5_A,
+      time_out_in_min=60,
+      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5,
+      project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
+      network=vm_resource.V5_NETWORKS,
+      subnetwork=vm_resource.V5P_SUBNETWORKS,
+  )
+
   microbenchmarks_v5e_4 = get_microbenchmark_config(
       tpu_version=vm_resource.TpuVersion.V5E,
       tpu_cores=4,
@@ -79,14 +90,6 @@ with models.DAG(
       subnetwork=vm_resource.V5E_SUBNETWORKS,
   )
 
-#   microbenchmarks_v6e_4 = get_microbenchmark_config(
-#       tpu_version=vm_resource.TpuVersion.TRILLIUM,
-#       tpu_cores=4,
-#       tpu_zone=vm_resource.Zone.US_EAST5_C,
-#       time_out_in_min=60,
-#       runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV6,
-#       project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
-#   )
 
   microbenchmarks_v5e_256 = get_microbenchmark_xpk_config(
       time_out_in_min=60,


### PR DESCRIPTION
# Description

Update the dags for the microbenchmarks:
1. Get tests from the accelerator-microbenchmarks repo
2. Update the resources to run: 
  Removed tests for v6e-4 for now since there's no capacity available

# Tests

Ran the dags on ml-auto-solutions-dev composer: https://pantheon.corp.google.com/composer/dags/us-central1/ml-automation-solutions-dev/framework_microbenchmark/runs?referrer=search&e=13803378&invt=Abu2kw&mods=allow_workbench_image_override&project=cloud-ml-auto-solutions&pageState=(%22taskInstanceList%22:(%22p%22:0,%22f%22:%22%255B%255D%22))

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.