### PR TITLE
Add Trillium tpu-recipes regression tests

### DIFF
--- a/dags/common/model_configs.py
+++ b/dags/common/model_configs.py
@@ -25,17 +25,14 @@ class MaxTextV5eModelConfigs(enum.Enum):
   DEFAULT_128B = "default_128b_v5e_256"
   GPT3_175B = "gpt_3_175b_v5e_256"
   LLAMA2_7B = "llama2_7b_v5e_256"
-  LLAMA2_13B = "llama2_13b_v5e_256"
   LLAMA2_70B = "llama2_70b_v5e_256"
 
 
 class MaxTextTrilliumModelConfigs(enum.Enum):
   # Refers to model configs in https://github.com/AI-Hypercomputer/maxtext/blob/main/benchmarks/maxtext_trillium_model_configs.py
   GPT3_175B = "gpt_3_175b"
-  LLAMA2_70B_4096 = "llama2_70b_4096_synthetic"
   LLAMA3_1_8B_8192 = "llama3_1_8b_8192"
   LLAMA3_1_70B_8192 = "llama3_1_70b_8192"
-  LLAMA3_1_70B_129024 = "llama3_1_70b_129024"
   LLAMA3_1_405B_8192 = "llama3_1_405b_8192_fsdp_dcn"
   MIXTRAL_8X7B_DROPLESS = "mixtral_8x7b_dropless"
   MIXTRAL_8X7B_DROPPED = "mixtral_8x7b_dropped"

--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -374,3 +374,6 @@ class DockerImage(enum.Enum):
   MICROBENCH_NIGHTLY = (
       "gcr.io/tpu-prod-env-one-vm/microbenchmarks_runner:latest"
   )
+  MAXTEXT_JAX_052_RECIPES_012 = (
+      "gcr.io/tpu-prod-env-multipod/maxtext_tpu_recipes:jax0.5.2-recipes0.1.2"
+  )

--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_inference_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_inference_benchmarking_dags.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DAGs to run Aotc inference reproducibility benchmarks."""
+
+import datetime
+import os
+
+from airflow import models
+from dags import composer_env
+from dags.map_reproducibility.internal_runs.dag_configs_inference import DAG_CONFIGS_INFERENCE_MEGA
+from dags.map_reproducibility.utils.internal_aotc_inference_workload import run_internal_aotc_inference_workload
+
+
+# Configuration parameters
+TEST_RUN = False
+TURN_ON_SCHEDULE = True if composer_env.is_prod_env() else False
+
+# Pull the MaxText container from NVIDIA
+IMAGE = "ghcr.io/nvidia/jax:maxtext"
+
+# Define common tags
+DAG_TAGS = [
+    "reproducibility",
+    "experimental",
+    "xlml",
+    "v1.13",
+    "internal",
+    "regressiontests",
+    "a3mega",
+    "inference",
+]
+
+# Create DAGs for each configuration
+for config_path, config_info in DAG_CONFIGS_INFERENCE_MEGA.items():
+  # Extract config name for the DAG ID
+  config_name = os.path.basename(config_path).replace(".yaml", "")
+  nightly_schedule = (
+      config_info["nightly_schedule"] if TURN_ON_SCHEDULE else None
+  )
+  release_schedule = (
+      config_info["release_schedule"] if TURN_ON_SCHEDULE else None
+  )
+  timeout = config_info["timeout_minutes"]
+
+  # Create DAG for nightly build
+  with models.DAG(
+      dag_id=f"new_internal_inference_{config_name}",
+      schedule=nightly_schedule,
+      tags=DAG_TAGS,
+      start_date=datetime.datetime(2025, 4, 17),
+      catchup=False,
+  ) as dag:
+    run_internal_aotc_inference_workload(
+        relative_config_yaml_path=config_path,
+        test_run=TEST_RUN,
+        timeout=timeout,
+        image_version=IMAGE,
+    )

--- a/dags/map_reproducibility/internal_runs/dag_configs_inference.py
+++ b/dags/map_reproducibility/internal_runs/dag_configs_inference.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dags.map_reproducibility.utils.constants import Schedule
+
+
+DAG_CONFIGS_INFERENCE_MEGA = {
+    "recipes/inference/a3mega/a3mega_llama2-70b_8gpus_bf16_maxtext.yaml": {
+        "timeout_minutes": 40,
+        "backfill_group_nightly": 1,
+        "backfill_group_release": 1,
+        "nightly_schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+        "release_schedule": Schedule.WEEKDAY_PDT_12AM_EXCEPT_THURSDAY,
+    },
+}

--- a/dags/map_reproducibility/utils/common_utils_inference.py
+++ b/dags/map_reproducibility/utils/common_utils_inference.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jsonlines, json
+from google.cloud.bigquery import Client, LoadJobConfig, SourceFormat, SchemaField
+
+PROJECT = "supercomputer-testing"
+BUCKET_NAME = "regression-testing-xlml"
+
+
+def helm_apply_cmds_internal_run_inference(
+    framework: str,
+    hypercomputer: str,
+    config_file,
+    recipe_repo_root,
+    values_file_path,
+    docker_image,
+    aotc: bool = False,
+    cluster_name: str = "a3plus-benchmark",
+    kueue_name: str = "a3-ultra",
+    additional_cmds: str = "",
+    test_run=False,
+):
+  gcs_cmd = ""
+  if framework == "maxtext":
+    gcs_cmd += f" --set volumes.gcsMounts[0].bucketName={BUCKET_NAME} "
+
+  if hypercomputer == "a3ultra":
+    if framework != "maxtext":
+      gcs_cmd += f" --set queue={kueue_name} "
+  else:
+    gcs_cmd += f" --set workload.gcsBucketForDataCataPath={BUCKET_NAME} "
+
+  cluster_cmd = ""
+  if framework == "nemo" and hypercomputer == "a3ultra":
+    cluster_cmd = f" --set clusterName={cluster_name} "
+
+  run_name_cmd = ""
+  if framework == "maxtext":
+    run_name_cmd = " --set workload.run_name=$JOB_NAME "
+
+  set_aotc = ""
+  if aotc:
+    set_aotc = " --set-string workload.aotc=true "
+
+  if test_run:
+    helm_template_path = f"/home/airflow/gcs/dags/dags/map_reproducibility/helm-charts/{hypercomputer}/{framework}-inference"
+  else:
+    helm_template_path = f"{recipe_repo_root}/src/helm-charts/{hypercomputer}/{framework}-inference"
+
+  print(f"helm_template_path is {helm_template_path}")
+
+  helm_cmds = (
+      f" helm install -f {values_file_path} "
+      "--namespace default "
+      "--set namespace=default"
+      f" --set-file {framework}_config"
+      f"={config_file}"
+      " --set workload.image"
+      f"={docker_image} "
+      f"{cluster_cmd} {run_name_cmd} {gcs_cmd} {set_aotc}"
+      f"{additional_cmds}"
+      f" $JOB_NAME {helm_template_path}",
+  )
+  print("*******helm cmd is*******")
+  print(helm_cmds)
+  return helm_cmds
+
+
+def get_gcs_output_location(bucket_name=BUCKET_NAME):
+  return f"gs://{bucket_name}/maxtext-inference/output"
+
+
+def copy_inference_output_cmds(
+    tmpdir, bucket_name=BUCKET_NAME, project=PROJECT
+):
+  gcs_location = f"gs://{bucket_name}/maxtext-inference/"
+
+  cmds = (
+      f"OUTPUT_FILE={tmpdir}/output.txt",
+      f"export LOG_FILE=$(gcloud storage ls {gcs_location} --project={project}  | grep microbenchmark | sort -k 2 -r | head -n 1)",
+      'echo "LOG_FILE ${LOG_FILE}"',
+      "gcloud storage cp $LOG_FILE $OUTPUT_FILE",
+  )
+  return cmds
+
+
+def extract_autoregressive_write_to_jsonl(job_name, input_file, output_file):
+  """
+    Reads a JSON file, extracts the 'autoregressive' data, and writes them to a JSONL file.
+
+  Args:
+      input_file (str): Path to the input text file.
+      output_file (str): Path to the output JSONL file.
+  """
+  try:
+    with open(input_file, "r") as f:
+      data = json.load(f)
+    autoregressive_data = data["autoregressive"]
+    autoregressive_data["job_name"] = job_name
+    with jsonlines.open(output_file, "w") as writter:
+      writter.write(autoregressive_data)
+      print(f"Extracted results written to {output_file}")
+  except FileNotFoundError:
+    print(f"Error: Input file '{input_file}' not found.")
+  except Exception as e:
+    print(f"An error occurred during extract to jsonl: {e}")
+
+
+def write_jsonl_to_bigquery(
+    jsonl_file_path: str,
+    project_id: str = PROJECT,
+    dataset_id: str = "maxtext_inference",
+    table_id: str = "microbenchmark_llama2_70b",
+):
+  try:
+    client = Client(project=project_id)
+    dataset_ref = client.dataset(dataset_id)
+    table_ref = dataset_ref.table(table_id)
+    schema = [
+        SchemaField("job_name", "STRING", mode="REQUIRED"),
+        SchemaField("step_in_ms", "FLOAT", mode="NULLABLE"),
+        SchemaField("step_in_ms_per_seq", "FLOAT", mode="NULLABLE"),
+        SchemaField("global_batch_size", "FLOAT", mode="NULLABLE"),
+        SchemaField(
+            "total_throughput_tokens_per_second", "FLOAT", mode="NULLABLE"
+        ),
+        SchemaField("bw_per_device_GB_per_second", "FLOAT", mode="NULLABLE"),
+    ]
+    job_config = LoadJobConfig(
+        source_format=SourceFormat.NEWLINE_DELIMITED_JSON,
+        schema=schema,
+    )
+    print(f"Uploading {jsonl_file_path} to {table_ref.path}.")
+    with open(jsonl_file_path, "rb") as source_file:
+      load_job = client.load_table_from_file(
+          source_file, table_ref, job_config=job_config
+      )
+    load_job.result()
+    print(
+        f"Successfully loaded data from '{jsonl_file_path}' to '{table_ref.path}'."
+    )
+  except Exception as e:
+    print(f"An unexpected error occurred during uploading to bq: {e}")
+    return False

--- a/dags/map_reproducibility/utils/internal_aotc_inference_workload.py
+++ b/dags/map_reproducibility/utils/internal_aotc_inference_workload.py
@@ -1,0 +1,169 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Workload functions for AOTC inference reproducibility benchmarks."""
+
+import os
+import tempfile
+
+from airflow.decorators import task
+from airflow.hooks.subprocess import SubprocessHook
+from google.cloud import storage
+from dags.map_reproducibility.utils.common_utils import configure_project_and_cluster
+from dags.map_reproducibility.utils.common_utils import install_helm_cmds
+from dags.map_reproducibility.utils.common_utils import namespace_cmds
+from dags.map_reproducibility.utils.common_utils import internal_wait_for_jobs_cmds
+from dags.map_reproducibility.utils.common_utils import cleanup_cmds
+from dags.map_reproducibility.utils.common_utils import git_cookie_authdaemon
+from dags.map_reproducibility.utils.common_utils import clone_recipes_gob, clone_internal_recipes_gob
+from dags.map_reproducibility.utils.common_utils import get_internal_pre_workload_cmds, get_internal_pre_workload_job_name
+from dags.map_reproducibility.utils.common_utils import get_gpu_recipe_cmd
+from dags.map_reproducibility.utils.common_utils import get_recipe_repo_path, get_internal_recipe_repo_path
+from dags.map_reproducibility.utils.common_utils import get_cluster
+from dags.map_reproducibility.utils.common_utils import parse_internal_config_filename
+from dags.map_reproducibility.utils.common_utils_inference import helm_apply_cmds_internal_run_inference, extract_autoregressive_write_to_jsonl, copy_inference_output_cmds, write_jsonl_to_bigquery, get_gcs_output_location, BUCKET_NAME
+from dags.map_reproducibility.utils.common_utils import parse_internal_config_content
+from dags.map_reproducibility.utils.constants import KUEUE_NAME
+
+
+@task
+def run_internal_aotc_inference_workload(
+    relative_config_yaml_path,
+    test_run=False,
+    timeout=None,
+    image_version=None,
+):
+  """Runs the AOTC inference workload benchmark.
+
+  Args:
+    relative_config_yaml_path: Path to the config YAML relative to the repo root
+  """
+  # Parse config from filename
+  config_yaml_name = relative_config_yaml_path.rsplit("/", maxsplit=1)[
+      -1
+  ].replace(".yaml", "")
+  config = parse_internal_config_filename(config_yaml_name)
+
+  # Get derived configuration
+  cluster, cluster_region = get_cluster(config.HYPERCOMPUTER)
+  docker_image = image_version
+  values_name = f"{config.HYPERCOMPUTER}_{config.FRAMEWORK}_values"
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    hook = SubprocessHook()
+
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                git_cookie_authdaemon()
+                + clone_recipes_gob()
+                + (() if test_run else clone_internal_recipes_gob())
+            ),
+        ],
+        cwd=tmpdir,
+    )
+
+    recipe_repo_root = get_recipe_repo_path(tmpdir)
+
+    # Update paths now that we have the repo paths
+    internal_recipe_repo_root = (
+        "/home/airflow/gcs/dags/dags/map_reproducibility"
+    )
+    if not test_run:
+      internal_recipe_repo_root = get_internal_recipe_repo_path(tmpdir)
+    values_file_path = f"{internal_recipe_repo_root}/values/{values_name}.yaml"
+    model_specific_values_file_path = (
+        f"{internal_recipe_repo_root}/values/{config_yaml_name}_values.yaml"
+    )
+    if os.path.exists(model_specific_values_file_path):
+      # Use model-specific values file
+      values_file_path = model_specific_values_file_path
+      print(
+          f"Using model-specific values file: {model_specific_values_file_path}"
+      )
+    else:
+      print(
+          f"Model-specific values file not found, using general values file: {values_file_path}"
+      )
+
+    full_config_yaml_path = (
+        f"{internal_recipe_repo_root}/{relative_config_yaml_path}"
+    )
+    print(f"values_file_path is {values_file_path}")
+    print(f"full_config_yaml_path is {full_config_yaml_path}")
+
+    # Parse the config content now that we have the file path
+    config = parse_internal_config_content(full_config_yaml_path, config=config)
+    job_name = get_internal_pre_workload_job_name(
+        config.MODEL_ID, config.FRAMEWORK
+    )
+
+    container_timeout = int(timeout) - 4
+    print(f"container timeout is {container_timeout}")
+    result = hook.run_command(
+        [
+            "bash",
+            "-c",
+            ";".join(
+                configure_project_and_cluster(cluster, cluster_region)
+                + get_gpu_recipe_cmd(
+                    config.HYPERCOMPUTER,
+                    config.MODEL_ID,
+                    config.FRAMEWORK,
+                    recipe_repo_root,
+                )
+                + install_helm_cmds()
+                + namespace_cmds()
+                + get_internal_pre_workload_cmds(job_name=job_name)
+                + helm_apply_cmds_internal_run_inference(
+                    config.FRAMEWORK,
+                    config.HYPERCOMPUTER,
+                    full_config_yaml_path,
+                    internal_recipe_repo_root,
+                    values_file_path,
+                    docker_image,
+                    cluster_name=cluster,
+                    kueue_name=KUEUE_NAME,
+                    additional_cmds=f" --set workload.gpus={config.NUM_GPUS} ",
+                    test_run=test_run,
+                )
+                + internal_wait_for_jobs_cmds(timeout=container_timeout)
+                + copy_inference_output_cmds(tmpdir)
+                + cleanup_cmds()
+            ),
+        ],
+        cwd=tmpdir,
+    )
+    assert result.exit_code == 0, f"Command failed with code {result.exit_code}"
+
+    output_location = os.path.join(tmpdir, "output.txt")
+    jsonl_location = os.path.join(tmpdir, "output.jsonl")
+    extract_autoregressive_write_to_jsonl(
+        job_name, output_location, jsonl_location
+    )
+    write_jsonl_to_bigquery(jsonl_location)
+    gcs_output_location = get_gcs_output_location()
+    print(f"GCS output location is {gcs_output_location}")
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(BUCKET_NAME)
+    destination_file_name = f"{job_name}_results.jsonl"
+    destination_blob_name = os.path.join(
+        gcs_output_location, destination_file_name
+    )
+    blob = bucket.blob(destination_blob_name)
+    blob.upload_from_filename(jsonl_location)
+    print(f"File {jsonl_location} uploaded to {gcs_output_location}.")

--- a/dags/multipod/configs/common.py
+++ b/dags/multipod/configs/common.py
@@ -24,6 +24,7 @@ class SetupMode(enum.Enum):
   STABLE = "stable"
   NIGHTLY = "nightly"
   JAX_STABLE_STACK = "jax_stable_stack"
+  TPU_RECIPES = "tpu_recipes"
 
 
 class Platform(enum.Enum):

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -26,17 +26,18 @@ from dags.multipod.configs import maxtext_sweep_gke_config
 from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config
 
-# Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
-SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+# Run once a day at 3 am UTC (7 pm PST / 8 pm PDT)
+CONIFGS_SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
+    (SetupMode.TPU_RECIPES, DockerImage.MAXTEXT_JAX_052_RECIPES_012),
 ]
 BASE_OUTPUT_DIRECTORY = "gs://runner-maxtext-logs"
 
 with models.DAG(
     dag_id="maxtext_trillium_configs_perf",
-    schedule=SCHEDULED_TIME,
+    schedule=CONIFGS_SCHEDULED_TIME,
     tags=[
         "multipod_team",
         "maxtext",
@@ -50,8 +51,12 @@ with models.DAG(
   quarantine_task_group = TaskGroup(
       group_id="Quarantine", dag=dag, prefix_group_id=False
   )
+  all_tests = []
   for mode, image in DOCKER_IMAGES:
     for model in MaxTextTrilliumModelConfigs:
+      # No tpu-recipe for DeepSeek v3
+      if model == MaxTextTrilliumModelConfigs.DEEPSEEK_V3_EP16 and image == DockerImage.MAXTEXT_JAX_052_RECIPES_012:
+        continue
       base_run_model_cmds = [
           f"python3 -m benchmarks.benchmark_runner on-device --base_output_directory={BASE_OUTPUT_DIRECTORY} --model_name={model.value} --libtpu_type=maxtext-docker --num_steps=15",
       ]
@@ -77,15 +82,13 @@ with models.DAG(
               sweep_params={},
           )
       )
+      all_tests += maxtext_sweep_gke_test
 
-      chain_num = 4
-      prev = maxtext_sweep_gke_test[0].run_with_name_gen_and_quarantine(
-          quarantine_task_group
-      )
-      for i in range(1, len(maxtext_sweep_gke_test)):
-        curr = maxtext_sweep_gke_test[i].run_with_name_gen_and_quarantine(
-            quarantine_task_group
-        )
-        if i % chain_num != 0:
-          prev >> curr
-        prev = curr
+  # Add dependencies between the tests so they are not all launched at once
+  chain_num = 4
+  prev = all_tests[0].run_with_name_gen_and_quarantine(quarantine_task_group)
+  for i in range(1, len(all_tests)):
+    curr = all_tests[i].run_with_name_gen_and_quarantine(quarantine_task_group)
+    if i % chain_num != 0:
+      prev >> curr
+    prev = curr


### PR DESCRIPTION
# Description

- add `maxtext_tpu_recipes` docker image to test Trillium tpu recipes
- remove some models to reduce the number of tests
- add maxtext storage tpu-recipe config
- add support for running xpk workloads with attached storage https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#running-workloads-with-storage

# Tests

Ran 2 tpu-recipe models: http://screen/nHYs6JK8rmPfSJZ

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.