### PR TITLE
Updating a3ultra tests to match the new recipes 

### DIFF
--- a/dags/map_reproducibility/a3ultra/llama_3_1_405b_nemo.py
+++ b/dags/map_reproducibility/a3ultra/llama_3_1_405b_nemo.py
@@ -19,7 +19,7 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "llama3-1-405b"
@@ -27,6 +27,7 @@ METRICS_MODEL_ID = "llama3.1-405b"
 PRECISION = "fp8"
 HYPERCOMPUTER = "a3ultra"
 FRAMEWORK = "nemo"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
 
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
@@ -34,13 +35,13 @@ SCHEDULED_TIME = (
     else None
 )
 
-VALUE_YAML_PATH = (
-    f"training/{HYPERCOMPUTER}/{MODEL_ID}/nemo-pretraining-gke/values.yaml"
-)
+# VALUE_YAML_PATH = (
+#     f"training/{HYPERCOMPUTER}/{MODEL_ID}/nemo-pretraining-gke/values.yaml"
+# )
 SOFTWARE_ID = "pytorch_nemo"
-IMAGE_VERSION = "nemo_workload:24.12"
+# IMAGE_VERSION = "nemo_workload:24.12"
 KUEUE_NAME = "a3-ultra"
-NUM_GPUS = 576
+# NUM_GPUS = 576
 
 with models.DAG(
     dag_id=f"{HYPERCOMPUTER}_recipes_{MODEL_ID}_{FRAMEWORK}",
@@ -55,12 +56,13 @@ with models.DAG(
     start_date=datetime.datetime(2025, 5, 1),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
       kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
-      config_model_name=f"{MODEL_ID}-{NUM_GPUS}gpus-{HYPERCOMPUTER}-{PRECISION}.yaml",
+      # config_model_name=f"{MODEL_ID}-{NUM_GPUS}gpus-{HYPERCOMPUTER}-{PRECISION}.yaml",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/a3ultra/llama_3_1_70b_maxtext.py
+++ b/dags/map_reproducibility/a3ultra/llama_3_1_70b_maxtext.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,18 @@
 import datetime
 from airflow import models
 from dags import composer_env
-
-from dags.map_reproducibility.utils.common_utils import get_cluster
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import get_docker_image
-from dags.map_reproducibility.utils.common_utils import run_maxtext_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "llama3-1-70b"
+METRICS_MODEL_ID = "llama3.1-70b"
 PRECISION = "bf16"
 HYPERCOMPUTER = "a3ultra"
 FRAMEWORK = "maxtext"
+WORKLOAD_LAUNCHER = "maxtext-launcher.sh"
+OPTIMIZER = "adam"
+NUM_STEPS = 20
 
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
@@ -36,15 +37,7 @@ SCHEDULED_TIME = (
 )
 
 SOFTWARE_ID = "jax_maxtext"
-CLUSTER, CLUSTER_REGION = get_cluster(HYPERCOMPUTER)
-IMAGE_VERSION = "maxtext-nightly"
-DOCKER_IMAGE = get_docker_image(HYPERCOMPUTER, FRAMEWORK)
 KUEUE_NAME = "a3-ultra"
-
-OPTIMIZER = "adam"
-SEQUENCE_LENGTH = 2048
-NUM_STEPS = 30
-BATCH_SIZE_PER_DEVICE = 2
 
 
 with models.DAG(
@@ -60,28 +53,30 @@ with models.DAG(
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,
 ) as dag:
-  run_maxtext_workload(
+  run_256gpus = run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
-      num_steps=NUM_STEPS,
-      batch_size_per_device=BATCH_SIZE_PER_DEVICE,
       kueue_name=KUEUE_NAME,
+      metrics_model_id=METRICS_MODEL_ID,
+      workload_launcher=WORKLOAD_LAUNCHER,
+      config_model_name=f"llama3-1-70b-256gpus-a3u-{PRECISION}.yaml",
       optimizer=OPTIMIZER,
-      sequence_length=SEQUENCE_LENGTH,
-      helm_model_id=MODEL_ID,
+      num_steps=NUM_STEPS,
   )
-  run_maxtext_workload(
+  run_512gpus = run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
-      num_steps=NUM_STEPS,
-      batch_size_per_device=BATCH_SIZE_PER_DEVICE,
       kueue_name=KUEUE_NAME,
-      optimizer=OPTIMIZER,
-      sequence_length=SEQUENCE_LENGTH,
-      helm_model_id=MODEL_ID,
+      metrics_model_id=METRICS_MODEL_ID,
+      workload_launcher=WORKLOAD_LAUNCHER,
       num_gpus=512,
+      config_model_name=f"llama3-1-70b-512gpus-a3u-{PRECISION}.yaml",
+      optimizer=OPTIMIZER,
+      num_steps=NUM_STEPS,
   )
+
+  run_256gpus >> run_512gpus

--- a/dags/map_reproducibility/a3ultra/llama_3_1_70b_nemo.py
+++ b/dags/map_reproducibility/a3ultra/llama_3_1_70b_nemo.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "llama3-1-70b"
@@ -27,6 +27,7 @@ METRICS_MODEL_ID = "llama3.1-70b"
 PRECISION = "fp8"
 HYPERCOMPUTER = "a3ultra"
 FRAMEWORK = "nemo"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
 
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
@@ -34,13 +35,12 @@ SCHEDULED_TIME = (
     else None
 )
 
-VALUE_YAML_PATH = (
-    f"training/{HYPERCOMPUTER}/{MODEL_ID}/nemo-pretraining-gke/values.yaml"
-)
+# VALUE_YAML_PATH = (
+#     f"training/{HYPERCOMPUTER}/{MODEL_ID}/nemo-pretraining-gke/values.yaml"
+# )
 SOFTWARE_ID = "pytorch_nemo"
-IMAGE_VERSION = "nemo_workload:24.07"
 KUEUE_NAME = "a3-ultra"
-NUM_GPUS = 256
+# NUM_GPUS = 256
 
 
 with models.DAG(
@@ -56,12 +56,12 @@ with models.DAG(
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
       kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
-      config_model_name=f"{MODEL_ID}-{NUM_GPUS}gpus-{HYPERCOMPUTER}-{PRECISION}.yaml",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/a3ultra/mixtral_8_7b_nemo.py
+++ b/dags/map_reproducibility/a3ultra/mixtral_8_7b_nemo.py
@@ -19,7 +19,7 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "mixtral-8x7b"
@@ -27,6 +27,8 @@ METRICS_MODEL_ID = "mixtral-7b"
 PRECISION = "bf16"
 HYPERCOMPUTER = "a3ultra"
 FRAMEWORK = "nemo"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
+
 
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
@@ -35,6 +37,7 @@ SCHEDULED_TIME = (
 )
 
 KUEUE_NAME = "a3-ultra"
+NUM_GPUS = 256
 
 
 with models.DAG(
@@ -50,11 +53,13 @@ with models.DAG(
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
       kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
+      config_model_name=f"{MODEL_ID}-{NUM_GPUS}gpus-a3u-{PRECISION}.yaml",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/tests/test_common_utils.py
+++ b/dags/map_reproducibility/tests/test_common_utils.py
@@ -1,0 +1,333 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import tempfile
+import os
+import yaml
+from dags.map_reproducibility.utils.common_utils import helm_apply_cmds_workload, BUCKET_NAME, copy_bucket_cmds_workload, extract_value_from_yaml
+
+
+class TestHelmApplyCmdsWorkload(unittest.TestCase):
+
+  def setUp(self):
+    self.framework_maxtext = "maxtext"
+    self.framework_nemo = "nemo"
+    self.hypercomputer = "a3ultra"
+    self.config_file = "/path/to/config.yaml"
+    self.recipe_repo_root = "/path/to/recipes"
+    self.workload_launcher = "my-launcher"
+    self.base_expected_start = (
+        "helm install -f values.yaml"
+        " --namespace default"
+        " --set namespace=default"
+        f' --set-file workload_config="{self.config_file}"'
+        f' --set-file workload_launcher="{self.workload_launcher}"'
+    )
+    self.base_expected_end = f" $JOB_NAME {self.recipe_repo_root}/src/helm-charts/{self.hypercomputer}/jobset"
+
+  def test_maxtext_framework_with_num_steps(self):
+    num_steps = 100
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        num_steps=num_steps,
+    )
+    self.assertEqual(len(cmds), 1)
+    expected_workload_args = f'--set workload.arguments[0]="base_output_directory=gs://{BUCKET_NAME}/maxtext-experiments jax_distributed_initialization_timeout=600 steps={num_steps}"'
+    self.assertIn(self.base_expected_start, cmds[0])
+    self.assertIn(expected_workload_args, cmds[0])
+    self.assertNotIn(
+        f"--set volumes.gcsMounts[0].bucketName={BUCKET_NAME}", cmds[0]
+    )  # gcs_cmd is empty for maxtext
+    self.assertIn(self.base_expected_end, cmds[0])
+
+  def test_maxtext_framework_without_num_steps(self):
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+    )
+    self.assertEqual(len(cmds), 1)
+    expected_workload_args = f'--set workload.arguments[0]="base_output_directory=gs://{BUCKET_NAME}/maxtext-experiments jax_distributed_initialization_timeout=600"'
+    self.assertIn(self.base_expected_start, cmds[0])
+    self.assertIn(expected_workload_args, cmds[0])
+    self.assertNotIn(
+        f"--set volumes.gcsMounts[0].bucketName={BUCKET_NAME}", cmds[0]
+    )
+    self.assertIn(self.base_expected_end, cmds[0])
+
+  def test_other_framework_with_num_steps(self):
+    num_steps = 200
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_nemo,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        num_steps=num_steps,
+    )
+    self.assertEqual(len(cmds), 1)
+    expected_workload_args = (
+        f'--set workload.arguments[0]="trainer.max_steps={num_steps}"'
+    )
+    expected_gcs_cmd = f"--set volumes.gcsMounts[0].bucketName={BUCKET_NAME}"
+    self.assertIn(self.base_expected_start, cmds[0])
+    self.assertIn(expected_workload_args, cmds[0])
+    self.assertIn(expected_gcs_cmd, cmds[0])
+    self.assertIn(self.base_expected_end, cmds[0])
+
+  def test_other_framework_without_num_steps(self):
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_nemo,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+    )
+    self.assertEqual(len(cmds), 1)
+    # workload_arguments_cmd is empty in this case
+    self.assertNotIn("--set workload.arguments[0]=", cmds[0])
+    expected_gcs_cmd = f"--set volumes.gcsMounts[0].bucketName={BUCKET_NAME}"
+    self.assertIn(self.base_expected_start, cmds[0])
+    self.assertIn(expected_gcs_cmd, cmds[0])
+    self.assertIn(self.base_expected_end, cmds[0])
+
+  def test_with_kueue_name(self):
+    kueue_name = "my-custom-queue"
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        kueue_name=kueue_name,
+    )
+    self.assertEqual(len(cmds), 1)
+    self.assertIn(f" --set queue={kueue_name}", cmds[0])
+
+  def test_without_kueue_name(self):
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        kueue_name=None,  # Explicitly None
+    )
+    self.assertEqual(len(cmds), 1)
+    self.assertNotIn(" --set queue=", cmds[0])
+
+  def test_with_aotc_true(self):
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        aotc=True,
+    )
+    self.assertEqual(len(cmds), 1)
+    self.assertIn(" --set-string workload.aotc=true ", cmds[0])
+
+  def test_with_aotc_false(self):
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        aotc=False,  # Explicitly False (default)
+    )
+    self.assertEqual(len(cmds), 1)
+    self.assertNotIn(" --set-string workload.aotc=true ", cmds[0])
+
+  def test_with_additional_cmds(self):
+    additional_cmds = "--set foo=bar --set baz=qux"
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        additional_cmds=additional_cmds,
+    )
+    self.assertEqual(len(cmds), 1)
+    self.assertIn(additional_cmds, cmds[0])
+
+  def test_all_options_enabled_maxtext(self):
+    num_steps = 50
+    kueue_name = "test-queue"
+    additional_cmds = "--set custom.value=true"
+    cmds = helm_apply_cmds_workload(
+        framework=self.framework_maxtext,
+        hypercomputer=self.hypercomputer,
+        config_file=self.config_file,
+        recipe_repo_root=self.recipe_repo_root,
+        workload_launcher=self.workload_launcher,
+        aotc=True,
+        kueue_name=kueue_name,
+        additional_cmds=additional_cmds,
+        num_steps=num_steps,
+    )
+    self.assertEqual(len(cmds), 1)
+    expected_command = (
+        f"{self.base_expected_start}"
+        f" --set queue={kueue_name}"
+        f' --set workload.arguments[0]="base_output_directory=gs://{BUCKET_NAME}/maxtext-experiments jax_distributed_initialization_timeout=600 steps={num_steps}"'
+        # No gcs_cmd for maxtext
+        f" --set-string workload.aotc=true "
+        f"{additional_cmds}"
+        f"{self.base_expected_end}"
+    )
+    # Normalize spaces for comparison
+    self.assertEqual(
+        " ".join(cmds[0].split()), " ".join(expected_command.split())
+    )
+
+
+class TestExtractValueFromYaml(unittest.TestCase):
+
+  def setUp(self):
+    self.temp_dir = tempfile.TemporaryDirectory()
+    self.test_yaml_file_name = "test_config.yaml"
+    self.test_yaml_content = {
+        "workload": {
+            "image": "test_image:latest",
+            "gpus": 8,
+            "settings": {"timeout": 3600, "retries": 3},
+        },
+        "metadata": {"version": "1.0", "author": "test_user"},
+        "simple_key": "simple_value",
+    }
+    with open(
+        os.path.join(self.temp_dir.name, self.test_yaml_file_name), "w"
+    ) as f:
+      yaml.dump(self.test_yaml_content, f)
+
+  def tearDown(self):
+    self.temp_dir.cleanup()
+
+  def test_extract_top_level_key(self):
+    value = extract_value_from_yaml(
+        self.temp_dir.name, self.test_yaml_file_name, "simple_key"
+    )
+    self.assertEqual(value, "simple_value")
+
+  def test_extract_nested_key(self):
+    value = extract_value_from_yaml(
+        self.temp_dir.name, self.test_yaml_file_name, "workload.image"
+    )
+    self.assertEqual(value, "test_image:latest")
+
+  def test_extract_deeply_nested_key(self):
+    value = extract_value_from_yaml(
+        self.temp_dir.name,
+        self.test_yaml_file_name,
+        "workload.settings.timeout",
+    )
+    self.assertEqual(value, 3600)
+
+  def test_key_not_found_top_level(self):
+    value = extract_value_from_yaml(
+        self.temp_dir.name, self.test_yaml_file_name, "non_existent_key"
+    )
+    self.assertIsNone(value)
+
+  def test_key_not_found_nested(self):
+    value = extract_value_from_yaml(
+        self.temp_dir.name,
+        self.test_yaml_file_name,
+        "workload.non_existent_setting",
+    )
+    self.assertIsNone(value)
+
+  def test_file_not_found(self):
+    value = extract_value_from_yaml(
+        self.temp_dir.name, "non_existent_file.yaml", "workload.image"
+    )
+    self.assertIsNone(value)
+
+  def test_invalid_yaml_content(self):
+    invalid_yaml_file_name = "invalid.yaml"
+    with open(
+        os.path.join(self.temp_dir.name, invalid_yaml_file_name), "w"
+    ) as f:
+      f.write("workload: image: test_image:latest\n  gpus: 8")  # Malformed YAML
+    value = extract_value_from_yaml(
+        self.temp_dir.name, invalid_yaml_file_name, "workload.image"
+    )
+    self.assertIsNone(value)
+
+
+class TestCopyBucketCmdsWorkload(unittest.TestCase):
+
+  def setUp(self):
+    self.recipe_repo_root = "/path/to/recipes"
+    self.tmpdir = "/test/tmp"
+    # BUCKET_NAME is imported from common_utils
+
+  def test_maxtext_framework(self):
+    framework = "maxtext"
+    cmds = copy_bucket_cmds_workload(
+        recipe_repo_root=self.recipe_repo_root,
+        tmpdir=self.tmpdir,
+        framework=framework,
+    )
+
+    gcs_location = f"gs://{BUCKET_NAME}/maxtext-experiments/"
+    expected_cmds = (
+        f"METRICS_FILE={self.tmpdir}/tflog/metrics",
+        f"export BUCKET_FOLDER=$(gcloud storage ls {gcs_location} | grep $JOB_NAME)",
+        'echo "BUCKET_FOLDER ${BUCKET_FOLDER}"',
+        "export COMPLETE_JOB_NAME=$(gcloud storage ls ${BUCKET_FOLDER}tensorboard/ | grep $JOB_NAME)",
+        'echo "COMPLETE_JOB_NAME ${COMPLETE_JOB_NAME}"',
+        "export LOG_FILE=$(gcloud storage ls ${COMPLETE_JOB_NAME} | grep events)",
+        'echo "LOG_FILE ${LOG_FILE}"',
+        f"gcloud storage cp $LOG_FILE $METRICS_FILE",
+    )
+    self.assertEqual(cmds, expected_cmds)
+
+  def test_nemo_framework(self):
+    framework = "nemo"
+    cmds = copy_bucket_cmds_workload(
+        recipe_repo_root=self.recipe_repo_root,
+        tmpdir=self.tmpdir,  # tmpdir is not used by nemo branch, but it's a required arg
+        framework=framework,
+    )
+
+    gcs_location = f"gs://{BUCKET_NAME}/nemo-experiments/"
+    expected_cmds = (
+        f"export COMPLETE_JOB_NAME=$(gcloud storage ls {gcs_location} | grep $JOB_NAME)",
+        'echo "COMPLETE_JOB_NAME ${COMPLETE_JOB_NAME}"',
+        f"cd {self.recipe_repo_root}/src/utils/training_metrics",
+        "gcloud storage cp ${COMPLETE_JOB_NAME}dllogger/rank-0/dllogger.json .",
+    )
+    self.assertEqual(cmds, expected_cmds)
+
+  def test_other_framework_behaves_like_nemo(self):
+    framework = "some_other_framework"  # Should fall into the 'else' block
+    # For a framework not explicitly "maxtext", it should default to the "nemo" command structure.
+    # This test verifies that behavior.
+    # Reusing the expected commands from the "nemo" test.
+    self.test_nemo_framework()
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -33,7 +33,7 @@ from dags.map_reproducibility.utils.benchmarkdb_utils import write_run
 from datetime import datetime, timezone
 from dags import composer_env
 from google.cloud import storage
-from typing import Optional
+from typing import Optional, Set, Tuple
 
 
 # Configure logging
@@ -130,7 +130,7 @@ def get_gpu_recipe_cmd(hypercomputer, model_id, framework, recipe_repo_root):
 def get_pre_workload_cmds(model_id, framework):
   prepare_workload_cmds = (
       "NOW=$(date +%s)",
-      f"export JOB_NAME=imo-team-regr-test-{model_id}-$NOW-{framework}",
+      f"export JOB_NAME=imo-{model_id}-$NOW-{framework}",
   )
   return prepare_workload_cmds
 
@@ -331,6 +331,81 @@ def helm_apply_cmds_internal_run(
   return helm_cmds
 
 
+def helm_apply_cmds_workload(
+    framework: str,
+    hypercomputer: str,
+    config_file: str,
+    recipe_repo_root: str,
+    workload_launcher: str,
+    aotc: bool = False,
+    kueue_name: Optional[str] = None,
+    additional_cmds: str = "",
+    num_steps: Optional[int] = None,
+) -> tuple[str, ...]:
+  """
+  Generates the Helm install command string for a workload jobset.
+  """
+  cmd_parts = [
+      "helm",
+      "install",
+      "-f",
+      "values.yaml",
+      "--namespace",
+      "default",
+      "--set",
+      "namespace=default",
+      # Maintaining original quoting for test compatibility:
+      f'--set-file workload_config="{config_file}"',
+      f'--set-file workload_launcher="{workload_launcher}"',
+  ]
+
+  if kueue_name:
+    cmd_parts.append(f"--set queue={kueue_name}")
+
+  # Determine workload arguments and GCS settings based on framework
+  workload_args_value_parts = []
+  gcs_part_for_non_maxtext = None
+
+  if framework == "maxtext":
+    workload_args_value_parts.append(
+        f"base_output_directory=gs://{BUCKET_NAME}/maxtext-experiments"
+    )
+    workload_args_value_parts.append(
+        "jax_distributed_initialization_timeout=600"
+    )
+    if num_steps is not None:
+      workload_args_value_parts.append(f"steps={num_steps}")
+  else:  # Other frameworks (e.g., nemo)
+    if num_steps is not None:
+      workload_args_value_parts.append(f"trainer.max_steps={num_steps}")
+    # GCS command is typically added for non-maxtext frameworks
+    gcs_part_for_non_maxtext = (
+        f"--set volumes.gcsMounts[0].bucketName={BUCKET_NAME}"
+    )
+
+  if workload_args_value_parts:
+    cmd_parts.append(
+        f'--set workload.arguments[0]="{" ".join(workload_args_value_parts)}"'
+    )
+
+  if gcs_part_for_non_maxtext:
+    cmd_parts.append(gcs_part_for_non_maxtext)
+
+  if aotc:
+    cmd_parts.append("--set-string workload.aotc=true")
+
+  if additional_cmds:
+    # additional_cmds is expected to be a string of pre-formatted Helm arguments
+    cmd_parts.append(additional_cmds)
+
+  # Add job name and chart path
+  cmd_parts.append("$JOB_NAME")
+  cmd_parts.append(f"{recipe_repo_root}/src/helm-charts/{hypercomputer}/jobset")
+
+  # Join all parts with a single space and return as a single-element tuple
+  return (" ".join(cmd_parts),)
+
+
 def wait_for_jobs_cmds():
   wait_for_job = (
       "kubectl get pods --selector=job-name=$JOB_NAME --namespace=default",
@@ -339,6 +414,30 @@ def wait_for_jobs_cmds():
       "job/$JOB_NAME --namespace=default --timeout=100m",
   )
   return wait_for_job
+
+
+def wait_for_jobsets_cmds(timeout: str = "100m"):
+  """
+  Generates kubectl commands to wait for a JobSet to complete.
+
+  Args:
+    timeout: The duration to wait for the JobSet to complete (e.g., "100m").
+
+  Returns:
+    A tuple of command strings.
+  """
+  wait_for_jobset = (
+      'echo "Listing pods associated with JobSet $JOB_NAME:"',
+      "kubectl get pods --selector=jobset.sigs.k8s.io/jobset-name=$JOB_NAME --namespace=default",
+      'echo "Will wait for JobSet $JOB_NAME to finish..."',
+      # The condition for JobSet completion is typically 'Completed'.
+      f"kubectl wait --for=condition=Completed jobset/$JOB_NAME --namespace=default --timeout={timeout}",
+      'echo "JobSet $JOB_NAME finished. Describing JobSet:"',
+      "kubectl describe jobset $JOB_NAME --namespace=default",
+      'echo "Final pod status for JobSet $JOB_NAME:"',
+      "kubectl get pods --selector=jobset.sigs.k8s.io/jobset-name=$JOB_NAME --namespace=default",
+  )
+  return wait_for_jobset
 
 
 def internal_wait_for_jobs_cmds(timeout="100m"):
@@ -424,6 +523,39 @@ def copy_bucket_cmds_maxtext(tmpdir, bucket_name=BUCKET_NAME):
       'echo "LOG_FILE ${LOG_FILE}"',
       "gcloud storage cp $LOG_FILE $METRICS_FILE",
   )
+  return cmds
+
+
+def copy_bucket_cmds_workload(
+    recipe_repo_root: str, tmpdir: str, framework: str
+) -> Tuple[str, ...]:
+  gcs_location = ""
+  if framework == "maxtext":
+    gcs_location = f"gs://{BUCKET_NAME}/maxtext-experiments/"
+    cmds = (
+        f"METRICS_FILE={tmpdir}/tflog/metrics",
+        "export BUCKET_FOLDER=$(gcloud storage ls "
+        f"{gcs_location} | grep $JOB_NAME)",
+        'echo "BUCKET_FOLDER ${BUCKET_FOLDER}"',
+        "export COMPLETE_JOB_NAME=$(gcloud storage ls "
+        "${BUCKET_FOLDER}tensorboard/ | grep $JOB_NAME)",
+        'echo "COMPLETE_JOB_NAME ${COMPLETE_JOB_NAME}"',
+        "export LOG_FILE=$(gcloud storage ls "
+        "${COMPLETE_JOB_NAME} | grep events)",
+        'echo "LOG_FILE ${LOG_FILE}"',
+        "gcloud storage cp $LOG_FILE $METRICS_FILE",
+    )
+  else:
+    gcs_location = f"gs://{BUCKET_NAME}/nemo-experiments/"
+    cmds = (
+        "export COMPLETE_JOB_NAME=$(gcloud storage ls "
+        f"{gcs_location} | grep $JOB_NAME)",
+        'echo "COMPLETE_JOB_NAME ${COMPLETE_JOB_NAME}"',
+        f"cd {recipe_repo_root}/src/utils/training_metrics",
+        "gcloud storage cp ${COMPLETE_JOB_NAME}"
+        "dllogger/rank-0/dllogger.json .",
+    )
+
   return cmds
 
 
@@ -575,6 +707,37 @@ def extract_gpus(tmpdir, yaml_file):
     return None
 
   return gpus
+
+
+def extract_value_from_yaml(tmpdir, yaml_file, key="workload.image"):
+  """
+  Extract a value from a YAML file given a key using dot notation.
+
+  Args:
+      tmpdir (str): Temporary directory where the YAML file is located.
+      yaml_file (str): Name of the YAML file.
+      key (str): Key to extract, using dot notation (e.g., 'workload.image').
+
+  Returns:
+      The value associated with the key, or None if the key is not found or an error occurs.
+  """
+  try:
+    yaml_file_path = os.path.join(tmpdir, yaml_file)
+    with open(yaml_file_path, "r", encoding="utf-8") as file:
+      config = yaml.safe_load(file)
+
+    # Navigate through the dictionary using dot notation
+    keys = key.split(".")
+    value = config
+    for k in keys:
+      if isinstance(value, dict) and k in value:
+        value = value[k]
+      else:
+        return None  # Key not found
+    return value
+  except (FileNotFoundError, yaml.YAMLError) as e:
+    print(f"Error: {e}")
+    return None
 
 
 def extract_run_details(root, config_path):
@@ -1108,6 +1271,170 @@ def run_maxtext_workload(
         tokens_per_second=-1,
         writer_path=bq_writer_repo_root,
         topology="",
+        comment="Regression tests",
+        is_test=(False if composer_env.is_prod_env() else True),
+    )
+
+
+@task
+def run_workload(
+    hypercomputer: str,
+    model_id: str,
+    framework: str,
+    precision: str,
+    metrics_model_id: str,
+    workload_launcher: str,
+    num_gpus: Optional[int] = None,
+    num_steps: Optional[int] = None,
+    kueue_name: str = None,
+    config_model_name: str = None,
+    optimizer: Optional[str] = None,
+):
+  with tempfile.TemporaryDirectory() as tmpdir:
+    hook = SubprocessHook()
+
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                git_cookie_authdaemon()
+                + clone_recipes_gob()
+                + get_bq_writer_repo()
+            ),
+        ],
+        cwd=tmpdir,
+    )
+
+    recipe_repo_root = get_recipe_repo_path(tmpdir)
+    bq_writer_repo_root = get_bq_writer_path(tmpdir)
+    value_yaml_path = f"training/{hypercomputer}/{model_id}/{framework}-pretraining-gke/values.yaml"
+
+    workload_num_gpus = (
+        num_gpus
+        if num_gpus
+        else extract_gpus(recipe_repo_root, value_yaml_path)
+    )
+
+    if config_model_name:
+      config_yaml_path = f"src/frameworks/{hypercomputer}/{framework}-configs/{config_model_name}"
+    else:
+      config_yaml_path = f"src/frameworks/{hypercomputer}/{framework}-configs/{model_id}-{workload_num_gpus}gpus-{hypercomputer}-{precision}.yaml"
+
+    full_config_yaml_path = os.path.join(recipe_repo_root, config_yaml_path)
+    workload_launcher_path = f"src/launchers/{workload_launcher}"
+    full_workload_launcher_path = os.path.join(
+        recipe_repo_root, workload_launcher_path
+    )
+    if framework == "nemo":
+      (
+          global_batch_size,
+          optimizer,
+          seq_length,
+          num_steps,
+      ) = extract_run_details(recipe_repo_root, config_yaml_path)
+    else:
+      global_batch_size = (
+          extract_value_from_yaml(
+              recipe_repo_root, config_yaml_path, "per_device_batch_size"
+          )
+          * workload_num_gpus
+      )
+      seq_length = extract_value_from_yaml(
+          recipe_repo_root, config_yaml_path, "max_target_length"
+      )
+
+    accelerator_type = get_accelerator_type(hypercomputer)
+    print(
+        f"batch size: {global_batch_size}, num gpus: {workload_num_gpus}, seq length: {seq_length}, num steps: {num_steps}"
+    )
+
+    additional_cmds = ""
+
+    if num_gpus:
+      additional_cmds += f" --set workload.gpus={num_gpus} "
+
+    cluster, cluster_region = get_cluster(hypercomputer)
+    if framework == "nemo":
+      metrics_cmd = get_nemo_metrics_cmds(
+          global_batch_size,
+          workload_num_gpus,
+          precision,
+          metrics_model_id,
+          accelerator_type,
+          tmpdir,
+          two_node=False,
+      )
+    else:
+      metrics_cmd = ()
+
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                configure_project_and_cluster(cluster, cluster_region)
+                + get_gpu_recipe_cmd(
+                    hypercomputer, model_id, framework, recipe_repo_root
+                )
+                + install_helm_cmds()
+                + namespace_cmds()
+                + get_pre_workload_cmds(model_id, framework)
+                + helm_apply_cmds_workload(
+                    framework,
+                    hypercomputer,
+                    full_config_yaml_path,
+                    recipe_repo_root,
+                    workload_launcher=full_workload_launcher_path,
+                    kueue_name=kueue_name,
+                    additional_cmds=additional_cmds,
+                    num_steps=num_steps,
+                )
+                + wait_for_jobsets_cmds()
+                + copy_bucket_cmds_workload(
+                    recipe_repo_root=recipe_repo_root,
+                    tmpdir=tmpdir,
+                    framework=framework,
+                )
+                + metrics_cmd
+                + cleanup_cmds()
+            ),
+        ],
+        cwd=tmpdir,
+    )
+
+    assert result.exit_code == 0, f"Command failed with code {result.exit_code}"
+
+    if framework == "nemo":
+      average_step_time, mfu = get_nemo_metrics(tmpdir)
+    else:
+      log_location = os.path.join(tmpdir, "tflog/metrics")
+      mfu, average_step_time = calculate_maxtext_metrics(
+          log_location, hypercomputer
+      )
+      print(f"mfu: {mfu}")
+      print(f"step_time: {average_step_time}")
+
+    write_run(
+        model_id=model_id,
+        hardware_id=hypercomputer,
+        software_id=get_software_id(framework),
+        number_of_nodes=workload_num_gpus / 8,
+        number_of_chips=workload_num_gpus,
+        container_image_name=extract_value_from_yaml(
+            recipe_repo_root, value_yaml_path, "workload.image"
+        ),
+        global_batch_size=global_batch_size,
+        precision=precision,
+        optimizer=optimizer,
+        seq_length=seq_length,
+        median_step_time=average_step_time,
+        e2e_time=0,
+        number_of_steps=num_steps,
+        mfu=mfu,
+        tokens_per_second=global_batch_size * seq_length / average_step_time,
+        writer_path=bq_writer_repo_root,
+        topology="-",
         comment="Regression tests",
         is_test=(False if composer_env.is_prod_env() else True),
     )


### PR DESCRIPTION
# Description

This PR modify the regression test for the a3ultra pretraining recipes (gpu-recipes)[https://github.com/ai-hypercomputer/gpu-recipes/]. The changes to the recipes is a consolidation of helm charts agnostic to the framework to use (maxtext/nemo). 


# Tests
- Added test cases for all the helper functions added.
- Tested on internal test composer instance

**Instruction and/or command lines to reproduce your tests:** 
python -m unittest discover dags/map_reproducibility/tests -p "test_common_utils.py"

**List links for your tests (use go/shortn-gen for any internal link):** 
Some of the tests done:
- [Llama-3.1-70b Nemo](http://shortn/_GckCNOtMEO)
- [Llama-3.1-405b Maxtext](http://shortn/_088u1H7MMM)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.