### PR TITLE
Add DAGs/E2E checkpoint and forward logit tests for Llama4

### DIFF
--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -96,6 +96,18 @@ with models.DAG(
               "time_out_in_min": 90,
           },
       ],
+      "llama4": [
+          {
+              "script_name": "tpu/llama4/1_test_llama4",
+              "cluster": XpkClusters.CPU_M1_MEGAMEM_96_CLUSTER,
+              "time_out_in_min": 240,
+          },
+          {
+              "script_name": "tpu/llama4/2_test_llama4",
+              "cluster": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
+              "time_out_in_min": 90,
+          },
+      ],
   }
 
   def convert_checkpoint_and_run_training(


### PR DESCRIPTION
# Description

In this PR, I add a new DAG to test Llama4 checkpoint conversion (on a CPU machine) and logits (on a v6e-256 pod).  I only test Scout for now, but the logic is there for Maverick if we want to enable that later on.

The corresponding MaxText PR can be found [here](https://github.com/AI-Hypercomputer/maxtext/pull/1715)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.