### PR TITLE
Move sft and checkpointing dags to v5p cluster

### DIFF
--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -52,7 +52,7 @@ with models.DAG(
         'bash end_to_end/tpu/test_sft_trainer.sh',
     )
     maxtext_v4_configs_test = gke_config.get_gke_config(
-        cluster=XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
+        cluster=XpkClusters.TPU_V5P_8_CLUSTER,
         time_out_in_min=60,
         test_name=f'sft-trainer-{mode.value}',
         run_model_cmds=command,


### PR DESCRIPTION
# Description

Move DAGS: `maxtext_sft_trainer` and `maxtext_checkpointing` to v5p-8 cluster

# Tests
Tested on local airflow server

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.