### PR TITLE
Fix typo in MaxText llama2-7b e2e test

### DIFF
--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -48,7 +48,7 @@ with models.DAG(
   test_models_tpu = {
       "llama2-7b": {
           "owner": test_owner.MOHIT_K,
-          "commands": ["bash end_tp_end/tpu/llama2/7b/test_llama2_7b.sh"],
+          "commands": ["bash end_to_end/tpu/llama2/7b/test_llama2_7b.sh"],
       },
       "mistral-7b": {
           "owner": test_owner.MOHIT_K,


### PR DESCRIPTION
# Description

Fix a small typo in the MaxText llama2-7b end_to_end tests. Seeing this error in the Airflow tests:

```
bash: end_tp_end/tpu/llama2/7b/test_llama2_7b.sh: No such file or directory
```

# Tests

Will let these tests run after merging and confirm they are working now

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.