### PR TITLE
Pause vllm_benchmark nightly test

### DIFF
--- a/dags/solutions_team/solutionsteam_vllm_benchmarks.py
+++ b/dags/solutions_team/solutionsteam_vllm_benchmarks.py
@@ -11,9 +11,8 @@ from dags.multipod.configs.common import SetupMode, Platform
 from dags.solutions_team.configs.vllm import vllm_benchmark_config
 
 
-# Run once a day at 6 pm UTC (10 am PST)
-SCHEDULED_TIME = "0 18 * * *" if composer_env.is_prod_env() else None
-
+# Pause this DAG by default.
+SCHEDULED_TIME = None
 
 with models.DAG(
     dag_id="solutionsteam_vllm_benchmark",


### PR DESCRIPTION
# Description

The solution_team nightly tests currently include the `solutionsteam_vllm_benchmark` test but this test is currently not being used by the vLLM team, hence we are pausing it for now. 

# Tests

Manual 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.