### PR TITLE
clean up dag to clean jobset

### DIFF
--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -789,8 +789,13 @@ def get_nemo_metrics_cmds(
 
 def cleanup_all_runs_cmds(cluster, cluster_region, prefix="cml-"):
   cleanup_cmds = (
-      f"echo 'Getting credentials for cluster {cluster}...' && gcloud container clusters get-credentials {cluster} --region {cluster_region} --project {PROJECT} ",
-      f"echo 'Uninstalling jobs with prefix {prefix}...' && JOBS=$(kubectl get job -n default | grep \"^{prefix}\" | awk '{{print $1}}') && if [ -n \"$JOBS\" ]; then echo \"$JOBS\" | xargs -L1 helm uninstall -n default; else echo 'No matching jobs found'; fi",
+      f"echo 'Getting credentials for cluster {cluster}...' && gcloud container clusters get-credentials {cluster} --region {cluster_region} --project {PROJECT}",
+      f"echo 'Uninstalling jobs with prefix {prefix}...' && "
+      f"JOBS=$(kubectl get job -n default | grep '^{prefix}' | awk '{{print $1}}' | sed 's/-workload-0$//' | sort -u) && "
+      f'if [ -n "$JOBS" ]; then '
+      f'echo "$JOBS" | xargs -L1 helm uninstall -n default || true && '
+      f'echo "$JOBS" | xargs -L1 kubectl delete job -n default || true; '
+      f"else echo 'No matching jobs found'; fi",
   )
   return cleanup_cmds
 


### PR DESCRIPTION
# Description

clean up dag to clean jobset. jobsets end with cml-mixtral-8x7b-bf168a3um0603-wrq-workload-0.  We need to remove -workload-0 for the cleanup cmd

# Tests
https://screenshot.googleplex.com/6NPGH5fUkAkobwp
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.