### PR TITLE
Pin sqlalchemy-spanner to 1.11.0

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,3 +1,4 @@
+sqlalchemy-spanner==1.11.0
 apache-airflow==2.10.2
 apache-airflow-providers-sendgrid
 fabric


### PR DESCRIPTION
Pin sqlalchemy-spanner==1.11.0 in .github/requirements.txt before airflow dependencies to resolve a version issue

# Description

sqlalchemy-spanner is recently broken: https://github.com/googleapis/python-spanner-sqlalchemy/issues/337
This pin is needed to fix the issue. Otherwise, python dep installation will fail. 

# Tests

pip install -r .github/requirements.txt

works

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.