### PR TITLE
fix get_cluster a3plus-benchmark

### DIFF
--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -1069,7 +1069,7 @@ def get_gcs_automation_repo_path(tmpdir):
 
 def get_cluster(hardware: str = "a3ultra"):
   if hardware == "a3mega":
-    return "a3plus-benchmark", "australia-southeast1"
+    return "a3plus-benchmark", "us-east5"
   if hardware == "a3ultra":
     return "imo-a3ultra", "europe-west1"
   if hardware == "a4":


### PR DESCRIPTION
# Description

The hardcoded region in the get_cluster function within `common_utils.py` has been changed to us-east5, which is a valid and available region for a3plus-benchmark. (A similar fix was previously applied to `vm_resource.py`, and this change extends the correction to `common_utils.py`)

# Tests

before: [link](https://paste.googleplex.com/4788042308780032)

after: [link](https://paste.googleplex.com/5387499215781888)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.