### PR TITLE
fix: change GPU_A3PLUS_CLUSTER zone to US_EAST5_A

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -303,7 +303,7 @@ class XpkClusters:
       device_version=GpuVersion.XPK_H100_MEGA,
       core_count=8,
       project=Project.SUPERCOMPUTER_TESTING.value,
-      zone=Zone.AUSTRALIA_SOUTHEAST1_C.value,
+      zone=Zone.US_EAST5_A.value,
   )
   CPU_M1_MEGAMEM_96_CLUSTER = XpkClusterConfig(
       name="m1-megamem-96-shared",


### PR DESCRIPTION
GPU_A3PLUS_CLUSTER previously set to AUSTRALIA_SOUTHEAST1_C, but A3PLUS is only available in US_EAST5_A (also B and C).

# Description

The GPU_A3PLUS_CLUSTER was previously set to a zone where the cluster is not available.
Updated the zone to US_EAST5_A, which is the correct location for the GPU_A3PLUS_CLUSTER  cluster.

# Tests

Tests were conducted using maxtext_moe_gpu_e2e: [link](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_moe_gpu_e2e/grid?tags=maxtext&search=maxtext_moe_gpu_e2e&dag_run_id=scheduled__2025-07-19T11%3A00%3A00%2B00%3A00&task_id=maxtext-candidate-mixtral-8x7b-1node-h100-mega-80gb-8.run_model.launch_workload.run_workload&tab=logs)



before: [link](https://paste.googleplex.com/6041758605246464)
after: [link](https://paste.googleplex.com/4976061120774144)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [ ] I have made or will make corresponding changes to the doc if needed.