### PR TITLE
Reenabling pathways_maxtext_v5e_configs_perf

### DIFF
--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -92,7 +92,7 @@ PATHWAYS_SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="pathways_maxtext_v5e_configs_perf",
-    schedule=None,
+    schedule=SCHEDULED_TIME,
     tags=["multipod_team", "maxtext", "stable", "nightly", "mlscale_perfx"],
     start_date=datetime.datetime(2024, 2, 19),
     catchup=False,


### PR DESCRIPTION
# Description

The Pathways version of this perf test has been disabled for a couple months because of consistent failures. Those failures have been addressed

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [ ] I have made or will make corresponding changes to the doc if needed.