### PR TITLE
change the data retrieval time range from 30 to 60 days for xlml dashboard

### DIFF
--- a/dags/dashboard/configs/export_config.py
+++ b/dags/dashboard/configs/export_config.py
@@ -91,7 +91,7 @@ TABLES: list[AirflowTable] = [
     AirflowTable(
         table_name="dag_run",
         time_field_for_filtering="updated_at",
-        time_frame="30 days",
+        time_frame="60 days",
         post_actions=[
             lambda df: dataframe_inplace_apply(df, "conf", safe_json)
         ],
@@ -107,7 +107,7 @@ TABLES: list[AirflowTable] = [
     AirflowTable(
         table_name="task_instance",
         time_field_for_filtering="updated_at",
-        time_frame="30 days",
+        time_frame="60 days",
         post_actions=[
             lambda df: dataframe_inplace_apply(df, "executor_config", safe_json)
         ],
@@ -116,7 +116,7 @@ TABLES: list[AirflowTable] = [
     AirflowTable(
         table_name="task_fail",
         time_field_for_filtering="start_date",
-        time_frame="30 days",
+        time_frame="60 days",
         post_actions=[lambda df: cast_int(df, "duration")],
     ),
     # Holds the rendered parameters and templates for each task instance.


### PR DESCRIPTION
To show more data on the XLML dashbaord, we need to extend the time frame of query statements.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.