### PR TITLE
Remove Llama 2 13B from v5e perf tests

### DIFF
--- a/dags/common/model_configs.py
+++ b/dags/common/model_configs.py
@@ -25,7 +25,6 @@ class MaxTextV5eModelConfigs(enum.Enum):
   DEFAULT_128B = "default_128b_v5e_256"
   GPT3_175B = "gpt_3_175b_v5e_256"
   LLAMA2_7B = "llama2_7b_v5e_256"
-  LLAMA2_13B = "llama2_13b_v5e_256"
   LLAMA2_70B = "llama2_70b_v5e_256"
 
 


### PR DESCRIPTION
# Description

Remove Llama 2 13B from v5e perf tests to reduce the number of tests running nightly.

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.