### PR TITLE
add profile extraction

### DIFF
--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -1,0 +1,130 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run end-to-end MoE tests."""
+
+
+import datetime
+from airflow import models
+from airflow.utils.task_group import TaskGroup
+from dags import composer_env
+from dags.common.quarantined_tests import QuarantineTests
+from dags.common import test_owner
+from dags.common.vm_resource import XpkClusters, DockerImage
+from dags.multipod.configs import gke_config
+from xlml.utils import name_format
+from xlml.apis import metric_config
+import os
+
+
+# Run once a day at 1 am UTC (5 pm PST)
+SCHEDULED_TIME = "0 1 * * *" if composer_env.is_prod_env() else None
+
+
+docker_image = {
+    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-09",
+}
+
+test_models_tpu = {
+    "mixtral-8x7b_pretraining-megablox_config-true_upload-one": {
+        "cluster": XpkClusters.TPU_V4_128_CLUSTER,
+        "time_out_in_min": 60,
+        "base_output_directory": "gs://runner-maxtext-logs",
+        "train_command": [
+            "python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+            " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+        ],
+    },
+    "mixtral-8x7b_pretraining-megablox_config-false": {
+        "cluster": XpkClusters.TPU_V4_128_CLUSTER,
+        "time_out_in_min": 60,
+        "base_output_directory": "gs://runner-maxtext-logs",
+        "train_command": [
+            "python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+            " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+        ],
+    },
+    "mixtral-8x7b_pretraining-megablox_config-true_upload-all": {
+        "cluster": XpkClusters.TPU_V4_128_CLUSTER,
+        "time_out_in_min": 60,
+        "base_output_directory": "gs://runner-maxtext-logs",
+        "train_command": [
+            "python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+            " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 upload_all_profiler_results=True",
+        ],
+    },
+    "mixtral-8x7b_pretraining-megablox_config-true_upload-none": {
+        "cluster": XpkClusters.TPU_V4_128_CLUSTER,
+        "time_out_in_min": 60,
+        "base_output_directory": "gs://runner-maxtext-logs",
+        "train_command": [
+            "python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+            " steps=10",
+        ],
+    },
+}
+
+
+with models.DAG(
+    dag_id="maxtext_profile_namegen_example_dag",
+    schedule=SCHEDULED_TIME,
+    tags=[
+        "sparsity_diffusion_devx",
+        "multipod_team",
+        "maxtext",
+        "tpu",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
+    start_date=datetime.datetime(2024, 11, 14),
+    catchup=False,
+) as dag:
+  tests = []
+  for run_name, test_scripts_details in test_models_tpu.items():
+    for image in docker_image.keys():
+      base_output_directory = test_scripts_details["base_output_directory"]
+      test_scripts_details["train_command"] = [
+          f"export BASE_OUTPUT_PATH={base_output_directory}"
+      ] + test_scripts_details["train_command"]
+
+      # file_location: pass in base_output_directory, will be altered in `run_with_run_name_generation`
+      job_metric_config = metric_config.MetricConfig()
+      job_metric_config.tensorboard_summary = metric_config.SummaryConfig(
+          file_location=base_output_directory,  # init location
+          aggregation_strategy=metric_config.AggregationStrategy.MEDIAN,
+          use_regex_file_location=True,
+      )
+      # turn off for config-false testing
+      if run_name != "mixtral-8x7b_pretraining-megablox_config-false":
+        job_metric_config.profile = metric_config.ProfileConfig(
+            file_location=base_output_directory,  # init location
+        )
+
+      tpu_task = gke_config.get_gke_config(
+          time_out_in_min=test_scripts_details["time_out_in_min"],
+          test_name=f"maxtext_{image}_{run_name}",
+          run_model_cmds=test_scripts_details["train_command"],
+          docker_image=docker_image[image],
+          test_owner=test_owner.RAN_R,
+          cluster=test_scripts_details["cluster"],
+          user_specified_job_metric_config=job_metric_config,
+      ).run_with_run_name_generation(run_name_env="RUN_NAME")
+
+      tests.append(tpu_task)
+
+  for test in tests:
+    test
+  # for i in range(len(tests) - 1):
+  #   tests[i] >> tests[i + 1]

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -1,0 +1,170 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to run end-to-end MoE tests."""
+
+
+import datetime
+from airflow import models
+from airflow.utils.task_group import TaskGroup
+from dags import composer_env
+from dags.common.quarantined_tests import QuarantineTests
+from dags.common import test_owner
+from dags.common.vm_resource import XpkClusters, DockerImage, Project
+from dags.multipod.configs import gke_config
+from xlml.utils import name_format
+from xlml.apis import metric_config
+import os
+from dags.multipod.configs import maxtext_sweep_gke_config
+
+
+# Run once a day at 1 am UTC (5 pm PST)
+SCHEDULED_TIME = "0 1 * * *" if composer_env.is_prod_env() else None
+
+
+def dict_to_arg(param_dict):
+  cmd = [f"{param}={value}" for param, value in param_dict.items()]
+  return " ".join(cmd)
+
+
+docker_image = {
+    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-09",
+}
+
+test_models_tpu = {
+    "mixtral_8x7b_dropped": {
+        "time_out_in_min": 60,
+        "cluster": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
+        "base_output_directory": "gs://runner-maxtext-logs",
+        "train_command": [
+            "python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} model_name=mixtral-8x7b "
+            # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            + dict_to_arg({
+                "per_device_batch_size": 12,
+                "ici_fsdp_parallelism": -1,
+                "max_target_length": 4096,
+                "remat_policy": "custom",
+                "decoder_layer_input": "offload",
+                "out_proj": "offload",
+                "query_proj": "offload",
+                "key_proj": "offload",
+                "value_proj": "offload",
+                "attention": "flash",
+                "gcs_metrics": True,
+                "use_iota_embed": True,
+                "dataset_path": "gs://max-datasets-rogue",
+                "dataset_type": "synthetic",
+                "reuse_example_batch": 1,
+                "enable_checkpointing": False,
+                "sa_block_q": 2048,
+                "sa_block_q_dkv": 2048,
+                "sa_block_q_dq": 2048,
+                "megablox": False,
+                "sparse_matmul": False,
+                "capacity_factor": 1.25,
+                "tokenizer_path": "assets/tokenizer.mistral-v1",
+            })
+        ],
+    },
+    "mixtral_8x7b_dropless": {
+        "time_out_in_min": 60,
+        "cluster": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
+        "base_output_directory": "gs://runner-maxtext-logs",
+        "train_command": [
+            "python3 -m MaxText.train MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} model_name=mixtral-8x7b "
+            # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            + dict_to_arg({
+                "per_device_batch_size": 12,
+                "ici_fsdp_parallelism": -1,
+                "max_target_length": 4096,
+                "remat_policy": "full",
+                "attention": "flash",
+                "gcs_metrics": True,
+                "use_iota_embed": True,
+                "dataset_path": "gs://max-datasets-rogue",
+                "dataset_type": "synthetic",
+                "reuse_example_batch": 1,
+                "enable_checkpointing": False,
+                "sa_block_q": 2048,
+                "sa_block_q_dkv": 2048,
+                "sa_block_q_dq": 2048,
+                "megablox": True,
+                "sparse_matmul": True,
+            })
+        ],
+    },
+}
+
+
+with models.DAG(
+    dag_id="maxtext_profile_sweep_example_dag",
+    schedule=SCHEDULED_TIME,
+    tags=[
+        "sparsity_diffusion_devx",
+        "multipod_team",
+        "maxtext",
+        "tpu",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
+    start_date=datetime.datetime(2024, 11, 14),
+    catchup=False,
+) as dag:
+  quarantine_task_group = TaskGroup(
+      group_id="Quarantine", dag=dag, prefix_group_id=False
+  )
+  # unchained_tests = []
+  for run_name, test_scripts_details in test_models_tpu.items():
+    for image in docker_image.keys():
+      base_output_directory = test_scripts_details["base_output_directory"]
+      test_scripts_details["train_command"] = [
+          f"export BASE_OUTPUT_PATH={base_output_directory}"
+      ] + test_scripts_details["train_command"]
+
+      # sweep num_slices and other training params
+      # automatically generate run_name and tensorboard/profile location for extraction
+      num_slices = [1]
+      sweep_params = {}
+      maxtext_sweep_gke_test = (
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              test_owner=test_owner.RAN_R,
+              dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              dataset_name=metric_config.DatasetOption.XLML_DATASET,
+              cluster=test_scripts_details["cluster"],
+              time_out_in_min=test_scripts_details["time_out_in_min"],
+              base_output_directory=base_output_directory,
+              num_slices=num_slices,
+              docker_image=docker_image[image],
+              run_name_prefix=f"maxtext_{image}_{run_name}",
+              base_run_model_cmds=test_scripts_details["train_command"],
+              sweep_params=sweep_params,
+              enable_profile_config=True,  # add flag to enable profiler
+          )
+      )
+
+      chain_num = 4
+      prev = maxtext_sweep_gke_test[0].run_with_name_gen_and_quarantine(
+          quarantine_task_group
+      )
+      for i in range(1, len(maxtext_sweep_gke_test)):
+        curr = maxtext_sweep_gke_test[i].run_with_name_gen_and_quarantine(
+            quarantine_task_group
+        )
+        if i % chain_num != 0:
+          prev >> curr
+        prev = curr

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -53,6 +53,7 @@ def get_maxtext_sweep_gke_config(
     metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
     dataset_project: str = None,
     composer_project: str = None,
+    enable_profile_config: bool = False,
 ) -> List[task.XpkTask]:
   if not dataset_project:
     dataset_project = cluster.project
@@ -116,6 +117,10 @@ def get_maxtext_sweep_gke_config(
             use_regex_file_location=True,
         ),
     )
+    if enable_profile_config:
+      job_metric_config.profile = metric_config.ProfileConfig(
+          file_location=base_output_directory,
+      )
 
     xpk_task = task.XpkTask(
         task_test_config=job_test_config,

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -47,7 +47,7 @@ class JSONLinesConfig:
   """A class to set up JSON Lines config.
 
   Attributes:
-    file_location: The locatioin of the file in GCS. When
+    file_location: The location of the file in GCS. When
       `use_runtime_generated_gcs_folder` flag is ture, use relative path.
   """
 
@@ -59,7 +59,7 @@ class SummaryConfig:
   """A class to set up TensorBoard summary config.
 
   Attributes:
-    file_location: The locatioin of the file in GCS. When
+    file_location: The location of the file in GCS. When
       `use_runtime_generated_gcs_folder` flag is ture, use relative path.
     aggregation_strategy: The aggregation strategy for metrics.
     include_tag_patterns: The matching patterns of tags that wil be included.
@@ -83,13 +83,14 @@ class ProfileConfig:
   """A class to set up profile config.
 
   Attributes:
-    file_locations: The locatioin of the file in GCS. When
+    file_locations: The location of the file in GCS. When
       `use_runtime_generated_gcs_folder` flag is ture, use relative path.
       If JSON_LINES format type is used for metrics and dimensions, please
       ensure the order of profiles match with test runs in JSON Lines.
   """
 
-  file_locations: List[str]
+  file_location: str
+  metrics: Optional[dict] = None
 
 
 @dataclasses.dataclass

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -263,13 +263,32 @@ class XpkTask(BaseTask):
           tb_file_location
       )
 
-      (
-          run_name
-          >> tb_file_location
-          >> self.run_model(use_pathways=use_pathways, xpk_branch=xpk_branch)
-          >> self.post_process()
-      )
+      # update profile file location
+      if self.task_metric_config.profile:
+        profile_file_location = name_format.generate_profile_file_location(
+            run_name, self.task_metric_config.profile.file_location
+        )
+        self.task_metric_config.profile.file_location = profile_file_location
 
+        run_model, gcs_path = self.run_model(
+            use_pathways=use_pathways, xpk_branch=xpk_branch
+        )
+        (
+            run_name
+            >> (tb_file_location, profile_file_location)
+            >> run_model
+            >> self.post_process(gcs_path)
+        )
+      else:
+        run_model, gcs_path = self.run_model(
+            use_pathways=use_pathways, xpk_branch=xpk_branch
+        )
+        (
+            run_name
+            >> tb_file_location
+            >> run_model
+            >> self.post_process(gcs_path)
+        )
     return group
 
   def run_model(
@@ -384,13 +403,28 @@ class XpkTask(BaseTask):
     """
     with TaskGroup(group_id="post_process") as group:
       process_id = metric.generate_process_id.override(retries=0)()
-      metric.process_metrics.override(retries=0)(
+      post_process_metrics = metric.process_metrics.override(retries=0)(
           process_id,
           self.task_test_config,
           self.task_metric_config,
           self.task_gcp_config,
           folder_location=result_location,
       )
+
+      if self.task_metric_config and self.task_metric_config.profile:
+        profile_tmp_location = metric.download_profile(
+            self.task_metric_config.profile.file_location
+        )
+        self.task_metric_config.profile.metrics = metric.xplane_to_metrics(
+            profile_tmp_location
+        )
+        (
+            (process_id, profile_tmp_location)
+            >> self.task_metric_config.profile.metrics
+            >> post_process_metrics
+        )
+      else:
+        process_id >> post_process_metrics
 
       return group
 

--- a/xlml/utils/name_format.py
+++ b/xlml/utils/name_format.py
@@ -65,6 +65,19 @@ def generate_tb_file_location(
 
 
 @task
+def generate_profile_file_location(
+    run_name: str, base_output_directory: str
+) -> str:
+  return os.path.join(
+      base_output_directory,
+      run_name,
+      "tensorboard",
+      "plugins",
+      "profile",
+  )
+
+
+@task
 def generate_gcs_folder_location(subfolder: str, benchmark_id: str) -> str:
   """Generates folder location in GCS.
 


### PR DESCRIPTION
# Description

## Change

main:
- metrics.py: add profile extraction to `process_metrics`
- tasks.py: modify task flow in `post_process `

to accommodate run_name generation:
- name_format.py: add task for generating profile extraction location
- tasks.py: add profile location generation in `run_with_run_name_generation`

to accomodate sweep run:
- maxtext_sweep_gke_config.py: enable optional profile config 

add two example dags
- maxtext_profile_namegen_example_dag.py
- maxtext_profile_sweep_example_dag.py

## Use

Main use case: each node is a training command, with `profiler=xplane`

To enable extraction: pass profile_config to metric_config 

profile_config.file_location: 
  - We want it to be unique, so the file extractor can correctly identity the profile with regex. 
  - To achieve uniqueness, we use `run_with_run_name_generation`, which generates run_name with timestamp, and then generate profile file_location.

can find extract metric in the log of `profile_to_metrics`
https://screenshot.googleplex.com/597TiKfEhzVck5L
metrics are
`{'device_type': 'TPU v6 Lite', 'device_core_count': 4, 'Average Tensor Core Step Time (ms)': 16662.5, 'TPU FLOPS Utilization (%): exclude_idle': 44.7, 'HBM Bandwidth Utilization (%): exclude_idle': 19.93, 'Peak memory allocation (MiB): jit_train_step, HBM': 30425.91, 'Peak memory allocation (MiB): jit_train_step, host': 43008.0}`

can find original gcs profile location in the log of `download_profile`
https://screenshot.googleplex.com/69JzkZtaAmbNaJD

the metrics are uploaded to bigquery in `process_metrics`, along with other metrics (profile-specific metrics has name prefix `xprof/`)
https://screenshot.googleplex.com/86rb97SmpouG8o2


### Metric Correpondonce in Xprof

Optionally, you can download the original profile to verify correctness, e.g., 
```
gcloud storage cp gs://runner-maxtext-logs/maxtext_stable_mixtral_8x7b_dropped-0-v6e-256-2025-05-16-21-53-45/tensorboard/plugins/profile/2025_05_16_22_02_40/gke-tpu-4e2ce392-t7pp.xplane.pb .
```
upload to xpof:
https://xprof.corp.google.com/overview_page/shuningjin-15516904343502207095
- 'device_type', device_core_count: https://screenshot.googleplex.com/7R7WNHD5Try37HV
- 'Average Tensor Core Step Time (ms)': https://screenshot.googleplex.com/3vXdqxCretdAQPG
- TPU FLOPS Utilization (%): exclude_idle & HBM Bandwidth Utilization (%): exclude_idle: 
https://screenshot.googleplex.com/7MWZwmdZ8Crahyd
- 'Peak memory allocation (MiB): jit_train_step, HBM', https://screenshot.googleplex.com/4AzEX8mtkji3BBS
- 'Peak memory allocation (MiB): jit_train_step, host': https://screenshot.googleplex.com/7pSbuiaPnYXxcdZ

## Worflow Cases

1. enable profile config (xlml), and upload single profile (training command): this is our main target
- generate_profile_file_location -> download_profile  -> profile_to_metrics -> process_metrics
- https://screenshot.googleplex.com/5FGtNUFfePhFwin

2. not enable profile config (xlml): this is the previous status, to show we are not breaking things or adding additional steps
- no generate_profile_file_location, download_profile , profile_to_metrics
- process_metrics still works
- https://screenshot.googleplex.com/63xo2i3qNQHx3N5

3. enable profile config (xlml), and upload single profile (training command, upload_all_profile = true):  this is our auxilary target
- works the same as 1. download_profile only find one of the many profiles.
- https://screenshot.googleplex.com/9XNbTBxGX3oW4cA

4. enable profile config (xlml), and upload no profile (training command, profiler=''): this is for error handling, in case training does not any profile. 
- `download_profile` produces a warning, but can still proceed to `process_metrics`
- https://screenshot.googleplex.com/AAeowPpyGEhf9mc

## Code Justification


1 Why wrap xplane_to_metrics as task.virtualenv
We need `tensorboard_plugin_profile` package
However, unable to update the environment directly
Thus seek https://airflow.apache.org/docs/apache-airflow-providers-standard/stable/operators/python.html#pythonvirtualenvoperator

```
@task.virtualenv(
    task_id="xplane_to_metrics",
    requirements=["tensorboard_plugin_profile"],
    system_site_packages=False,
)
def xplane_to_metrics(input_path: str): ...
```

2 post_process, additional steps
2.1 profile_tmp_location >> raw_metrics >> process_metrics

Ideally, we want to wrap xplane_to_metrics function inside process_metrics task. Now that xplane_to_metrics becomes a task, we have cyclic task dependencies: process_metrics -> xplane_to_metrics -> process_metrics
To linearize, I am breaking down it as
```
# task1: download profile from gcs
profile_tmp_location = download_profile(file_location)
# task2 wrapped in virtualenv: tensorboard_plugin_profile only, *cannot access other functions in xlml*
# process xplane profiles to list
raw_metrics = xplane_to_metrics(profile_tmp_location)
# task3 process_metrics: task that is already defined
profile_tmp_location >> raw_metrics >> process_metrics
````

2.2 can we combine task1 and task2: no. task2 is isolated from the outside world

https://screenshot.googleplex.com/APgoVMdeAoNtMZ7
https://screenshot.googleplex.com/BCAQGS4pv8x6wQT




# Tests

XLML e2e test:
- namegen example dag: https://screenshot.googleplex.com/53SWtSY8puHdQPi
- sweep example dag: https://screenshot.googleplex.com/7HuVdepwKtmxqtz

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.