### PR TITLE
Export dag_id in process_metrics for Global Uniqueness and DAG Params to DB Metadata

### DIFF
--- a/xlml/utils/metric.py
+++ b/xlml/utils/metric.py
@@ -606,11 +606,6 @@ def add_airflow_metadata(
 
     airflow_meta.append(
         bigquery.MetadataHistoryRow(
-            job_uuid=uuid, metadata_key="dag_id", metadata_value=dag_id
-        )
-    )
-    airflow_meta.append(
-        bigquery.MetadataHistoryRow(
             job_uuid=uuid, metadata_key="run_id", metadata_value=run_id
         )
     )
@@ -629,6 +624,19 @@ def add_airflow_metadata(
             metadata_value=airflow_dag_run_link,
         )
     )
+    airflow_meta.append(
+        bigquery.MetadataHistoryRow(
+            job_uuid=uuid, metadata_key="dag_id", metadata_value=dag_id
+        )
+    )
+    for key, value in context.get("params", {}).items():
+      airflow_meta.append(
+          bigquery.MetadataHistoryRow(
+              job_uuid=uuid,
+              metadata_key=f"param:{key}",
+              metadata_value=str(value),
+          )
+      )
 
     metadata[index].extend(airflow_meta)
   return metadata


### PR DESCRIPTION
# Description

* Export dag_id in process_metrics for Global Uniqueness:

   * The run_id is only unique within the scope of its current DAG run. To ensure global uniqueness for all emitted metrics, the dag_id is now exported in process_metrics in addition to the existing run_id.

* Export DAG Parameters to Database as Metadata:

  * The DAG parameters (dag_params) are essential for dynamically configuring benchmarks.

  * Exporting these parameters to the database as metadata allows the DAG trigger to pass a specific reference number. This reference number can then be used to easily query and retrieve related data from the database.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...
Triggered the workflow by using the Airflow UI Trigger button.

**List links for your tests (use go/shortn-gen for any internal link):** ...
  * http://shortn/_X83UfxOJcv
  * http://shortn/_3nWfqhUTVR

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.