### PR TITLE
Extend test coverage for DAGs that validate interruption count

### DIFF
--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -9,6 +9,7 @@ from typing import List
 from airflow import models
 from airflow.decorators import task
 from airflow.exceptions import AirflowSkipException
+from airflow.utils.task_group import TaskGroup
 from dags.common.vm_resource import Project
 from dags.map_reproducibility.utils.constants import Schedule
 from dags.multipod.configs.common import Platform
@@ -520,34 +521,49 @@ def create_interruption_dag(
         both sources to ensure they match.
       """,
   ) as dag:
-    configs = Configs(
-        project_id=models.Variable.get(
-            'INTERRUPTION_PROJECT_ID',
-            default_var=Project.TPU_PROD_ENV_ONE_VM.value,
-        ),
-        platform=platform,
-        interruption_reason=interruption_reason,
-    )
+    for project in Project:
+      match project:
+        case Project.TPU_PROD_ENV_AUTOMATED | Project.CLOUD_TPU_INFERENCE_TEST:
+          # Production composer lacks permission for these projects; ignore them.
+          continue
+        case _:
+          with TaskGroup(
+              group_id=f'validation_for_{project.value}',
+              tooltip=f'Validation pipeline for Project ID: {project.value}',
+          ) as group:
+            configs = Configs(
+                project_id=project.value,
+                platform=platform,
+                interruption_reason=interruption_reason,
+            )
 
-    @task
-    def fetch_interruption_metric_records_task(
-        configs: Configs,
-        proper_time_range: TimeRange,
-    ) -> List[EventRecord]:
-      return fetch_interruption_metric_records(configs, proper_time_range)
+            @task
+            def fetch_interruption_metric_records_task(
+                configs: Configs,
+                proper_time_range: TimeRange,
+            ) -> List[EventRecord]:
+              return fetch_interruption_metric_records(
+                  configs, proper_time_range
+              )
 
-    proper_time_range = determine_time_range(configs)
-    metric_records = fetch_interruption_metric_records_task(
-        configs,
-        proper_time_range,
-    )
-    log_records = fetch_interruption_log_records(
-        configs,
-        proper_time_range,
-    )
-    check_event_count = validate_interruption_count(metric_records, log_records)
+            proper_time_range = determine_time_range(configs)
+            metric_records = fetch_interruption_metric_records_task(
+                configs,
+                proper_time_range,
+            )
+            log_records = fetch_interruption_log_records(
+                configs,
+                proper_time_range,
+            )
+            check_event_count = validate_interruption_count(
+                metric_records, log_records
+            )
 
-    proper_time_range >> [metric_records, log_records] >> check_event_count
+            (
+                proper_time_range
+                >> [metric_records, log_records]
+                >> check_event_count
+            )
 
     return dag
 


### PR DESCRIPTION
# Description

Improve the existing validate_interruption_count_* DAG.

This change extends the data capture to include more projects instead of just the tpu-prod-env-one-vm project.

# Tests

GCE DAGs

- **validate_interruption_count_gce_bare_metal_preemption**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_bare_metal_preemption/grid)
- **validate_interruption_count_gce_defragmentation**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_defragmentation/grid)
- **validate_interruption_count_gce_eviction**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_eviction/grid)
- **validate_interruption_count_gce_host_error**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_host_error/grid)
- **validate_interruption_count_gce_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_hwsw_maintenance/grid)
- **validate_interruption_count_gce_migrate_on_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_migrate_on_hwsw_maintenance/grid)
- **validate_interruption_count_gce_other**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_other/grid)

GKE DAGs

- **validate_interruption_count_gke_bare_metal_preemption**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_bare_metal_preemption/grid)
- **validate_interruption_count_gke_defragmentation**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_defragmentation/grid)
- **validate_interruption_count_gke_eviction**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_eviction/grid)
- **validate_interruption_count_gke_host_error**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_host_error/grid)
- **validate_interruption_count_gke_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_hwsw_maintenance/grid)
- **validate_interruption_count_gke_migrate_on_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_migrate_on_hwsw_maintenance/grid)
- **validate_interruption_count_gke_other**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_other/grid)


# Airflow/Composer

- GCP Composer name: `dennis-airflow-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
