### PR TITLE
Add maxtext tag into DAGs under map_reproducibility folder

### DIFF
--- a/dags/map_reproducibility/a3ultra/llama_3_1_405b_maxtext.py
+++ b/dags/map_reproducibility/a3ultra/llama_3_1_405b_maxtext.py
@@ -49,6 +49,7 @@ with models.DAG(
         "xlml",
         "regressiontests",
         "a3ultra",
+        "maxtext",
     ],
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,

--- a/dags/map_reproducibility/a3ultra/llama_3_1_70b_maxtext.py
+++ b/dags/map_reproducibility/a3ultra/llama_3_1_70b_maxtext.py
@@ -49,6 +49,7 @@ with models.DAG(
         "xlml",
         "regressiontests",
         "a3ultra",
+        "maxtext",
     ],
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,

--- a/dags/map_reproducibility/a3ultra/mixtral_8_7b_maxtext.py
+++ b/dags/map_reproducibility/a3ultra/mixtral_8_7b_maxtext.py
@@ -55,6 +55,7 @@ with models.DAG(
         "xlml",
         "regressiontests",
         "a3ultra",
+        "maxtext",
     ],
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,

--- a/dags/map_reproducibility/a4/llama3_1_70b/maxtext.py
+++ b/dags/map_reproducibility/a4/llama3_1_70b/maxtext.py
@@ -47,6 +47,7 @@ with models.DAG(
         "xlml",
         "regressiontests",
         "a3ultra",
+        "maxtext",
     ],
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,

--- a/dags/map_reproducibility/a4/llama_3_1_405b/maxtext.py
+++ b/dags/map_reproducibility/a4/llama_3_1_405b/maxtext.py
@@ -46,6 +46,7 @@ with models.DAG(
         "xlml",
         "regressiontests",
         "a3ultra",
+        "maxtext",
     ],
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,

--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_benchmarking_dags.py
@@ -42,6 +42,7 @@ DAG_TAGS = [
     "internal",
     "regressiontests",
     "a3mega",
+    "maxtext",
 ]
 
 # Create DAGs for each configuration

--- a/dags/map_reproducibility/internal_runs/a3mega_maxtext_inference_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3mega_maxtext_inference_benchmarking_dags.py
@@ -40,6 +40,7 @@ DAG_TAGS = [
     "regressiontests",
     "a3mega",
     "inference",
+    "maxtext",
 ]
 
 # Create DAGs for each configuration

--- a/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a3ultra_maxtext_benchmarking_dags.py
@@ -42,6 +42,7 @@ DAG_TAGS = [
     "internal",
     "regressiontests",
     "a3ultra",
+    "maxtext",
 ]
 
 

--- a/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
+++ b/dags/map_reproducibility/internal_runs/a4_maxtext_benchmarking_dags.py
@@ -42,6 +42,7 @@ DAG_TAGS = [
     "internal",
     "regressiontests",
     "a4",
+    "maxtext",
 ]
 
 

--- a/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
+++ b/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
@@ -28,7 +28,7 @@ SCHEDULED_TIME = None
 with models.DAG(
     dag_id="maxtext_profiling_vertex_ai_tensorboard",
     schedule=SCHEDULED_TIME,
-    tags=[],
+    tags=["maxtext"],
     start_date=datetime.datetime(2024, 6, 1),
     catchup=False,
     concurrency=2,


### PR DESCRIPTION
Adding the "maxtext" tag to MaxText training tasks for A3 Mega, A3 Ultra, and A4 series within the map_reproducibility folder.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.