### PR TITLE
add trillium config for deepseek3

### DIFF
--- a/dags/common/model_configs.py
+++ b/dags/common/model_configs.py
@@ -40,3 +40,4 @@ class MaxTextTrilliumModelConfigs(enum.Enum):
   MIXTRAL_8X7B_DROPLESS = "mixtral_8x7b_dropless"
   MIXTRAL_8X7B_DROPPED = "mixtral_8x7b_dropped"
   MIXTRAL_8X7B_DROPPED_INT8 = "mixtral_8x7b_dropped_int8"
+  DEEPSEEK_V3_EP16 = "deepseek_v3_ep16"

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -58,6 +58,7 @@ with models.DAG(
       num_slices = (
           [2]
           if model == MaxTextTrilliumModelConfigs.LLAMA3_1_405B_8192
+          or model == MaxTextTrilliumModelConfigs.DEEPSEEK_V3_EP16
           else [1, 2]
       )
       maxtext_sweep_gke_test = (


### PR DESCRIPTION
# Description

add deepseek3 trillium config for benchmarking
- already added "deepseek_v3_ep16" in [MaxText](https://github.com/AI-Hypercomputer/maxtext/blob/58bcbb1efbb3abe6add3918cecc7714e7b00d9c6/benchmarks/maxtext_trillium_model_configs.py#L1589-L1627)
- now link it to XLML

# Tests

Using "maxtext_trillium_configs_perf.py" as a template, I create a local dag for testing pretraining of deepseek (num_slice=2, jax nightly docker).
- Code: https://screenshot.googleplex.com/AckdDpKYFBYbNzg
- Pretraining is successful: https://screenshot.googleplex.com/7kfX38i3Zg79EkH

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.