### PR TITLE
update upload-test.sh and remove default allowed DAG

### DIFF
--- a/plugins/allow_list.txt
+++ b/plugins/allow_list.txt
@@ -1,6 +1,1 @@
 on_failure_actions_trigger
-maxtext_sft_trainer
-maxtext_configs_aot
-maxtext_convergence
-maxtext_end_to_end
-maxtext_profiling

--- a/scripts/upload-tests.sh
+++ b/scripts/upload-tests.sh
@@ -31,7 +31,6 @@ if [[ "$GCS_DAGS_FOLDER" == */dags ]]; then
     ROOT_PATH="${GCS_DAGS_FOLDER%/dags}"
 fi
 
-gsutil -m rsync -r -d -x '.*\.md$' plugins "$ROOT_PATH"/plugins
-
+gsutil -m rsync -c -d -r -x '.*\.(md|txt)$' plugins "$ROOT_PATH"/plugins
 
 echo "Successfully uploaded tests."


### PR DESCRIPTION
# Description
Currently the allowed and blocked list must be updated via a PR, as direct changes are overwritten by Cloud Build. To support manual edits, we excluded the *.txt files (containing allow_list and block_list) from the rsync scope. I also removed the default allowed DAG.

# Tests

Manual Test

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.