### PR TITLE
Added optional custom script post processing task

### DIFF
--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -18,6 +18,7 @@ import abc
 import dataclasses
 import datetime
 import shlex
+import os
 from dags.common.quarantined_tests import QuarantineTests
 from typing import Optional, Tuple, Union
 import airflow
@@ -135,6 +136,25 @@ def run_queued_resource_test(
           task_gcp_config,
           folder_location=output_location,
       )
+
+      # Pass all of the AIRFLOW_* environment variables to the SSH session for
+      # custom post processing script running on the TPU VM
+      airflow_env = dict(
+          [(x, os.environ[x]) for x in os.environ if x.startswith("AIRFLOW_")]
+      )
+      custom_post_processing = tpu.ssh_tpu.override(
+          task_id="custom_script", trigger_rule="all_done"
+      )(
+          queued_resource_name,
+          task_test_config.post_processing_script,
+          ssh_keys,
+          all_workers=False,
+          env={
+              **airflow_env,
+              "GCS_OUTPUT": output_location,
+          },
+      )
+      run_model >> custom_post_processing
 
     clean_up = tpu.delete_queued_resource.override(group_id="clean_up")(
         queued_resource_name

--- a/xlml/apis/test_config.py
+++ b/xlml/apis/test_config.py
@@ -197,6 +197,7 @@ class TpuVmTest(TestConfig[Tpu]):
   test_name: str
   set_up_cmds: Iterable[str]
   run_model_cmds: Iterable[str]
+  post_processing_cmds: Optional[str] = []
   num_slices: int = attrs.field(default=1, kw_only=True)
 
   @property
@@ -214,6 +215,10 @@ class TpuVmTest(TestConfig[Tpu]):
   @property
   def test_script(self) -> str:
     return '\n'.join(('set -xue', *self.run_model_cmds))
+
+  @property
+  def post_processing_script(self) -> Optional[str]:
+    return '\n'.join(('set -xue', *self.post_processing_cmds))
 
 
 @attrs.define


### PR DESCRIPTION
# Description

Added optional custom script post processing task in run_queued_resource_test()

- Optional bash script which will be run after run_model() task as part of the
  post_proces task group.
- custom script will run regardless of the result from run_model() allowing it to do 
  get metrics, logs, etc from failed test runs. 

# Tests

Tested existing DAGs that use the run_queued_resource_test() function

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.