### PR TITLE
trillium perf moe tests: use stable stack candidate

### DIFF
--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -82,7 +82,6 @@ with models.DAG(
           or model == MaxTextTrilliumModelConfigs.DEEPSEEK_V3_EP16
           else [1, 2]
       )
-
       maxtext_sweep_gke_test = (
           maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
               test_owner=test_owner.RAYMOND_Z,


### PR DESCRIPTION
# Description

I am changing MoE tests in the **trillium perf DAG**: http://shortn/_OFhjMgl4Du

use **stable-stack-candidate** intead of stable-stack, **only for mixtral-int8 and deepseek3** as they requires updated aqtp and jax
- partially fixes **b/413482906** (1.2 and 1.3; mixtral-int8): need `aqtp>=0.8.3`
- fixes **b/414641718** (deepseek): need `jax>=0.5.3`
- previously, [stable-stack](http://shortn/_0cmTDEO6ze): aqtp: 0.8.2, jax: 0.5.2: http://shortn/_7W6VDHohPJ
- now, [stable stack candidate](http://shortn/_yzTqEIEaUq): aqtp: 0.8.3, jax: 0.6.0: http://shortn/_m7n8XP2xgj

# Tests

maxtext-mixtral_8x7b_dropped_int8-stable-0-v6e-256: 
- [prev error](https://screenshot.googleplex.com/9gNSw4b8SbyeDzb) -> [now fixed](https://screenshot.googleplex.com/Ai3jQaX3pUEozea)

maxtext-mixtral_8x7b_dropped_int8-stable-1-2xv6e-256:
- [prev error](https://screenshot.googleplex.com/ApooCAKYM6j7bVq) -> [now OOM](https://screenshot.googleplex.com/BqGsxBUJGk94WHU), will deal with OOM later on

maxtext-deepseek_v3_ep16-stable-0-2xv6e-256: 
- [prev error](https://screenshot.googleplex.com/933ApykTaWodzJR) -> [now fixed](https://screenshot.googleplex.com/8NnL8dXhtn3cj63)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.