### PR TITLE
Correct AOT test A3 core number

### DIFF
--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -109,10 +109,10 @@ with models.DAG(
     )
 
   # GPU AoT tests
-  cmd = f"bash MaxText/configs/a3/llama_2_7b/16vm.sh EXECUTABLE=train_compile M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=16"
+  cmd = "bash MaxText/configs/a3/llama_2_7b/8vm.sh EXECUTABLE=train_compile M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=8"
   stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
       time_out_in_min=300,
-      test_name=f"maxtext-aot-a3-stable",
+      test_name="maxtext-aot-a3-stable",
       run_model_cmds=(cmd,),
       num_slices=1,
       cluster=XpkClusters.GPU_A3PLUS_CLUSTER,


### PR DESCRIPTION
# Description

Correct AOT test A3 core number from 16 to 8.

# Tests


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.