### PR TITLE
Update candidate jaii dag

### DIFF
--- a/dags/sparsity_diffusion_devx/jax_ai_image_candidate_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_candidate_tpu_e2e.py
@@ -38,6 +38,7 @@ with models.DAG(
     ],
     start_date=datetime.datetime(2025, 7, 24),
     catchup=False,
+    schedule=None,
 ) as dag:
   current_datetime = config.get_current_datetime()
   maxtext_test_configs = {
@@ -58,12 +59,12 @@ with models.DAG(
 
   maxtext_docker_images = [(
       SetupMode.STABLE,
-      DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE,
+      "gcr.io/tpu-prod-env-multipod/maxtext_stable_stack_candidate:latest",
   )]
 
   maxdiffusion_docker_images = [(
       SetupMode.STABLE,
-      DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK_CANDIDATE,
+      "gcr.io/tpu-prod-env-multipod/maxdiffusion_stable_stack_candidate:latest",
   )]
 
   for accelerator, slices in maxtext_test_configs.items():

--- a/dags/sparsity_diffusion_devx/jax_ai_image_candidate_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_candidate_tpu_e2e.py
@@ -85,7 +85,7 @@ with models.DAG(
                 f"base_output_directory={gcs_bucket.BASE_OUTPUT_DIR}/maxtext/jax-stable-stack/automated/{current_datetime}",
             ),
             test_name=f"maxtext-jax-stable-stack-{mode.value}-{accelerator}-{slice_num}x",
-            docker_image=image.value,
+            docker_image=image,
             test_owner=test_owner.ROHAN_B,
         ).run_with_quarantine(quarantine_task_group)
 
@@ -109,6 +109,6 @@ with models.DAG(
                 f"output_dir={gcs_bucket.BASE_OUTPUT_DIR}/maxdiffusion-jax-stable-stack-{mode.value}-{accelerator}-{slice_num}/automated/{current_datetime}",
             ),
             test_name=f"maxdiffusion-jax-stable-stack-sdxl-{mode.value}-{accelerator}-{slice_num}x",
-            docker_image=image.value,
+            docker_image=image,
             test_owner=test_owner.ROHAN_B,
         ).run_with_quarantine(quarantine_task_group)


### PR DESCRIPTION
# Description

Currently the candidate JAII DAG should be manual trigger only, since we only want to run it to verify a newly created candidate image. However, right now it is running everyday causing the DAG to be red.

Also, we can set the image pulled to be latest instead of a specific day since this DAG will only be using the latest candidate image created.

# Tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.