### PR TITLE
upgrade image version for production environment

### DIFF
--- a/deployment/modules/composer_env/main.tf
+++ b/deployment/modules/composer_env/main.tf
@@ -6,7 +6,7 @@ resource "google_composer_environment" "example_environment" {
   config {
     environment_size = "ENVIRONMENT_SIZE_MEDIUM"
     software_config {
-      image_version = "composer-2.10.1-airflow-2.10.2"
+      image_version = "composer-2.13.1-airflow-2.10.5"
       airflow_config_overrides = {
         core-allowed_deserialization_classes_regexp = ".*"
         core-dags_are_paused_at_creation = false


### PR DESCRIPTION
# Description

Upgrade `prod` image: "composer-2.10.1-airflow-2.10.2"  -> "**composer-2.13.1-airflow-2.10.5**"

Why: Current image is too old for #728: c++ dependency issue
- failed for `dev`, used to be same as prod with [composer-2.10.1-airflow-2.10.2](https://screenshot.googleplex.com/6jT2fDaa2T5Kqbd): 
https://screenshot.googleplex.com/ZhyKVQBFq8Brx2k
  ```
  ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /tmp/venvqpko7so_/lib/python3.11/site-packages/tensorboard_plugin_profile/convert/_pywrap_profiler_plugin.so)
  ```
- succeed for `shuningjin-test` (my test env), used to have [composer-2.12.0-airflow-2.10.2](https://screenshot.googleplex.com/4aXUwZPhTi7SdZd): https://screenshot.googleplex.com/BVqBpKodNrAqA65

Checked the upgrade on dev env and my test env, now roll out for prod env

# Tests

1 manual image upgrade `shuningjin-test` to **composer-2.13.1-airflow-2.10.5**
https://screenshot.googleplex.com/7qvMKwmD5JBCUmL

#728 works:
- namegen: https://screenshot.googleplex.com/5mDstjVnMaeZh97
- sweep: https://screenshot.googleplex.com/8VBT2ncwyJLLSYu

2 manual image upgrade `dev` to **composer-2.13.1-airflow-2.10.5** 
https://screenshot.googleplex.com/6sN8nNR3BCy6r3J

#728 works:
- namegen: https://screenshot.googleplex.com/7a8oTj4ffspS7xz
- sweep: https://screenshot.googleplex.com/4fn8EdXmgCm3oZM

Checking other DAGs:
- maxtext_convergence (tpu, v4-128): https://screenshot.googleplex.com/7TRQW4rJAAXJHvX
- jax_functional_tests (tpu, v4-8, v5p-8): https://screenshot.googleplex.com/9reK7F4Swsk5bht
- mxla_maxtext_nightly_gke (tpu, v5p-8): https://screenshot.googleplex.com/7WTxRB5sYnCKMpN

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.