### PR TITLE
Update microbenchmarks_config.py with gcloud storage cp instead of gsutil cp

### DIFF
--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -55,7 +55,7 @@ def get_microbenchmark_config(
   # Check if the metrics report exists, and if so, upload it to GCS
   run_model_cmds += (
       f"if [ -f {metrics_report} ]; then "
-      f"gsutil cp {metrics_report} {metric_config.SshEnvVars.GCS_OUTPUT.value}; "
+      f"gcloud storage cp {metrics_report} {metric_config.SshEnvVars.GCS_OUTPUT.value}; "
       "fi",
   )
 


### PR DESCRIPTION
# Description

Testing out fix for oncall nightly test that is failing at `gsutil cp` step due to `AttributeError: module 'google._upb._message' has no attribute 'MessageMapContainer'`.

# Tests


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.