### PR TITLE
Update setup_terraform.sh

### DIFF
--- a/deployment/deployment_composer_env/setup_terraform.sh
+++ b/deployment/deployment_composer_env/setup_terraform.sh
@@ -16,5 +16,8 @@ grep -o '\.terraform/bin' <<< $PATH \
     || grep -H '\.terraform/bin' ~/.bashrc \
     || echo 'export PATH=${PATH}:~/.terraform/bin' >> ~/.bashrc
 
-source ~/.bashrc
+export PATH="${PATH}:$HOME/.terraform/bin"
+
+# Verify the installation was successful
+echo "Terraform installation successful. Current version:"
 terraform -v


### PR DESCRIPTION
While `source ~/.bashrc` its intent is to load the new PATH into the current session, it often fails inside a script.

To fix this, we should export the PATH directly within the script, which ensures the change takes effect immediately for the script's environment.

# Description

Please include a summary of relevant context/issue and your changes.

The original script creates "./setup_terraform.sh: line 20: terraform: command not found" issue when running on cloudtop. The updated script fixes the issue.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

run `./setup_terraform.sh`

**List links for your tests (use go/shortn-gen for any internal link):** ...
http://shortn/_2FQnUa1921

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.