### PR TITLE
add kubectl delete

### DIFF
--- a/dags/map_reproducibility/utils/internal_aotc_workload.py
+++ b/dags/map_reproducibility/utils/internal_aotc_workload.py
@@ -118,7 +118,8 @@ def run_internal_aotc_workload(
         config.MODEL_ID, config.FRAMEWORK
     )
 
-    container_timeout = int(timeout) - 3
+    container_timeout = int(timeout) - 4
+    print(f"container timeout is {container_timeout}")
     result = hook.run_command(
         [
             "bash",


### PR DESCRIPTION
# Description
add kubectl delete and force delete

Old pods deletion code are not work as expected: https://screenshot.googleplex.com/7U3XpALRBM8WqvJ
So we changed to the new force deletion cmd to grantee the release of resources. 
Jobs or pods are not guaranteed to be deleted by the ttl setup as well. Details [here](https://docs.google.com/document/d/1hBMgXc44p69k2QLt2XALLTlsuyFcomJc8cpzs38zHwk/edit?tab=t.faaa4oeom6t2#bookmark=id.eqy7n8uvwci2).

The new deletion logic is:
helm uninstall -> wait 60s -> regular kubectl delete ->wait 30s-> kubectl force delete

# Tests
1. manual test that helm uninstall normally takes 60s: [here](https://paste.googleplex.com/6285594009010176)
2. if helm uninstall works: https://screenshot.googleplex.com/7TZgcrJFSsFG6U9
3. if helm uninstall not work but kubectl works: https://screenshot.googleplex.com/3uHTiEYFJZbtN4a



# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.