### PR TITLE
Change the mechanism to trigger the alert plugin by DAG

### DIFF
--- a/dags/examples/always_fail.py
+++ b/dags/examples/always_fail.py
@@ -35,7 +35,6 @@ with models.DAG(
     schedule=None,
     tags=[
         "test_dag",
-        "on_failure_alert",  # Add this to enable DagRunListener
     ],
     catchup=False,
     default_args={

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,7 +14,7 @@ If you want your DAG to **trigger this plugin**, add your DAG ID as a new line i
 
 ##### Disabling the Plugin for a DAG
 
-If you want your DAG to **never trigger this plugin**, add your DAG ID as a new line in **plugins/block_list.txt**. This block list is intended to prevent repeated issue postings for DAGs that cannot be resolved at the moment.
+To prevent your DAG from ever triggering this plugin, add your DAG ID as a new line in **plugins/block_list.txt**. This list is intended to avoid repeated issue postings for DAGs that are not currently resolvable.
 
 > **Note:** Each DAG ID should be placed on its own line, without extra spaces or quotes.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,7 +14,7 @@ If you want your DAG to **trigger this plugin**, add your DAG ID as a new line i
 
 ##### Disabling the Plugin for a DAG
 
-If you want your DAG to **never trigger this plugin**, add your DAG ID as a new line in **plugins/block_list.txt**.
+If you want your DAG to **never trigger this plugin**, add your DAG ID as a new line in **plugins/block_list.txt**. This block list is intended to prevent repeated issue postings for DAGs that cannot be resolved at the moment.
 
 > **Note:** Each DAG ID should be placed on its own line, without extra spaces or quotes.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,18 +4,29 @@ The "on_failure_actions" plugin listens to the DAGs run results and takes action
 To leverage the "on_failure_actions" plugin, ensure the following conditions are met:
 
 ### 1.  **DAG Opt-In:**
-Each DAG intended to utilize this feature **must include the `"on_failure_alert"` tag** within its DAG definition. DAGs without this specific tag will be ignored by the plugin's failure-handling logic, and no GitHub issue will be filed for their failures.
+#### Plugin Activation Instructions
 
-    with DAG(
-        dag_id='my_critical_dag',
-        # ... other DAG parameters ...
-        tags = [
-                   'data_ingestion',
-                   'critical',
-                   'on_failure_alert' # <--- Add this tag
-               ],
-    ) as dag:
-        # ... tasks ...
+By default, this plugin is **disabled** for all DAGs.
+
+##### Enabling the Plugin for a DAG
+
+If you want your DAG to **trigger this plugin**, add your DAG ID as a new line in **plugins/allow_list.txt**.
+
+##### Disabling the Plugin for a DAG
+
+If you want your DAG to **never trigger this plugin**, add your DAG ID as a new line in **plugins/block_list.txt**.
+
+> **Note:** Each DAG ID should be placed on its own line, without extra spaces or quotes.
+
+> **Note:** The priority of block list is higher than the one of allow list.
+
+##### Example
+
+```
+<DAG_ID 1>
+<DAG_ID 2>
+...
+```
 
 ### 2.  **GitHub Owner Mapping:**
 For accurate issue assignment, ensure that the `owner` property defined for tests within your DAGs corresponds directly to valid **GitHub usernames**. The plugin will collect unique test owners from the failed DAG and attempt to assign the GitHub issue to these users.

--- a/plugins/allow_list.txt
+++ b/plugins/allow_list.txt
@@ -1,1 +1,6 @@
 on_failure_actions_trigger
+maxtext_sft_trainer
+maxtext_configs_aot
+maxtext_convergence
+maxtext_end_to_end
+maxtext_profiling

--- a/plugins/allow_list.txt
+++ b/plugins/allow_list.txt
@@ -1,0 +1,1 @@
+on_failure_actions_trigger

--- a/plugins/on_failure_actions.py
+++ b/plugins/on_failure_actions.py
@@ -17,8 +17,8 @@ from google.cloud import secretmanager
 
 from urllib import parse
 
-PROJECT_ID = "cloud-ml-auto-solutions"
-REPO_NAME = "GoogleCloudPlatform/ml-auto-solutions"
+PROJECT_ID = "cienet-cmcs"
+REPO_NAME = "CIeNET-International/ml-auto-solutions-2"
 SECRET_MANAGER = (
     "airflow-connections-"
     + os.environ.get("COMPOSER_ENVIRONMENT", default="ml-automation-solutions")
@@ -167,14 +167,6 @@ class DagRunListener:
 
     try:
       # Only DAGs with the 'on_failure_alert' tag will be processed.
-      if "on_failure_alert" not in dag_run.dag.tags:
-        logging.info(
-            f"[{self.log_prefix}] DAG {dag_run.dag_id} isn't enabled 'on_failure_alert' by tags. Return"
-        )
-        return
-      logging.info(
-          f"[{self.log_prefix}] DAG run {dag_run.dag_id} is enabled 'on_failure_alert'"
-      )
 
       failed_task_instances = [
           ti for ti in dag_run.task_instances if ti.state == "failed"

--- a/plugins/on_failure_actions.py
+++ b/plugins/on_failure_actions.py
@@ -177,6 +177,7 @@ class DagRunListener:
     logging.info(f"[{self.log_prefix}] msg: {msg}")
 
     try:
+      # A DAG would trigger the following logic if the DAG ID is in allow list and not in block list.
       if not DagRunListener.is_in_allow_list(
           dag_run.dag_id
       ) or DagRunListener.is_in_block_list(dag_run.dag_id):

--- a/plugins/on_failure_actions.py
+++ b/plugins/on_failure_actions.py
@@ -13,17 +13,19 @@ from airflow.models import DagRun, TaskInstance
 from airflow.plugins_manager import AirflowPlugin
 from github import Github, Auth
 from github.Issue import Issue
-from google.cloud import secretmanager
+from google.cloud import secretmanager, storage
 
 from urllib import parse
 
-PROJECT_ID = "cienet-cmcs"
-REPO_NAME = "CIeNET-International/ml-auto-solutions-2"
+PROJECT_ID = "cloud-ml-auto-solutions"
+REPO_NAME = "GoogleCloudPlatform/ml-auto-solutions"
 SECRET_MANAGER = (
     "airflow-connections-"
     + os.environ.get("COMPOSER_ENVIRONMENT", default="ml-automation-solutions")
     + "-github_app"
 )
+ALLOW_LIST_PATH = "plugins/allow_list.txt"
+BLOCK_LIST_PATH = "plugins/block_list.txt"
 
 
 def get_github_client() -> Github:
@@ -130,6 +132,15 @@ def create_comment(issue, body):
   issue.create_comment(body=body)
 
 
+def read_txt_from_gcs(bucket_name: str, blob_name: str) -> set[str]:
+  storage_client = storage.Client()
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(blob_name)
+  content = blob.download_as_text(encoding="utf-8")
+  lines = [line.strip() for line in content.splitlines() if line.strip()]
+  return set(lines)
+
+
 """
 Airflow Listener class to handle DAG run failures.
 
@@ -166,7 +177,13 @@ class DagRunListener:
     logging.info(f"[{self.log_prefix}] msg: {msg}")
 
     try:
-      # Only DAGs with the 'on_failure_alert' tag will be processed.
+      if not DagRunListener.is_in_allow_list(
+          dag_run.dag_id
+      ) or DagRunListener.is_in_block_list(dag_run.dag_id):
+        logging.info(
+            f"[{self.log_prefix}] DAG {dag_run.dag_id} didn't enable plugin. Return"
+        )
+        return
 
       failed_task_instances = [
           ti for ti in dag_run.task_instances if ti.state == "failed"
@@ -283,6 +300,21 @@ class DagRunListener:
     response = requests.get(request_endpoint, headers=headers)
     configs = response.json()
     return configs["config"]["airflowUri"]
+
+  @staticmethod
+  def is_in_allow_list(dag_id: str):
+    logging.info(f"[DagRunListener] BUCKET {os.environ.get('GCS_BUCKET')}")
+    allow_list = read_txt_from_gcs(
+        os.environ.get("GCS_BUCKET"), ALLOW_LIST_PATH
+    )
+    return True if dag_id in allow_list else False
+
+  @staticmethod
+  def is_in_block_list(dag_id: str):
+    block_list = read_txt_from_gcs(
+        os.environ.get("GCS_BUCKET"), BLOCK_LIST_PATH
+    )
+    return True if dag_id in block_list else False
 
 
 class ListenerPlugins(AirflowPlugin):


### PR DESCRIPTION
# Description

To decouple the development of DAGs and the plugin, we modified the logic of the alert plugin.
Read the allow list and block list in the plugin folder to trigger.
In addition, I have added the DAGs Alex mentioned into allow_list.txt.

# Tests

Manual test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.