### PR TITLE
Shift vllm benchmark schedule by 12 hours

### DIFF
--- a/dags/solutions_team/solutionsteam_vllm_benchmarks.py
+++ b/dags/solutions_team/solutionsteam_vllm_benchmarks.py
@@ -11,8 +11,8 @@ from dags.multipod.configs.common import SetupMode, Platform
 from dags.solutions_team.configs.vllm import vllm_benchmark_config
 
 
-# Run once a day at 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
+# Run once a day at 6 pm UTC (10 am PST)
+SCHEDULED_TIME = "0 18 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(


### PR DESCRIPTION
Shifting the vllm benchmark test schedule by 12 hours to avoid conflicting with other tests.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.