### PR TITLE
reduce retry

### DIFF
--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
@@ -57,9 +57,19 @@ for config_path, config_info in DAG_CONFIGS_MEGA.items():
   )
   timeout = config_info["timeout_minutes"]
 
+  # Set retry parameter based on timeout
+  retries = 1 if timeout <= 15 else 2
+  retry_delay = datetime.timedelta(minutes=1)
+
+  dag_default_args = {
+      "retries": retries,
+      "retry_delay": retry_delay,
+  }
+
   # Create DAG for nightly build
   with models.DAG(
       dag_id=f"new_internal_{config_name}",
+      default_args=dag_default_args,
       schedule=nightly_schedule,
       tags=DAG_TAGS,
       start_date=datetime.datetime(2025, 4, 3),
@@ -76,6 +86,7 @@ for config_path, config_info in DAG_CONFIGS_MEGA.items():
   # Create DAG for stable release
   with models.DAG(
       dag_id=f"new_internal_stable_release_{config_name}",
+      default_args=dag_default_args,
       schedule=release_schedule,
       tags=DAG_TAGS,
       start_date=datetime.datetime(2025, 4, 7),

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -52,10 +52,19 @@ for config_path, config_info in DAG_CONFIGS_ULTRA.items():
   config_name = os.path.basename(config_path).replace(".yaml", "")
   schedule = config_info["schedule"] if TURN_ON_SCHEDULE else None
   timeout = config_info["timeout_minutes"]
+  # Set retry parameter based on timeout
+  retries = 1 if timeout <= 15 else 2
+  retry_delay = datetime.timedelta(minutes=1)
+
+  dag_default_args = {
+      "retries": retries,
+      "retry_delay": retry_delay,
+  }
 
   # Create DAG for nightly build
   with models.DAG(
       dag_id=f"new_internal_{config_name}",
+      default_args=dag_default_args,
       schedule=schedule,
       tags=DAG_TAGS,
       start_date=datetime.datetime(2025, 4, 3),
@@ -72,6 +81,7 @@ for config_path, config_info in DAG_CONFIGS_ULTRA.items():
   # Create DAG for stable release
   with models.DAG(
       dag_id=f"new_internal_stable_release_{config_name}",
+      default_args=dag_default_args,
       schedule=schedule,
       tags=DAG_TAGS,
       start_date=datetime.datetime(2025, 4, 3),

--- a/dags/map_reproducibility/internal_runs/backfill_dags.py
+++ b/dags/map_reproducibility/internal_runs/backfill_dags.py
@@ -73,7 +73,7 @@ def create_adaptive_backfill_dag(
     backfill: bool = DEFAULT_BACKFILL,
     nightly_image_tag: str = DEFAULT_NIGHTLY_IMAGE_TAG,
     release_image_tag: str = DEFAULT_RELEASE_IMAGE_TAG,
-    retries: int = 3,  # Number of retries for tasks
+    retries: int = 2,  # Number of retries for tasks
 ) -> models.DAG:
   """
   Creates an Airflow DAG for backfilling Aotc reproducibility benchmarks.


### PR DESCRIPTION
# Description

reduce num of retry to save benchmarking time. Originally is the default 3 retries. Now it is changed to 2 for small workloads and 1 to large workloads

# Tests
https://screenshot.googleplex.com/AKS9NPs8Kc5CAfZ

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.