### PR TITLE
Update dags for microbenchmarks

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -371,4 +371,6 @@ class DockerImage(enum.Enum):
       "us-docker.pkg.dev/cloud-tpu-v2-images-dev/hybridsim/cloud_hybridsim_gcloud_python:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MICROBENCH_NIGHTLY = "gcr.io/tpu-prod-env-one-vm/microbenchmarks_runner:latest"
+  MICROBENCH_NIGHTLY = (
+      "gcr.io/tpu-prod-env-one-vm/microbenchmarks_runner:latest"
+  )

--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -371,3 +371,4 @@ class DockerImage(enum.Enum):
       "us-docker.pkg.dev/cloud-tpu-v2-images-dev/hybridsim/cloud_hybridsim_gcloud_python:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
+  MICROBENCH_NIGHTLY = "gcr.io/tpu-prod-env-one-vm/microbenchmarks_runner:latest"

--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -44,6 +44,7 @@ def get_microbenchmark_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
+      " rm -rf accelerator-microbenchmarks ",
       "git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git  ",
       "cd accelerator-microbenchmarks ",
       "pip install -r requirements.txt ",
@@ -105,22 +106,13 @@ def get_microbenchmark_xpk_config(
       composer_project=composer_project,
   )
 
-  set_up_cmds = (
-      "pip install --upgrade pip",
-      (
-          "pip install jax[tpu] -f"
-          " https://storage.googleapis.com/jax-releases/libtpu_releases.html"
-      ),
-  )
-
   benchmark_config = (
       f"xlml_v{cluster.device_version.value}_{cluster.core_count}.yaml"
   )
   metrics_report = "/tmp/microbenchmarks/outputs/metrics_report.jsonl"
 
   # Initial commands
-  run_model_cmds = set_up_cmds + (
-      "git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git ",
+  run_model_cmds = (
       # Create the output directory
       "mkdir -p /tmp/microbenchmarks/outputs ",
       # Remove any existing metrics report
@@ -129,9 +121,7 @@ def get_microbenchmark_xpk_config(
 
   # Run the benchmark tests.
   run_model_cmds += (
-      "cd accelerator-microbenchmarks ",
-      "pip install -r requirements.txt ",
-      "JAX_PLATFORMS=cpu ENABLE_PJRT_COMPATIBILITY=true ",
+      "cd /app/accelerator-microbenchmarks ",
       # Run the benchmark script
       f"python3 src/run_benchmark.py " f"--config=configs/{benchmark_config} ",
   )

--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -45,17 +45,6 @@ with models.DAG(
       subnetwork=vm_resource.V5P_SUBNETWORKS,
   )
 
-  microbenchmarks_v5p_128 = get_microbenchmark_config(
-      tpu_version=vm_resource.TpuVersion.V5P,
-      tpu_cores=128,
-      tpu_zone=vm_resource.Zone.US_EAST5_A,
-      time_out_in_min=60,
-      runtime_version=vm_resource.RuntimeVersion.V2_ALPHA_TPUV5,
-      project=vm_resource.Project.TPU_PROD_ENV_AUTOMATED,
-      network=vm_resource.V5_NETWORKS,
-      subnetwork=vm_resource.V5P_SUBNETWORKS,
-  )
-
   microbenchmarks_v5p_256 = get_microbenchmark_config(
       tpu_version=vm_resource.TpuVersion.V5P,
       tpu_cores=256,
@@ -92,7 +81,7 @@ with models.DAG(
   microbenchmarks_v5e_256 = get_microbenchmark_xpk_config(
       time_out_in_min=60,
       test_name="framework-microbenchmark-v5e-256",
-      docker_image=vm_resource.DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
+      docker_image=vm_resource.DockerImage.MICROBENCH_NIGHTLY.value,
       test_owner=test_owner.QINY_Y,
       cluster=vm_resource.XpkClusters.TPU_V5E_256_CLUSTER,
   ).run()
@@ -100,7 +89,7 @@ with models.DAG(
   microbenchmarks_v6e_256 = get_microbenchmark_xpk_config(
       time_out_in_min=60,
       test_name="framework-microbenchmark-v6e-256",
-      docker_image=vm_resource.DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
+      docker_image=vm_resource.DockerImage.MICROBENCH_NIGHTLY.value,
       test_owner=test_owner.QINY_Y,
       cluster=vm_resource.XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
   ).run()


### PR DESCRIPTION
# Description

Fix microbenchmarks XLML failures:
1. Fix "accelerator-microbenchmarks already exists" error by adding `rm accelerator-microbenchmarks` before git clone.
2. Use the 'microbenchmark-runner' docker container instead of maxtext for XPK runs. 
3. remove v5p-128 and only keep v5p-256 to avoid resource contention.

# Tests
Ran dag on ml-auto-solutions-dev

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.