### PR TITLE
Reduce SFT fine-tuning steps to avoid timeout

### DIFF
--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -47,7 +47,7 @@ with models.DAG(
         'export PRE_TRAINED_MODEL_TOKENIZER=meta-llama/Llama-2-7b-chat-hf',
         'export PRE_TRAINED_MODEL_CKPT_PATH=gs://maxtext-model-checkpoints/llama2-7b-chat/scanned/0/items',
         f'export BASE_OUTPUT_DIRECTORY={base_output_directory}',
-        'export STEPS=2500',
+        'export STEPS=1000',
         'export PROMPT="Suggest some famous landmarks in London."',
         'bash end_to_end/tpu/test_sft_trainer.sh',
     )


### PR DESCRIPTION
# Description

This change reduces the number of fine-tuning steps for the Supervised Fine-Tuning tests. This is necessary to ensure that the tests can complete within the DAG's specified timeout (60 minutes), preventing job failures.

# Tests

Tested with local airflow server: http://shortn/_p1IIKMCVan

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.