### PR TITLE
Modifying wait_for_jobset to get the jobset from helm release name

### DIFF
--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -548,15 +548,17 @@ def wait_for_jobsets_cmds(timeout: str = "100m"):
     A tuple of command strings.
   """
   wait_for_jobset = (
-      'echo "Listing pods associated with JobSet $JOB_NAME:"',
-      "kubectl get pods --selector=jobset.sigs.k8s.io/jobset-name=$JOB_NAME --namespace=default",
-      'echo "Will wait for JobSet $JOB_NAME to finish..."',
+      """export JOBSET_NAME=$(kubectl get jobset -o custom-columns=NAME:.metadata.name,NAME2:.metadata.annotations  |grep meta.helm.sh/release-name:$JOB_NAME | awk {'print $1'})""",
+      'echo "Release Name: $JOB_NAME - JOBSET_NAME: $JOBSET_NAME"',
+      'echo "Listing pods associated with JobSet $JOBSET_NAME:"',
+      "kubectl get pods --selector=jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME --namespace=default",
+      'echo "Will wait for JobSet $JOBSET_NAME to finish..."',
       # The condition for JobSet completion is typically 'Completed'.
-      f"kubectl wait --for=condition=Completed jobset/$JOB_NAME --namespace=default --timeout={timeout}",
-      'echo "JobSet $JOB_NAME finished. Describing JobSet:"',
-      "kubectl describe jobset $JOB_NAME --namespace=default",
-      'echo "Final pod status for JobSet $JOB_NAME:"',
-      "kubectl get pods --selector=jobset.sigs.k8s.io/jobset-name=$JOB_NAME --namespace=default",
+      f"kubectl wait --for=condition=Completed jobset/$JOBSET_NAME --namespace=default --timeout={timeout}",
+      'echo "JobSet $JOBSET_NAME finished. Describing JobSet:"',
+      "kubectl describe jobset $JOBSET_NAME --namespace=default",
+      'echo "Final pod status for JobSet $JOBSET_NAME:"',
+      "kubectl get pods --selector=jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME --namespace=default",
   )
   return wait_for_jobset
 


### PR DESCRIPTION
# Description

This PR fix an issue given jobset name can have a different name than the helm release name on recipes.
In this way we find the jobset name from the release name.

# Tests

This have been tested on nemo two nodes for a3ultra and MaxText Llama-3.1-70b for a3ultra

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** 
- Llama-3.1-70B Maxtext a3ultra run: http://shortn/_6dr31THwlE (32 nodes)
- Mitral-8x7B two nodes a3ultra run: http://shortn/_AnEtw29rlS
- 


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.