### PR TITLE
Update tree_map API call

### DIFF
--- a/dags/multipod/legacy_tests/gpt1-like.py
+++ b/dags/multipod/legacy_tests/gpt1-like.py
@@ -153,7 +153,7 @@ multiply_layers_and_grad = jax.value_and_grad(
 
 def training_loop(in_act, in_layers):
   _, grad_layers = multiply_layers_and_grad(in_act, in_layers)
-  out_layers = jax.tree_map(
+  out_layers = jax.tree_util.tree_map(
       lambda param, grad: param - 1e-4 * grad, in_layers, grad_layers[0]
   )
   return out_layers


### PR DESCRIPTION
# Description

Fixes the issue of `AttributeError: jax.tree_map was removed in JAX v0.6.0: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).` in MaxText legacy test

# Tests

Ran locally ` python3 gpt1-like.py` and it works

**Instruction and/or command lines to reproduce your tests:** ...
` python3 gpt1-like.py`

**List links for your tests (use go/shortn-gen for any internal link):** ...
N/A
# 
Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.