### PR TITLE
Use jax nightly until new jax version releases

### DIFF
--- a/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
@@ -111,7 +111,7 @@ with models.DAG(
               f"output_dir={sdxl_base_output_dir}",
           ),
           test_name=sdxl_run_name_prefix,
-          docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK.value,
+          docker_image=DockerImage.MAXDIFFUSION_TPU_STABLE_STACK_NIGHTLY_JAX.value,
           test_owner=test_owner.PARAM_B,
           tensorboard_summary_config=sdxl_tensorboard_summary_config,
       ).run_with_name_gen_and_quarantine(
@@ -133,7 +133,7 @@ with models.DAG(
               f"LOSS_THRESHOLD=100",
           ),
           test_name=sdxl_nan_run_name_prefix,
-          docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK.value,
+          docker_image=DockerImage.MAXDIFFUSION_TPU_STABLE_STACK_NIGHTLY_JAX.value,
           test_owner=test_owner.PARAM_B,
           tensorboard_summary_config=sdxl_nan_tensorboard_summary_config,
       ).run_with_name_gen_and_quarantine(


### PR DESCRIPTION
# Description

Currently using latest stable jax release 0.7.2 is causing OOM issues in maxdiffusion workloads. We do not see the same issue in jax nightly, so we are upgrading the maxdiffusion DAG to use jax nightly until the next jax release.

# Tests

Similar MD workload in JAX AI Image DAG passs using the same image

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.