### PR TITLE
a4 dag

### DIFF
--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
@@ -25,7 +25,7 @@ from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_a
 
 
 # Configuration parameters
-TEST_RUN = False
+TEST_RUN = False if composer_env.is_prod_env() else True
 TURN_ON_SCHEDULE = True if composer_env.is_prod_env() else False
 BACKFILL = False
 

--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
@@ -26,7 +26,6 @@ from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_a
 
 # Configuration parameters
 TEST_RUN = False if composer_env.is_prod_env() else True
-TURN_ON_SCHEDULE = True if composer_env.is_prod_env() else False
 BACKFILL = False
 
 # Get current date for image tags
@@ -49,12 +48,8 @@ DAG_TAGS = [
 for config_path, config_info in DAG_CONFIGS_MEGA.items():
   # Extract config name for the DAG ID
   config_name = os.path.basename(config_path).replace(".yaml", "")
-  nightly_schedule = (
-      config_info["nightly_schedule"] if TURN_ON_SCHEDULE else None
-  )
-  release_schedule = (
-      config_info["release_schedule"] if TURN_ON_SCHEDULE else None
-  )
+  nightly_schedule = config_info["nightly_schedule"] if not TEST_RUN else None
+  release_schedule = config_info["release_schedule"] if not TEST_RUN else None
   timeout = config_info["timeout_minutes"]
 
   # Set retry parameter based on timeout

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -26,7 +26,6 @@ from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_a
 
 # Configuration parameters
 TEST_RUN = False if composer_env.is_prod_env() else True
-TURN_ON_SCHEDULE = True if composer_env.is_prod_env() else False
 BACKFILL = False
 
 # Get current date for image tags
@@ -50,7 +49,7 @@ DAG_TAGS = [
 for config_path, config_info in DAG_CONFIGS_ULTRA.items():
   # Extract config name for the DAG ID
   config_name = os.path.basename(config_path).replace(".yaml", "")
-  schedule = config_info["schedule"] if TURN_ON_SCHEDULE else None
+  schedule = config_info["schedule"] if not TEST_RUN else None
   timeout = config_info["timeout_minutes"]
   # Set retry parameter based on timeout
   retries = 1 if timeout <= 15 else 2

--- a/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
@@ -26,7 +26,6 @@ from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_a
 
 # Configuration parameters
 TEST_RUN = False if composer_env.is_prod_env() else True
-TURN_ON_SCHEDULE = True if composer_env.is_prod_env() else False
 BACKFILL = False
 
 # Get current date for image tags
@@ -50,7 +49,7 @@ DAG_TAGS = [
 for config_path, config_info in DAG_CONFIGS_A4.items():
   # Extract config name for the DAG ID
   config_name = os.path.basename(config_path).replace(".yaml", "")
-  schedule = config_info["schedule"] if TURN_ON_SCHEDULE else None
+  schedule = config_info["schedule"] if not TEST_RUN else None
   timeout = config_info["timeout_minutes"]
   # Set retry parameter based on timeout
   retries = 1 if timeout <= 15 else 2

--- a/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
@@ -33,7 +33,6 @@ BACKFILL = False
 utc_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
 NIGHTLY_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_NIGHTLY}:{utc_date}"
 RELEASE_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_RELEASE}:{utc_date}"
-NIGHTLY_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_NIGHTLY}:2025-04-17"
 
 # Common DAG tags
 DAG_TAGS = [

--- a/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
@@ -20,7 +20,7 @@ import os
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.constants import Image
-from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_ULTRA
+from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_A4
 from dags.map_reproducibility.utils.internal_aotc_workload import run_internal_aotc_workload
 
 
@@ -33,21 +33,22 @@ BACKFILL = False
 utc_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
 NIGHTLY_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_NIGHTLY}:{utc_date}"
 RELEASE_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_RELEASE}:{utc_date}"
+NIGHTLY_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_NIGHTLY}:2025-04-17"
 
 # Common DAG tags
 DAG_TAGS = [
     "reproducibility",
     "experimental",
     "xlml",
-    "v1.17",
+    "v1.0",
     "internal",
     "regressiontests",
-    "a3ultra",
+    "a4",
 ]
 
 
 # Create DAGs for each configuration
-for config_path, config_info in DAG_CONFIGS_ULTRA.items():
+for config_path, config_info in DAG_CONFIGS_A4.items():
   # Extract config name for the DAG ID
   config_name = os.path.basename(config_path).replace(".yaml", "")
   schedule = config_info["schedule"] if TURN_ON_SCHEDULE else None
@@ -67,7 +68,7 @@ for config_path, config_info in DAG_CONFIGS_ULTRA.items():
       default_args=dag_default_args,
       schedule=schedule,
       tags=DAG_TAGS,
-      start_date=datetime.datetime(2025, 4, 3),
+      start_date=datetime.datetime(2025, 4, 28),
       catchup=False,
   ) as dag:
     run_internal_aotc_workload(
@@ -84,7 +85,7 @@ for config_path, config_info in DAG_CONFIGS_ULTRA.items():
       default_args=dag_default_args,
       schedule=schedule,
       tags=DAG_TAGS,
-      start_date=datetime.datetime(2025, 4, 3),
+      start_date=datetime.datetime(2025, 4, 28),
       catchup=False,
   ) as dag:
     run_internal_aotc_workload(

--- a/dags/map_reproducibility/internal_runs/dag_configs.py
+++ b/dags/map_reproducibility/internal_runs/dag_configs.py
@@ -149,3 +149,67 @@ DAG_CONFIGS_ULTRA = {
         "schedule": Schedule.WEEKDAY_PDT_2AM_EXCEPT_THURSDAY,
     },
 }
+
+
+DAG_CONFIGS_A4 = {
+    "recipes/a4/a4_llama3.1-8b_8gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-8b_8gpus_fp8_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-8b_16gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-8b_16gpus_fp8_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_mixtral-8x7b_8gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_mixtral-8x7b_16gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-70b_256gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 20,
+        "backfill_group_nightly": 2,
+        "backfill_group_release": 2,
+        "schedule": Schedule.WEEKDAY_PDT_12_30AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-70b_256gpus_fp8_maxtext.yaml": {
+        "timeout_minutes": 15,
+        "backfill_group_nightly": 3,
+        "backfill_group_release": 3,
+        "schedule": Schedule.WEEKDAY_PDT_1AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-405b_256gpus_fp8_maxtext.yaml": {
+        "timeout_minutes": 30,
+        "backfill_group_nightly": 4,
+        "backfill_group_release": 4,
+        "schedule": Schedule.WEEKDAY_PDT_1_30AM_EXCEPT_THURSDAY,
+    },
+    "recipes/a4/a4_llama3.1-405b_256gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 40,
+        "backfill_group_nightly": 5,
+        "backfill_group_release": 5,
+        "schedule": Schedule.WEEKDAY_PDT_2AM_EXCEPT_THURSDAY,
+    },
+}

--- a/dags/map_reproducibility/internal_runs/sample_a3mega_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a3mega_maxtext_single_run.py
@@ -31,6 +31,26 @@ from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_MEGA
 from dags.map_reproducibility.utils.sample_workload_utils import run_internal_sample_aotc_workload
 
 
+# Skip execution when being run as part of the DAG check
+# Checking if the file doesn't exist is a reliable way to detect this context
+base_recipe_repo_root = os.path.abspath(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "..",
+        "..",
+        "internal-gpu-recipes",
+    )
+)
+
+if not os.path.exists(base_recipe_repo_root):
+  print(
+      f"Skipping sample_a3ultra_maxtext_single_run.py - required directory not found: {base_recipe_repo_root}"
+  )
+  sys.exit(0)
+
+
 def main():
   utc_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
   NIGHTLY_IMAGE = f"{Image.MAXTEXT_JAX_STABLE_NIGHTLY}:{utc_date}"

--- a/dags/map_reproducibility/internal_runs/sample_a3mega_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a3mega_maxtext_single_run.py
@@ -46,7 +46,7 @@ if project_root not in sys.path:
 
 import datetime
 from dags.map_reproducibility.utils.constants import Image
-from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_ULTRA
+from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_MEGA
 from dags.map_reproducibility.utils.sample_workload_utils import run_internal_sample_aotc_workload
 
 
@@ -62,9 +62,9 @@ def main():
 
   # Setup configuration
   relative_config_yaml_path = (
-      "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml"
+      "recipes/a3mega/a3mega_llama3.1-8b_8gpus_fp8_maxtext.yaml"
   )
-  timeout = DAG_CONFIGS_ULTRA[relative_config_yaml_path]["timeout_minutes"]
+  timeout = DAG_CONFIGS_MEGA[relative_config_yaml_path]["timeout_minutes"]
 
   run_internal_sample_aotc_workload(
       relative_config_yaml_path=relative_config_yaml_path,

--- a/dags/map_reproducibility/internal_runs/sample_a3mega_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a3mega_maxtext_single_run.py
@@ -16,25 +16,6 @@
 import sys
 import os
 
-# Skip execution when being run as part of the DAG check
-# Checking if the file doesn't exist is a reliable way to detect this context
-base_recipe_repo_root = os.path.abspath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        "..",
-        "..",
-        "..",
-        "..",
-        "internal-gpu-recipes",
-    )
-)
-
-if not os.path.exists(base_recipe_repo_root):
-  print(
-      f"Skipping sample_a3ultra_maxtext_single_run.py - required directory not found: {base_recipe_repo_root}"
-  )
-  sys.exit(0)
-
 script_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
 

--- a/dags/map_reproducibility/internal_runs/sample_a3ultra_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a3ultra_maxtext_single_run.py
@@ -16,25 +16,6 @@
 import sys
 import os
 
-# Skip execution when being run as part of the DAG check
-# Checking if the file doesn't exist is a reliable way to detect this context
-base_recipe_repo_root = os.path.abspath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        "..",
-        "..",
-        "..",
-        "..",
-        "internal-gpu-recipes",
-    )
-)
-
-if not os.path.exists(base_recipe_repo_root):
-  print(
-      f"Skipping sample_a3ultra_maxtext_single_run.py - required directory not found: {base_recipe_repo_root}"
-  )
-  sys.exit(0)
-
 script_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
 

--- a/dags/map_reproducibility/internal_runs/sample_a3ultra_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a3ultra_maxtext_single_run.py
@@ -30,6 +30,25 @@ from dags.map_reproducibility.utils.constants import Image
 from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_ULTRA
 from dags.map_reproducibility.utils.sample_workload_utils import run_internal_sample_aotc_workload
 
+# Skip execution when being run as part of the DAG check
+# Checking if the file doesn't exist is a reliable way to detect this context
+base_recipe_repo_root = os.path.abspath(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "..",
+        "..",
+        "internal-gpu-recipes",
+    )
+)
+
+if not os.path.exists(base_recipe_repo_root):
+  print(
+      f"Skipping sample_a3ultra_maxtext_single_run.py - required directory not found: {base_recipe_repo_root}"
+  )
+  sys.exit(0)
+
 
 def main():
   utc_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")

--- a/dags/map_reproducibility/internal_runs/sample_a4_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a4_maxtext_single_run.py
@@ -30,6 +30,25 @@ from dags.map_reproducibility.utils.constants import Image
 from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_A4
 from dags.map_reproducibility.utils.sample_workload_utils import run_internal_sample_aotc_workload
 
+# Skip execution when being run as part of the DAG check
+# Checking if the file doesn't exist is a reliable way to detect this context
+base_recipe_repo_root = os.path.abspath(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "..",
+        "..",
+        "internal-gpu-recipes",
+    )
+)
+
+if not os.path.exists(base_recipe_repo_root):
+  print(
+      f"Skipping sample_a3ultra_maxtext_single_run.py - required directory not found: {base_recipe_repo_root}"
+  )
+  sys.exit(0)
+
 
 def main():
   utc_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")

--- a/dags/map_reproducibility/internal_runs/sample_a4_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a4_maxtext_single_run.py
@@ -16,25 +16,6 @@
 import sys
 import os
 
-# Skip execution when being run as part of the DAG check
-# Checking if the file doesn't exist is a reliable way to detect this context
-base_recipe_repo_root = os.path.abspath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        "..",
-        "..",
-        "..",
-        "..",
-        "internal-gpu-recipes",
-    )
-)
-
-if not os.path.exists(base_recipe_repo_root):
-  print(
-      f"Skipping sample_a3ultra_maxtext_single_run.py - required directory not found: {base_recipe_repo_root}"
-  )
-  sys.exit(0)
-
 script_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
 

--- a/dags/map_reproducibility/internal_runs/sample_a4_maxtext_single_run.py
+++ b/dags/map_reproducibility/internal_runs/sample_a4_maxtext_single_run.py
@@ -46,7 +46,7 @@ if project_root not in sys.path:
 
 import datetime
 from dags.map_reproducibility.utils.constants import Image
-from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_ULTRA
+from dags.map_reproducibility.internal_runs.dag_configs import DAG_CONFIGS_A4
 from dags.map_reproducibility.utils.sample_workload_utils import run_internal_sample_aotc_workload
 
 
@@ -61,10 +61,8 @@ def main():
   SAMPLE_RUN_BUCKET_NAME = "yujunzou-dev-supercomputer-testing"
 
   # Setup configuration
-  relative_config_yaml_path = (
-      "recipes/a3ultra/a3ultra_llama3.1-8b_8gpus_fp8_maxtext.yaml"
-  )
-  timeout = DAG_CONFIGS_ULTRA[relative_config_yaml_path]["timeout_minutes"]
+  relative_config_yaml_path = "recipes/a4/a4_llama3.1-8b_8gpus_fp8_maxtext.yaml"
+  timeout = DAG_CONFIGS_A4[relative_config_yaml_path]["timeout_minutes"]
 
   run_internal_sample_aotc_workload(
       relative_config_yaml_path=relative_config_yaml_path,

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -282,7 +282,6 @@ def helm_apply_cmds_internal_run(
     cluster_name: str = "a3plus-benchmark",
     kueue_name: str = "a3-ultra",
     additional_cmds: str = "",
-    test_run=False,
     bucket_name=BUCKET_NAME,
 ):
   gcs_cmd = ""
@@ -307,11 +306,9 @@ def helm_apply_cmds_internal_run(
   if aotc:
     set_aotc = " --set-string workload.aotc=true "
 
-  local_helm_template_path = f"/home/airflow/gcs/dags/dags/map_reproducibility/helm-charts/{hypercomputer}/{framework}-training"
-  if test_run and os.path.exists(local_helm_template_path):
-    helm_template_path = local_helm_template_path
-  else:
-    helm_template_path = f"{recipe_repo_root}/src/helm-charts/{hypercomputer}/{framework}-training"
+  helm_template_path = (
+      f"{recipe_repo_root}/src/helm-charts/{hypercomputer}/{framework}-training"
+  )
 
   print(f"helm_template_path is {helm_template_path}")
 

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -608,7 +608,7 @@ def get_cluster(hardware: str = "a3ultra"):
   if hardware == "a3ultra":
     return "gke-a3ultra-bm-map-3", "europe-west1"
   if hardware == "a4":
-    return "gke-a4-map", "us-central1"
+    return "gke-a4-shared", "us-central1"
 
 
 def get_scheduled_time(hardware: str, model: str, framework: str):

--- a/dags/map_reproducibility/utils/internal_aotc_workload.py
+++ b/dags/map_reproducibility/utils/internal_aotc_workload.py
@@ -141,7 +141,6 @@ def run_internal_aotc_workload(
                     cluster_name=cluster,
                     kueue_name=KUEUE_NAME,
                     additional_cmds=f" --set workload.gpus={config.NUM_GPUS} ",
-                    test_run=test_run,
                 )
                 + internal_wait_for_jobs_cmds(timeout=container_timeout)
                 + copy_bucket_cmds_maxtext(tmpdir)

--- a/dags/map_reproducibility/utils/internal_aotc_workload.py
+++ b/dags/map_reproducibility/utils/internal_aotc_workload.py
@@ -75,7 +75,7 @@ def run_internal_aotc_workload(
             ";".join(
                 git_cookie_authdaemon()
                 + clone_recipes_gob()
-                + (() if test_run else clone_internal_recipes_gob())
+                + clone_internal_recipes_gob()
                 + get_bq_writer_repo()
             ),
         ],
@@ -86,11 +86,7 @@ def run_internal_aotc_workload(
     bq_writer_repo_root = get_bq_writer_path(tmpdir)
 
     # Update paths now that we have the repo paths
-    internal_recipe_repo_root = (
-        "/home/airflow/gcs/dags/dags/map_reproducibility"
-    )
-    if not test_run:
-      internal_recipe_repo_root = get_internal_recipe_repo_path(tmpdir)
+    internal_recipe_repo_root = get_internal_recipe_repo_path(tmpdir)
     values_file_path = f"{internal_recipe_repo_root}/values/{values_name}.yaml"
     model_specific_values_file_path = (
         f"{internal_recipe_repo_root}/values/{config_yaml_name}_values.yaml"

--- a/dags/map_reproducibility/utils/sample_workload_utils.py
+++ b/dags/map_reproducibility/utils/sample_workload_utils.py
@@ -286,7 +286,6 @@ def run_internal_sample_aotc_workload(
             cluster_name=cluster,
             kueue_name=KUEUE_NAME,
             additional_cmds=f" --set workload.gpus={config.NUM_GPUS} ",
-            test_run=True,
             bucket_name=sample_run_bucket_name,
         )
         + internal_wait_for_jobs_cmds(timeout=container_timeout)


### PR DESCRIPTION
# Description
1. internal recipe a4 dag
2.  TEST_RUN can only control whether the record is written to test DB or prod DB. TEST_RUN will not control where to pull the recipes. The system now can only pull recipes from the gob repo. If user want to use local recipes to test, the user can use the sample_a4_maxtext_single_run.py 

# Tests
sample run work:https://paste.googleplex.com/5510126137769984
test dag work: https://screenshot.googleplex.com/ANcr6ez8773faL5

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.