### PR TITLE
Removed pinned gpu image and replaced with candidate JAII image

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -354,10 +354,6 @@ class DockerImage(enum.Enum):
       "gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXTEXT_GPU_JAX_PINNED = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_pinned:"
-      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
-  )
   MAXTEXT_GPU_JAX_STABLE_STACK = (
       "gcr.io/tpu-prod-env-multipod/maxtext_gpu_jax_stable_stack:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
@@ -368,6 +364,10 @@ class DockerImage(enum.Enum):
   )
   MAXTEXT_GPU_STABLE_STACK_NIGHTLY_JAX = (
       "gcr.io/tpu-prod-env-multipod/maxtext_gpu_stable_stack_nightly_jax:"
+      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
+  )
+  MAXTEXT_GPU_JAX_AI_CANDIDATE_IMAGE = (
+      "gcr.io/tpu-prod-env-multipod/maxtext_stable_stack_candidate_gpu:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   CLOUD_HYBRIDSIM_NIGHTLY = (

--- a/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
@@ -54,13 +54,13 @@ def run_maxtext_tests():
   )
 
   for model, (test_script, nnodes) in test_models_gpu.items():
-    pinned_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
+    candidate_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=90,
-        test_name=f"{test_name_prefix}-pinned-{model}",
+        test_name=f"{test_name_prefix}-candidate-{model}",
         run_model_cmds=(test_script,),
         num_slices=nnodes,
         cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_PINNED.value,
+        docker_image=DockerImage.MAXTEXT_GPU_JAX_AI_CANDIDATE_IMAGE.value,
         test_owner=test_owner.MICHELLE_Y,
     ).run_with_quarantine(quarantine_task_group)
     stable_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
@@ -72,7 +72,7 @@ def run_maxtext_tests():
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
         test_owner=test_owner.MICHELLE_Y,
     ).run_with_quarantine(quarantine_task_group)
-    pinned_a3plus_gpu >> stable_a3plus_gpu
+    candidate_a3plus_gpu >> stable_a3plus_gpu
 
 
 with models.DAG(

--- a/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_gpu_e2e.py
@@ -54,15 +54,17 @@ def run_maxtext_tests():
   )
 
   for model, (test_script, nnodes) in test_models_gpu.items():
-    candidate_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-        time_out_in_min=90,
-        test_name=f"{test_name_prefix}-candidate-{model}",
-        run_model_cmds=(test_script,),
-        num_slices=nnodes,
-        cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-        docker_image=DockerImage.MAXTEXT_GPU_JAX_AI_CANDIDATE_IMAGE.value,
-        test_owner=test_owner.MICHELLE_Y,
-    ).run_with_quarantine(quarantine_task_group)
+    candidate_a3plus_gpu = (
+        gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
+            time_out_in_min=90,
+            test_name=f"{test_name_prefix}-candidate-{model}",
+            run_model_cmds=(test_script,),
+            num_slices=nnodes,
+            cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
+            docker_image=DockerImage.MAXTEXT_GPU_JAX_AI_CANDIDATE_IMAGE.value,
+            test_owner=test_owner.MICHELLE_Y,
+        ).run_with_quarantine(quarantine_task_group)
+    )
     stable_a3plus_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
         time_out_in_min=90,
         test_name=f"{test_name_prefix}-stable-{model}",


### PR DESCRIPTION
# Description

The GPU pinned image build in maxtext is broken and needs to be deprecated. Replacing the pinned image which uses an old version of jax with the candidate JAII + maxtext gpu image. 

# Tests

Ran tests in local Airflow to see that maxtext_moe_gpu_e2e DAG is pulling the gpu candidate image successfully. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.