### PR TITLE
Add a new DAG that tests the status of node pool are reported correctly

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -89,6 +89,7 @@ class Region(enum.Enum):
 
   # used for GKE
   US_CENTRAL1 = "us-central1"
+  ASIA_NORTHEAST1 = "asia-northeast1"
 
 
 class Zone(enum.Enum):
@@ -133,6 +134,8 @@ class Zone(enum.Enum):
   # reserved l4 in cloud-tpu-inference-test
   ASIA_EAST1_A = "asia-east1-a"
   ASIA_EAST1_C = "asia-east1-c"
+  # on-demand v6e in tpu-prod-env-one-vm
+  ASIA_NORTHEAST1_B = "asia-northeast1-b"
 
 
 class MachineVersion(enum.Enum):

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -1,0 +1,158 @@
+"""Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
+"""
+
+import copy
+import datetime
+
+from airflow import models
+
+from dags.common.vm_resource import Project
+from dags.common.vm_resource import Zone
+from dags.map_reproducibility.utils import constants
+from dags.tpu_observability.utils import node_pool_util as node_pool
+
+
+with models.DAG(
+    dag_id="gke_node_pool_status",
+    start_date=datetime.datetime(2025, 7, 30),
+    schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
+    catchup=False,
+    tags=["gke", "tpu-observability", "node-pool-status"],
+    description=(
+        "This DAG tests whether the status of a GKE node pool changes as"
+        " expected according to its lifecycle."
+    ),
+    doc_md="""
+        ### GKE Node Pool Status Validation DAG
+
+        This DAG automates the process of going through the lifecycle of a GKE
+        node pool and verifies whether the node pool status is reported correctly.
+        This test requires an existing cluster. It will create a node-pool under
+        the specified cluster, and clean it up after the tests.
+
+        It creates a node pool, waits for it from provisioning to be running,
+        deletes a random node to trigger reconciliation, waits for it to become
+        running again, and finally cleans up.
+        It also tests the error state by creating a node pool with invalid
+        parameters and verifies that the status changes to error.
+    """,
+) as dag:
+
+  node_pool_info = node_pool.Info(
+      project_id=models.Variable.get(
+          "PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
+      ),
+      cluster_name=models.Variable.get(
+          "CLUSTER_NAME", default_var="yuna-xpk-v6e-2"
+      ),
+      node_pool_name=models.Variable.get(
+          "NODE_POOL_NAME", default_var="yuna-v6e-autotest"
+      ),
+      location=models.Variable.get("LOCATION", default_var="asia-northeast1"),
+      node_locations=models.Variable.get(
+          "NODE_LOCATIONS", default_var=Zone.ASIA_NORTHEAST1_B.value
+      ),
+      num_nodes=models.Variable.get("NUM_NODES", default_var=4),
+      machine_type=models.Variable.get(
+          "MACHINE_TYPE", default_var="ct6e-standard-4t"
+      ),
+      tpu_topology=models.Variable.get("TPU_TOPOLOGY", default_var="4x4"),
+  )
+
+  problematic_node_pool_info = copy.deepcopy(node_pool_info)
+  problematic_node_pool_info.node_pool_name += "-wrong"
+  # Choosing a region that is different from the cluster location but still
+  # compatible with the specified TPU cause the cluster creation to fail
+  # due to mismatched node locations.
+  problematic_node_pool_info.node_locations = models.Variable.get(
+      "WRONG_NODE_LOCATION", default_var=Zone.ASIA_EAST1_C.value
+  )
+
+  task_id = "create_node_pool"
+  create_node_pool = node_pool.create.override(task_id=task_id)(
+      node_pool=node_pool_info
+  )
+
+  task_id = "wait_for_provisioning"
+  wait_for_provisioning = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.PROVISIONING
+  )
+
+  task_id = "wait_for_running"
+  wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.RUNNING
+  )
+
+  task_id = "delete_node"
+  delete_node = node_pool.delete_one_random_node.override(task_id=task_id)(
+      node_pool=node_pool_info
+  )
+
+  task_id = "wait_for_repair"
+  wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.RECONCILING
+  )
+
+  task_id = "wait_for_recovered"
+  wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.RUNNING
+  )
+
+  task_id = "delete_node_pool"
+  delete_node_pool = node_pool.delete.override(task_id=task_id)(
+      node_pool=node_pool_info
+  )
+
+  task_id = "wait_for_stopping"
+  wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.STOPPING
+  )
+
+  task_id = "cleanup_node_pool"
+  cleanup_node_pool = node_pool.delete.override(
+      task_id=task_id, trigger_rule="all_done"
+  )(node_pool=node_pool_info).as_teardown(
+      setups=create_node_pool,
+  )
+
+  # Intentionally create a node pool with problematic configurations
+  # to validate that it enters the ERROR state.
+  task_id = "create_problematic_node_pool_info"
+  create_problematic_node_pool_info = node_pool.create.override(
+      task_id=task_id
+  )(
+      # The failure is intentionally ignored because we want to validate
+      # that the status of the node pool (which fails to be created) is "ERROR".
+      node_pool=problematic_node_pool_info,
+      ignore_failure=True,
+  )
+
+  task_id = "wait_for_error"
+  wait_for_error = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=problematic_node_pool_info, status=node_pool.Status.ERROR
+  )
+
+  task_id = "cleanup_wrong_node_pool"
+  cleanup_wrong_node_pool = node_pool.delete.override(
+      task_id=task_id, trigger_rule="all_done"
+  )(node_pool=problematic_node_pool_info).as_teardown(
+      setups=create_problematic_node_pool_info,
+  )
+
+  normal_path_flow = (
+      create_node_pool
+      >> wait_for_provisioning
+      >> wait_for_running
+      >> delete_node
+      >> wait_for_repair
+      >> wait_for_recovered
+      >> delete_node_pool
+      >> wait_for_stopping
+      >> cleanup_node_pool
+  )
+
+  wrong_path_flow = (
+      create_problematic_node_pool_info
+      >> wait_for_error
+      >> cleanup_wrong_node_pool
+  )

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -1,12 +1,13 @@
-"""Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
-"""
+"""A Dag to validate the status of a GKE node pool through its lifecycle."""
 
 import copy
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags.common.vm_resource import Project
+from dags.common.vm_resource import Region
 from dags.common.vm_resource import Zone
 from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.utils import node_pool_util as node_pool
@@ -14,7 +15,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 
 with models.DAG(
     dag_id="gke_node_pool_status",
-    start_date=datetime.datetime(2025, 7, 30),
+    start_date=datetime.datetime(2025, 8, 1),
     schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
     catchup=False,
     tags=["gke", "tpu-observability", "node-pool-status"],
@@ -37,7 +38,6 @@ with models.DAG(
         parameters and verifies that the status changes to error.
     """,
 ) as dag:
-
   node_pool_info = node_pool.Info(
       project_id=models.Variable.get(
           "PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
@@ -48,7 +48,9 @@ with models.DAG(
       node_pool_name=models.Variable.get(
           "NODE_POOL_NAME", default_var="yuna-v6e-autotest"
       ),
-      location=models.Variable.get("LOCATION", default_var="asia-northeast1"),
+      location=models.Variable.get(
+          "LOCATION", default_var=Region.ASIA_NORTHEAST1.value
+      ),
       node_locations=models.Variable.get(
           "NODE_LOCATIONS", default_var=Zone.ASIA_NORTHEAST1_B.value
       ),
@@ -110,7 +112,7 @@ with models.DAG(
 
   task_id = "cleanup_node_pool"
   cleanup_node_pool = node_pool.delete.override(
-      task_id=task_id, trigger_rule="all_done"
+      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
   )(node_pool=node_pool_info).as_teardown(
       setups=create_node_pool,
   )
@@ -121,9 +123,9 @@ with models.DAG(
   create_problematic_node_pool_info = node_pool.create.override(
       task_id=task_id
   )(
+      node_pool=problematic_node_pool_info,
       # The failure is intentionally ignored because we want to validate
       # that the status of the node pool (which fails to be created) is "ERROR".
-      node_pool=problematic_node_pool_info,
       ignore_failure=True,
   )
 
@@ -134,12 +136,12 @@ with models.DAG(
 
   task_id = "cleanup_wrong_node_pool"
   cleanup_wrong_node_pool = node_pool.delete.override(
-      task_id=task_id, trigger_rule="all_done"
+      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
   )(node_pool=problematic_node_pool_info).as_teardown(
       setups=create_problematic_node_pool_info,
   )
 
-  normal_path_flow = (
+  normal_flow = (
       create_node_pool
       >> wait_for_provisioning
       >> wait_for_running
@@ -151,7 +153,7 @@ with models.DAG(
       >> cleanup_node_pool
   )
 
-  wrong_path_flow = (
+  flow_for_error_state = (
       create_problematic_node_pool_info
       >> wait_for_error
       >> cleanup_wrong_node_pool

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -1,0 +1,315 @@
+"""Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
+"""
+
+import dataclasses
+import enum
+import logging
+import random
+import re
+import subprocess
+import time
+from typing import List
+
+from airflow.decorators import task
+from google import auth
+from google.cloud import monitoring_v3
+from google.cloud.monitoring_v3 import types
+from googleapiclient import discovery
+
+
+dataclass = dataclasses.dataclass
+logger = logging.getLogger(__name__)
+
+
+class Status(enum.Enum):
+  """Enum for GKE node pool status."""
+
+  RUNNING = enum.auto()
+  PROVISIONING = enum.auto()
+  STOPPING = enum.auto()
+  RECONCILING = enum.auto()
+  ERROR = enum.auto()
+  UNKNOWN = enum.auto()
+
+  @staticmethod
+  def from_str(s: str) -> "Status":
+    """Converts a string to a Status enum member."""
+    status = Status.__members__.get(s)
+    if status is None:
+      logging.warning("Unknown status: %s", s)
+      return Status.UNKNOWN
+    return status
+
+
+@dataclasses.dataclass
+class Info:
+  """Encapsulates information related to a GKE node pool and represents a specific node pool."""
+
+  project_id: str
+  cluster_name: str
+  node_pool_name: str
+  location: str
+  node_locations: str
+  machine_type: str
+  num_nodes: int
+  tpu_topology: str
+
+
+@task
+def create(node_pool: Info, ignore_failure: bool = False) -> None:
+  """Creates a GKE node pool by the given node pool information."""
+
+  command = f"""
+                gcloud container node-pools create {node_pool.node_pool_name} \\
+                --project={node_pool.project_id} \\
+                --cluster={node_pool.cluster_name} \\
+                --location={node_pool.location} \\
+                --node-locations {node_pool.node_locations} \\
+                --num-nodes={node_pool.num_nodes} \\
+                --machine-type={node_pool.machine_type} \\
+                --tpu-topology={node_pool.tpu_topology}
+            """
+  if ignore_failure:
+    command += " 2>&1 || true"
+
+  process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+  logger.debug("STDOUT message: %s", process.stdout)
+  logger.debug("STDERR message: %s", process.stderr)
+
+
+@task
+def delete(node_pool: Info) -> None:
+  """Deletes the GKE node pool using gcloud command."""
+
+  command = f"""
+                gcloud container node-pools delete {node_pool.node_pool_name} \\
+                --project {node_pool.project_id} \\
+                --cluster {node_pool.cluster_name} \\
+                --location {node_pool.location} \\
+                --quiet
+            """
+
+  process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+  logger.debug("STDOUT message: %s", process.stdout)
+  logger.debug("STDERR message: %s", process.stderr)
+
+
+def list_nodes(node_pool: Info) -> List[str]:
+  """Lists all node names in the specified GKE node pool.
+
+  It queries GKE and Compute APIs and parses instance group URLs
+  to extract VM instance names.
+
+  Args:
+      node_pool: An instance of the Info class that encapsulates
+                   the configuration and metadata of a GKE node pool.
+  Returns:
+      A list of node names within the specified GKE node pool.
+  Raises:
+      RuntimeError: If no instance groups or zone are found for the node pool.
+  """
+  credentials, _ = auth.default()
+  container_client = discovery.build(
+      "container", "v1", credentials=credentials, cache_discovery=False
+  )
+  compute_client = discovery.build(
+      "compute", "v1", credentials=credentials, cache_discovery=False
+  )
+
+  nodepool_path = (
+      f"projects/{node_pool.project_id}/locations/{node_pool.location}"
+      f"/clusters/{node_pool.cluster_name}/nodePools/{node_pool.node_pool_name}"
+  )
+  nodepool = (
+      container_client.projects()
+      .locations()
+      .clusters()
+      .nodePools()
+      .get(name=nodepool_path)
+      .execute()
+  )
+
+  instance_group = nodepool.get("instanceGroupUrls", [])
+  if not instance_group:
+    raise RuntimeError(
+        f"No instance groups found for node pool {node_pool.node_pool_name}."
+    )
+
+  node_names = []
+
+  for url in instance_group:
+    # Extract the the name of an instance group from an URL like this:
+    # https://www.googleapis.com/compute/v1/projects/tpu-prod-env-one-vm/zones/asia-northeast1-b/instanceGroups/gke-yuna-xpk-v6e-2-yuna-xpk-v6e-2-np--b3a745c7-grp
+    # in which, `gke-yuna-xpk-v6e-2-yuna-xpk-v6e-2-np--b3a745c7-grp` is the of the instance group
+    match = re.search(r"instanceGroupManagers/([\w-]+)", url)
+    if not match:
+      logging.warning("Could not parse instance group URL: %s", url)
+      continue
+
+    ig_name = match.group(1)
+
+    instances = (
+        compute_client.instanceGroups()
+        .listInstances(
+            project=node_pool.project_id,
+            zone=node_pool.node_locations,
+            instanceGroup=ig_name,
+            body={"instanceState": "ALL"},
+        )
+        .execute()
+    )
+
+    for instance_item in instances.get("items", []):
+      instance_url = instance_item["instance"]
+      # Extract the {node_name} segments from an URL like this:
+      # https://www.googleapis.com/compute/v1/projects/<project>/zones/<zone>/instances/<node_name>
+      # in which, `gke-tpu-b3a745c7-08bk` is the name of the node
+      node_name = re.search(r"gke[\w-]+", instance_url).group()
+      if node_name:
+        node_names.append(node_name)
+      else:
+        logging.warning(
+            "Could not extract node name from URL: %s", instance_url
+        )
+  return node_names
+
+
+@task
+def delete_one_random_node(node_pool: Info) -> None:
+  """Delete one random node from the specified GKE node pool.
+
+  This function first lists all nodes under the given node pool,
+  then randomly selects one node and deletes it.
+
+  Args:
+      node_pool: An instance of the Info class that encapsulates
+                   the configuration and metadata of a GKE node pool.
+
+  Raises:
+      ValueError: If no nodes are found in the specified node pool.
+  """
+
+  nodes_list = list_nodes(node_pool)
+  if not nodes_list:
+    raise ValueError(
+        f"No nodes found in node pool '{node_pool.node_pool_name}'. "
+        "Cannot proceed with node deletion."
+    )
+
+  node_to_delete = random.choice(nodes_list)
+  logging.info(
+      "Randomly selected node for deletion: %s",
+      node_to_delete,
+  )
+
+  command = f"""
+                gcloud compute instances delete {node_to_delete} \\
+                    --project={node_pool.project_id} \\
+                    --zone={node_pool.node_locations} \\
+                    --quiet
+            """
+
+  process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+  logger.debug("STDOUT message: %s", process.stdout)
+  logger.debug("STDERR message: %s", process.stderr)
+
+
+def _query_status_metric(node_pool: Info) -> Status:
+  """Queries the latest status of the specified GKE node pool.
+
+  This function retrieves the status by querying the metric
+  "kubernetes.io/node_pool/status" via the Google Cloud Monitoring API.
+
+  Args:
+      node_pool: An instance of the Info class that encapsulates
+                   the configuration and metadata of a GKE node pool.
+
+  Returns:
+      A `Status` enum representing the latest status of the node pool.
+  """
+  monitoring_client = monitoring_v3.MetricServiceClient()
+  project_name = f"projects/{node_pool.project_id}"
+  now = int(time.time())
+  request = monitoring_v3.ListTimeSeriesRequest(
+      name=project_name,
+      filter=(
+          'metric.type="kubernetes.io/node_pool/status" '
+          f'resource.labels.project_id = "{node_pool.project_id}" '
+          f'resource.labels.cluster_name = "{node_pool.cluster_name}" '
+          f'resource.labels.node_pool_name = "{node_pool.node_pool_name}"'
+      ),
+      interval=types.TimeInterval(
+          {
+              "end_time": {"seconds": now},
+              # Metrics are sampled every 60s and stored in the GCP backend,
+              # but it may take up to 2 minutes for the data to become
+              # available on the client side.
+              # Therefore, a longer time interval is necessary.
+              # A 5-minute window is an arbitrary but sufficient choice to
+              # ensure we can retrieve the latest metric data.
+              "start_time": {"seconds": now - 300},
+          }
+      ),
+      view="FULL",
+  )
+
+  # A single query to the Monitoring API can return multiple TimeSeries objects,
+  # especially if the 'status' label changed within the time window (e.g., from
+  # 'PROVISIONING' to 'RUNNING').
+  #
+  # To robustly find the absolute latest status, this block first aggregates all
+  # data points from all series into a single flat list ('records'). It then
+  # finds the record with the maximum timestamp from this list to ensure the
+  # true latest status is identified.
+  time_series_data = monitoring_client.list_time_series(request)
+  records = []
+  for series in time_series_data:
+    np_status = series.metric.labels.get("status", "unknown").upper()
+    for point in series.points:
+      end_ts_dt = point.interval.end_time
+      records.append((end_ts_dt, np_status))
+  if not records:
+    return Status.UNKNOWN
+
+  _, latest_status = max(records, key=lambda r: r[0])
+
+  return Status.from_str(latest_status)
+
+
+@task.sensor(poke_interval=60, timeout=600, mode="reschedule")
+def wait_for_status(
+    node_pool: Info,
+    status: Status,
+    **context,
+) -> bool:
+  """Waits for the node pool to enter the target status.
+
+  This is a task waits for the node pool to enter the target status by querying
+  the status metric and comparing it with the expected status.
+  defaults task poke interval to 60 seconds and timeout to 600 seconds.
+
+  Args:
+      node_pool: An instance of the Info class that encapsulates
+                   the configuration and metadata of a GKE node pool.
+      status: The target status to wait for, represented as a `Status` enum.
+      context: The Airflow context dictionary, which includes task metadata.
+  Returns:
+      A boolean indicating whether the node pool has reached the target status.
+  """
+  timeout = context["task"].timeout
+  logging.info(
+      "Waiting for node pool '%s' status to become '%s' within %s"
+      " seconds...",
+      node_pool.node_pool_name,
+      status.name,
+      timeout,
+  )
+
+  latest_status = _query_status_metric(node_pool)
+  return latest_status == status


### PR DESCRIPTION
# Description
This change adds a new DAG which automates the process of going through the lifecycle of a node pool and verifies whether the node pool status is reported correctly.

This DAG requires an existing cluster. It will create a node-pool under the specified cluster, and clean it up after the tests.

# Tests
  - Dag Name : gke_node_pool_status
  - Airflow test results: https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/gke_node_pool_status/grid?tab=graph

## Airflow/Composer
- GCP Composer name: `dennis-airflow-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`
 
## Required Variables
- **Cluster Information** (This DAG requires an existing cluster)
  - `PROJECT_ID`: The GCP project ID where the cluster resides. (Default to _**tpu-prod-env-one-vm**_)
  - `CLUSTER_NAME`: The name of the target GKE cluster. (Default to _**yuna-xpk-v6e-2**_)
  - `LOCATION`: The region of the GKE cluster. (Default to _**asia-northeast1**_)
- **Node Pool Configurations**
  - `NODE_POOL_NAME`: The base name for the new node pool. (Default to _**yuna-v6e-autotest**_)
  - `NODE_LOCATIONS`: The zone for the nodes in the normal test path. (Default to _**asia-northeast1-b**_)
  - `NUM_NODES`: The number of nodes to create in the pool. (Default to _**4**_)
  - `MACHINE_TYPE`: The machine type for the GKE nodes. (Default to _**ct6e-standard-4t**_)
  - `TPU_TOPOLOGY`: The TPU topology for the node pool. (Default to _**4x4**_)
  - `ERROR_NODE_LOCATIONS`: An invalid zone used to intentionally trigger an error state for testing. (Default to _**asia-east1-c**_)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.