### PR TITLE
Add "Node Pool Status" metric dag file.

### DIFF
--- a/dags/tpu-obs/node_pool_status_dag.py
+++ b/dags/tpu-obs/node_pool_status_dag.py
@@ -1,0 +1,173 @@
+"""Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
+"""
+
+import datetime
+import os
+import sys
+
+from airflow import models
+import node_pool_util
+from node_pool_util import Status
+from airflow.operators.empty import EmptyOperator
+
+# --------------------------------------------------------------------------------
+# AIRFLOW DAG DEFINITION
+# --------------------------------------------------------------------------------
+
+with models.DAG(
+    dag_id="gke_node_pool_status_dag",
+    start_date=datetime.datetime(2025, 7, 30),
+    schedule=datetime.timedelta(days=1),
+    catchup=False,
+    tags=["gke", "tpu-observability", "node-pool-status"],
+    doc_md="""
+    ### GKE Node Pool Lifecycle Management DAG
+
+    This DAG automates the lifecycle of a GKE node pool for testing purposes.
+    It performs the following steps:
+    1.  **Normal Path**: Creates a node pool, waits for it to be running, deletes a random node to trigger reconciliation, waits for it to become running again, and finally cleans up.
+    2.  **Error Path**: Concurrently, it attempts to create a node pool with invalid parameters to test the error state, and then cleans up.
+    """,
+) as dag:
+
+  # Instantiate the GKENodePool class within a task
+  node_pool_info = node_pool_util.Info(
+      project_id=models.Variable.get(
+          "PROJECT_ID", default_var="tpu-prod-env-one-vm"
+      ),
+      cluster_name=models.Variable.get(
+          "CLUSTER_NAME", default_var="yuna-xpk-v6e-2"
+      ),
+      node_pool_name=models.Variable.get(
+          "NODE_POOL_NAME", default_var="yuna-v6e-autotest"
+      ),
+      location=models.Variable.get("LOCATION", default_var="asia-northeast1"),
+      node_locations=models.Variable.get(
+          "NODE_LOCATIONS", default_var="asia-northeast1-b"
+      ),
+      num_nodes=models.Variable.get("NUM_NODES", default_var=4),
+      machine_type=models.Variable.get(
+          "MACHINE_TYPE", default_var="ct6e-standard-4t"
+      ),
+      tpu_topology=models.Variable.get("TPU_TOPOLOGY", default_var="4x4"),
+  )
+
+  error_node_pool_info = node_pool_util.Info(
+      project_id=node_pool_info.project_id,
+      cluster_name=node_pool_info.cluster_name,
+      node_pool_name=node_pool_info.node_pool_name + "-error",
+      location=node_pool_info.location,
+      node_locations=models.Variable.get(
+          "ERROR_NODE_LOCATIONS", default_var="asia-east1-c"
+      ),
+      num_nodes=node_pool_info.num_nodes,
+      machine_type=node_pool_info.machine_type,
+      tpu_topology=node_pool_info.tpu_topology,
+  )
+  # =================================================================================
+  # Normal Path Tasks
+  # =================================================================================
+
+  """STEP 1: Creates the GKE node pool."""
+  create_node_pool = node_pool_util.create.override(
+      task_id="create_node_pool")(info=node_pool_info)  # Force success for testing purposes
+
+  """STEP 2: Validating Provisioning Status."""
+  wait_for_provisioning = node_pool_util.wait_for_status.override(task_id="wait_for_provisioning")(
+      info=node_pool_info,
+      status=Status.PROVISIONING,
+  )
+
+  """STEP 3: Validating Running Status."""
+  wait_for_running_initial = node_pool_util.wait_for_status.override(task_id="wait_for_running_initial")(
+      info=node_pool_info,
+      status=Status.RUNNING
+  )
+
+  """STEP 4: Deleting a random node to trigger reconciliation."""
+  delete_node = node_pool_util.delete_node(
+      info=node_pool_info
+  )
+
+  """STEP 5: Validating Reconciling Status."""
+  wait_for_reconciling = node_pool_util.wait_for_status.override(task_id="wait_for_reconciling")(
+      info=node_pool_info,
+      status=Status.RECONCILING
+  )
+
+  """STEP 6: Validating Running Status After Repair."""
+  wait_for_running_after_repair = node_pool_util.wait_for_status.override(task_id="wait_for_running_after_repair")(
+      info=node_pool_info,
+      status=Status.RUNNING
+  )
+
+  # TODO: In this DAG, cleaning up and verifying the state is part of the
+  # requirement. However, in other DAGs, resource cleanup may fail, but it is
+  # not part of the verification requirement. Therefore, even if the
+  # cleanup process fails, the overall task should still be considered
+  # successful. Please confirm what the overall task result would be when
+  # trigger_rule=ALL_DONE.
+  """STEP 7: Cleaning up - Deleting Node Pool."""
+  delete_node_pool = node_pool_util.delete.override(
+      task_id="delete_node_pool",trigger_rule="all_done")(
+      info=node_pool_info
+  )
+
+  """STEP 8: Validating Stopping Status."""
+  wait_for_stopping = node_pool_util.wait_for_status.override(task_id="wait_for_stopping",
+      trigger_rule="all_done")(
+      info=node_pool_info,
+      status=Status.STOPPING
+  )
+
+  # =================================================================================
+  # Error Path Tasks
+  # =================================================================================
+
+  # This task must be successful in airflow, if it have some issues next task will go to error state.
+  """STEP 1: Creating Error Node Pool."""
+  create_error_node_pool = node_pool_util.create.override(task_id="create_error_node_pool")(
+      info=error_node_pool_info,
+      force_task_success=True
+  )
+  """STEP 2: Validating Error Status."""
+  wait_for_error = node_pool_util.wait_for_status.override(task_id="wait_for_error")(
+      info=error_node_pool_info,
+      status=Status.ERROR
+  )
+  """STEP 3: Cleaning up - Deleting Error Node Pool."""
+  delete_error_node_pool = node_pool_util.delete.override(
+    task_id="delete_error_node_pool",
+    trigger_rule="all_done"
+    )(
+    info=error_node_pool_info)
+
+  # =================================================================================
+  # Define Task Dependencies
+  # =================================================================================
+  end = EmptyOperator(
+        task_id="final_status_check",
+        trigger_rule="all_success",  # 所有上游都成功，DAG 才標成功
+    )
+  
+  # Normal path workflow
+  normal_path_flow = (
+      create_node_pool
+      >> wait_for_provisioning
+      >> wait_for_running_initial
+      >> delete_node
+      >> wait_for_reconciling
+      >> wait_for_running_after_repair
+  )
+
+  # The cleanup task for the normal path runs after the main flow is complete
+  # (success or fail)
+  normal_path_flow >> delete_node_pool >> wait_for_stopping >> end
+
+  # Error path workflow (runs in parallel to the normal path)
+  error_path_flow = (
+      create_error_node_pool >> wait_for_error
+  )
+  
+  # The cleanup task for the error path runs after it's complete
+  error_path_flow >> delete_error_node_pool >> end

--- a/dags/tpu-obs/node_pool_util.py
+++ b/dags/tpu-obs/node_pool_util.py
@@ -1,0 +1,292 @@
+"""
+Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
+"""
+
+import dataclasses
+import enum
+import logging
+import random
+import re
+import time
+from typing import List
+
+from airflow import decorators
+import subprocess
+from airflow.providers.standard.operators.bash import BashOperator
+from google import auth
+from google.cloud import monitoring_v3
+from google.cloud.monitoring_v3 import types
+from googleapiclient import discovery
+
+
+dataclass = dataclasses.dataclass
+logger = logging.getLogger(__name__)
+
+
+class Status(enum.Enum):
+  """Enum for GKE node pool status."""
+  RUNNING = enum.auto()
+  PROVISIONING = enum.auto()
+  STOPPING = enum.auto()
+  RECONCILING = enum.auto()
+  ERROR = enum.auto()
+  UNKNOWN = enum.auto()
+
+  @staticmethod
+  def from_str(s: str) -> "Status":
+      """Converts a string to a Status enum member."""
+      status = Status.__members__.get(s)
+      if status is None:
+          logging.warning("Unknown status: %s", s)
+          return Status.UNKNOWN
+      return status
+
+
+@dataclasses.dataclass
+class Info():
+  """Class to hold GKE node pool configuration parameters."""
+  project_id: str
+  cluster_name: str
+  node_pool_name: str
+  location: str
+  node_locations: str
+  machine_type: str
+  num_nodes: int
+  tpu_topology: str
+
+
+@decorators.task
+def create(info: Info, force_task_success: bool = False) -> BashOperator:
+  """Creates the GKE node pool using gcloud command."""
+  command_suffix = " 2>&1 || true" if force_task_success else ""
+
+  command = f"""
+                gcloud container node-pools create {info.node_pool_name} \\
+                --project={info.project_id} \\
+                --cluster={info.cluster_name} \\
+                --location={info.location} \\
+                --node-locations {info.node_locations} \\
+                --num-nodes={info.num_nodes} \\
+                --machine-type={info.machine_type} \\
+                --tpu-topology={info.tpu_topology}{command_suffix}
+        """
+  process = None
+  process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+  logger.debug("STDOUT message: %s", process.stdout)
+  logger.debug("STDERR message: %s", process.stderr)
+
+
+@decorators.task
+def delete(
+    info: Info,
+) -> BashOperator:
+  """Deletes the GKE node pool using gcloud command."""
+  command = f"""
+                gcloud container node-pools delete {info.node_pool_name} \\
+                --project {info.project_id} \\
+                --cluster {info.cluster_name} \\
+                --location {info.location} \\
+                --quiet
+        """
+
+  process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+  logger.debug("STDOUT message: %s", process.stdout)
+  logger.debug("STDERR message: %s", process.stderr)
+
+
+def list_nodes(info: Info) -> List[str]:
+  """Lists all VM instances (nodes) within the specified GKE node pool.
+
+  This method queries the Google Cloud Container API and Compute API
+  to retrieve details about the nodes belonging to the configured
+  node pool. It parses instance group URLs to extract node names and zones.
+  Args:
+      info (Info): An instance of the Info class containing GKE node pool
+                   configuration parameters.
+  Returns:
+      A dictionary where keys are node names (str) and values are
+            the zones (str) where the nodes are located. Returns an empty
+            dictionary if no nodes are found, if GCP clients are not
+            initialized, or in case of a 404 HttpError (node pool not found).
+  Raises:
+      RuntimeError: If no instance groups or zone are found for the node pool.
+  """
+  credentials, _ = auth.default()
+  container_client = discovery.build(
+      "container", "v1", credentials=credentials, cache_discovery=False
+  )
+  compute_client = discovery.build(
+      "compute", "v1", credentials=credentials, cache_discovery=False
+  )
+
+  nodepool_path = (
+      f"projects/{info.project_id}/locations/{info.location}"
+      f"/clusters/{info.cluster_name}/nodePools/{info.node_pool_name}"
+  )
+  nodepool = (
+      container_client.projects().locations().clusters().nodePools()
+      .get(name=nodepool_path)
+      .execute()
+  )
+
+  instance_group = nodepool.get("instanceGroupUrls", [])
+  if not instance_group:
+    raise RuntimeError(
+        f"No instance groups found for node pool {info.node_pool_name}."
+    )
+
+  node_names = []
+  zone = None
+  for url in instance_group:
+    # Regex refined to be more specific to GCP instance group URLs
+    match = re.search(
+        r"zones/([\w-]+)/instanceGroupManagers/([\w-]+)", url
+    )
+    if not match:
+      logging.warning("Could not parse instance group URL: %s", url)
+      continue
+
+    zone = match.group(1)
+    ig_name = match.group(2)
+
+    instances = (
+        compute_client.instanceGroups()
+        .listInstances(
+            project=info.project_id,
+            zone=zone,
+            instanceGroup=ig_name,
+            body={"instanceState": "ALL"},
+        ).execute()
+    )
+
+    for instance_item in instances.get("items", []):
+      instance_url = instance_item["instance"]
+      # Regex refined to match GKE node names
+      # (e.g., gke-cluster-node-xxxx)
+      node_name = re.search(r"gke[\w-]+", instance_url).group()
+      if node_name:
+        node_names.append(node_name)
+      else:
+        logging.warning(
+            "Could not extract node name from URL: %s", instance_url
+        )
+  if zone is None:
+    raise RuntimeError(
+        f"No zone found for node pool {info.node_pool_name}."
+    )
+  return node_names, zone
+
+
+@decorators.task
+def delete_node(info: Info):
+  """Defines an Airflow task to delete a random node from the GKE node pool.
+
+  This function uses Airflow's `@task` decorator to create a Python callable
+  that will be executed as an Airflow task. The callable itself performs
+  the node listing, selection, and deletion using `gcloud` commands.
+
+  Args:
+      info (Info): An instance of the Info class containing GKE node pool
+                   configuration parameters.
+
+  Returns:
+      The decorated Airflow task object, ready to be included in a task flow.
+  """
+
+  nodes_list, zone = list_nodes(info)
+  if not nodes_list:
+    logging.warning(
+        "No nodes found in node pool '%s'. No deletion will be performed.",
+        info.node_pool_name,
+    )
+    return None  # Task succeeds, but no node deleted
+
+  node_to_delete = random.choice(nodes_list)
+  logging.info(
+      "Randomly selected node for deletion: %s",
+      node_to_delete,
+  )
+
+  command = f"""
+      gcloud compute instances delete {node_to_delete} \\
+          --project={info.project_id} \\
+          --zone={zone} \\
+          --quiet
+      """
+
+  process = None
+  try:
+    process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+    logging.info("Successfully deleted node %s", node_to_delete)
+  except Exception as e:
+    logger.error('Failed to run "%s": %s', " ".join(command), e)
+    if process:
+      # Subprocess hook stores the stdout + stderr in the `output` attribute
+      logger.debug("STDOUT message: %s", process.stdout)
+      logger.debug("STDERR message: %s", process.stderr)
+    raise
+
+
+def _query_status_metric(info: Info) -> Status:
+  """Fetches the status time series data for this specific node pool."""
+  project_name = f"projects/{info.project_id}"
+  now = int(time.time())
+  request = {
+      "name": project_name,
+      "filter": (
+          'metric.type="kubernetes.io/node_pool/status" '
+          f'resource.labels.project_id = "{info.project_id}" '
+          f'resource.labels.cluster_name = "{info.cluster_name}" '
+          f'resource.labels.node_pool_name = "{info.node_pool_name}"'
+      ),
+      "interval": types.TimeInterval({
+          "end_time": {"seconds": now},
+          "start_time": {"seconds": now - 300},
+      }),
+      "view": monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+  }
+
+  monitoring_client = monitoring_v3.MetricServiceClient()
+  time_series_data = monitoring_client.list_time_series(request)
+  records = []
+  for series in time_series_data:
+    np_status = series.metric.labels.get("status", "unknown").upper()
+    for point in series.points:
+      end_ts_dt = point.interval.end_time
+      records.append((end_ts_dt, np_status))
+  if not records:
+    logging.info("No records found yet. Retrying in 60s...")
+    return Status.UNKNOWN
+
+  _, latest_status = max(records, key=lambda r: r[0])
+
+  return Status.from_str(latest_status)
+
+
+@decorators.task.sensor(poke_interval=60, timeout=600, mode="reschedule")
+def wait_for_status(
+    info: Info,
+    status: Status,
+    **context,
+) -> None:
+  """Waits for the node pool to enter the target status."""
+  # Consistent with Airflow's default timeout for sensor tasks.
+  timeout = context["task"].timeout
+  logging.info(
+      "Waiting for node pool '%s' status to become '%s' within %s"
+      " seconds...",
+      info.node_pool_name,
+      status.name,
+      timeout,
+  )
+
+  latest_status = _query_status_metric(info)
+  return latest_status == status
+
+


### PR DESCRIPTION
# Description
Create new folder for TPU-Observability project auto test.

# Tests
This PR introduces an automated testing framework for TPU-Observability project by creating a new dags/tpu-obs directory. As the first test case, a new Airflow DAG is added to monitor and verify GKE node pool status metrics throughout its lifecycle.

This automation is crucial for ensuring the reliability and observability of our GKE infrastructure, allowing us to proactively detect issues related to node pool provisioning, reconciliation, and error states.

This DAG requires access to a pre-existing GKE cluster to run its tests.
Use gcloud command create cluster manually or 
[Cluster Env:](https://pantheon.corp.google.com/kubernetes/clusters/details/asia-northeast1/yuna-xpk-v6e-2/details?hl=en-au&inv=1&invt=Ab4NBw&project=tpu-prod-env-one-vm)
- Project ID: tpu-prod-env-one-vm
- Cluster Name: yuna-xpk-v6e-2
- Location: asia-northeast1

[Airflow/Composer Env: ](https://b371d513bb74418681c3aab7b27bbf12-dot-us-east1.composer.googleusercontent.com/home)
- Project ID: cloud-ml-auto-solutions
- Name: dennis-airflow-test
- Composer version: 2.13.1
- Airflow version: 2.10.5
 
Need setup/obtain parameters for a DAG:
Following this [doc](https://docs.google.com/document/d/19QTZGHBQr8hZ_JswOxQkw0-tUWoSCN7FrlxIeUwBEno/edit?resourcekey=0-QJ8ofJTT3AQDifmSBitdDQ&tab=t.0#heading=h.oi4pw8q0k50h)
- PROJECT_ID: The target Google Cloud Project ID. (Default: tpu-prod-env-one-vm)
- CLUSTER_NAME: The name of the existing GKE cluster. (Default: yuna-xpk-v6e-2)
- NODE_POOL_NAME: The base name for the new node pool. (Default: yuna-v6e-autotest)
- LOCATION: The region of the GKE cluster. (Default: asia-northeast1)
- NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default: asia-northeast1-b)
- NUM_NODES: The number of nodes to create in the pool. (Default: 4)
- MACHINE_TYPE: The machine type for the GKE nodes. (Default: ct6e-standard-4t)
- TPU_TOPOLOGY: The TPU topology for the node pool. (Default: 4x4)
- ERROR_NODE_LOCATIONS: An invalid zone used to intentionally trigger an error state for testing. (Default: asia-east1-c)

Test result:
Tests have been conducted in the "cloud-ml-auto-solutions" project with cloud composer.
- Dag Name: node_pool_status_dag
[Test Link](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/gke_node_pool_status_dag/grid)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.