### PR TITLE
Add maxtext trillium tpu-recipes regression tests

### DIFF
--- a/dags/common/model_configs.py
+++ b/dags/common/model_configs.py
@@ -25,17 +25,14 @@ class MaxTextV5eModelConfigs(enum.Enum):
   DEFAULT_128B = "default_128b_v5e_256"
   GPT3_175B = "gpt_3_175b_v5e_256"
   LLAMA2_7B = "llama2_7b_v5e_256"
-  LLAMA2_13B = "llama2_13b_v5e_256"
   LLAMA2_70B = "llama2_70b_v5e_256"
 
 
 class MaxTextTrilliumModelConfigs(enum.Enum):
   # Refers to model configs in https://github.com/AI-Hypercomputer/maxtext/blob/main/benchmarks/maxtext_trillium_model_configs.py
   GPT3_175B = "gpt_3_175b"
-  LLAMA2_70B_4096 = "llama2_70b_4096_synthetic"
   LLAMA3_1_8B_8192 = "llama3_1_8b_8192"
   LLAMA3_1_70B_8192 = "llama3_1_70b_8192"
-  LLAMA3_1_70B_129024 = "llama3_1_70b_129024"
   LLAMA3_1_405B_8192 = "llama3_1_405b_8192_fsdp_dcn"
   MIXTRAL_8X7B_DROPLESS = "mixtral_8x7b_dropless"
   MIXTRAL_8X7B_DROPPED = "mixtral_8x7b_dropped"

--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -377,3 +377,6 @@ class DockerImage(enum.Enum):
   MICROBENCH_NIGHTLY = (
       "gcr.io/tpu-prod-env-one-vm/microbenchmarks_runner:latest"
   )
+  MAXTEXT_JAX_052_RECIPES_012 = (
+      "gcr.io/tpu-prod-env-multipod/maxtext_tpu_recipes:jax0.5.2-recipes0.1.2"
+  )

--- a/dags/multipod/configs/common.py
+++ b/dags/multipod/configs/common.py
@@ -24,6 +24,7 @@ class SetupMode(enum.Enum):
   STABLE = "stable"
   NIGHTLY = "nightly"
   JAX_STABLE_STACK = "jax_stable_stack"
+  TPU_RECIPES = "tpu_recipes"
 
 
 class Platform(enum.Enum):

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -26,17 +26,18 @@ from dags.multipod.configs import maxtext_sweep_gke_config
 from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config
 
-# Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
-SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+# Run once a day at 3 am UTC (7 pm PST / 8 pm PDT)
+CONIFGS_SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
+    (SetupMode.TPU_RECIPES, DockerImage.MAXTEXT_JAX_052_RECIPES_012),
 ]
 BASE_OUTPUT_DIRECTORY = "gs://runner-maxtext-logs"
 
 with models.DAG(
     dag_id="maxtext_trillium_configs_perf",
-    schedule=SCHEDULED_TIME,
+    schedule=CONIFGS_SCHEDULED_TIME,
     tags=[
         "multipod_team",
         "maxtext",
@@ -50,8 +51,15 @@ with models.DAG(
   quarantine_task_group = TaskGroup(
       group_id="Quarantine", dag=dag, prefix_group_id=False
   )
+  all_tests = []
   for mode, image in DOCKER_IMAGES:
     for model in MaxTextTrilliumModelConfigs:
+      # No tpu-recipe for DeepSeek v3
+      if (
+          model == MaxTextTrilliumModelConfigs.DEEPSEEK_V3_EP16
+          and image == DockerImage.MAXTEXT_JAX_052_RECIPES_012
+      ):
+        continue
       base_run_model_cmds = [
           f"python3 -m benchmarks.benchmark_runner on-device --base_output_directory={BASE_OUTPUT_DIRECTORY} --model_name={model.value} --libtpu_type=maxtext-docker --num_steps=15",
       ]
@@ -77,15 +85,13 @@ with models.DAG(
               sweep_params={},
           )
       )
+      all_tests += maxtext_sweep_gke_test
 
-      chain_num = 4
-      prev = maxtext_sweep_gke_test[0].run_with_name_gen_and_quarantine(
-          quarantine_task_group
-      )
-      for i in range(1, len(maxtext_sweep_gke_test)):
-        curr = maxtext_sweep_gke_test[i].run_with_name_gen_and_quarantine(
-            quarantine_task_group
-        )
-        if i % chain_num != 0:
-          prev >> curr
-        prev = curr
+  # Add dependencies between the tests so they are not all launched at once
+  chain_num = 4
+  prev = all_tests[0].run_with_name_gen_and_quarantine(quarantine_task_group)
+  for i in range(1, len(all_tests)):
+    curr = all_tests[i].run_with_name_gen_and_quarantine(quarantine_task_group)
+    if i % chain_num != 0:
+      prev >> curr
+    prev = curr


### PR DESCRIPTION
# Description

- add `maxtext_tpu_recipes` docker image to test Trillium tpu recipes
- remove some models to reduce the number of tests

# Tests

Ran 2 tpu-recipe models: http://screen/nHYs6JK8rmPfSJZ

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.