### PR TITLE
change tpu to v5p-8 for SDv2

### DIFF
--- a/dags/sparsity_diffusion_devx/configs/gke_config.py
+++ b/dags/sparsity_diffusion_devx/configs/gke_config.py
@@ -30,7 +30,7 @@ clusters = {
     "v6e-256": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
     "a3": XpkClusters.GPU_A3_CLUSTER,
     "a3plus": XpkClusters.GPU_A3PLUS_CLUSTER,
-    "v5p-128": XpkClusters.TPU_V5P_128_CLUSTER,
+    "v5p-8": XpkClusters.TPU_V5P_8_CLUSTER,
 }
 
 

--- a/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
@@ -51,7 +51,7 @@ with models.DAG(
   }
   maxdiffusion_test_configs_sdv2 = {
       # accelerator: list of slices to test
-      "v5p-128": [1, 2]
+      "v5p-8": [1, 2]
   }
 
   quarantine_task_group = TaskGroup(


### PR DESCRIPTION
# Description

Changed TPU from v5p-128 to V5p-8 due to reservation bandwidth.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [ ] I have made or will make corresponding changes to the doc if needed.