### PR TITLE
Refactor: Separate GPU AOT tests from the main AOT DAG

### DIFF
--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -107,15 +107,3 @@ with models.DAG(
         >> maxtext_v5e_configs_test
         >> maxtext_v5p_configs_test
     )
-
-  # GPU AoT tests
-  cmd = "bash src/MaxText/configs/a3/llama_2_7b/8vm.sh EXECUTABLE=train_compile M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=8"
-  stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
-      time_out_in_min=300,
-      test_name="maxtext-aot-a3-stable",
-      run_model_cmds=(cmd,),
-      num_slices=1,
-      cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
-      docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
-      test_owner=test_owner.NUOJIN_C,
-  ).run_with_quarantine(quarantine_task_group)

--- a/dags/multipod/maxtext_configs_aot_gpu.py
+++ b/dags/multipod/maxtext_configs_aot_gpu.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A DAG to run AOT compilation tests for MaxText model configs.
+"""
+import datetime
+from airflow import models
+from airflow.utils.task_group import TaskGroup
+from dags import composer_env
+from dags.common import test_owner
+from dags.common.vm_resource import GpuVersion, TpuVersion, Zone, DockerImage, XpkClusters
+from dags.multipod.configs import gke_config
+from dags.multipod.configs.common import SetupMode
+
+# Run once a day at 5 am UTC (9 pm PST / 10 pm PDT)
+SCHEDULED_TIME = "0 5 * * *" if composer_env.is_prod_env() else None
+
+
+with models.DAG(
+    dag_id="maxtext_configs_aot_gpu",
+    schedule=SCHEDULED_TIME,
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_devx",
+    ],
+    start_date=datetime.datetime(2024, 2, 19),
+    catchup=False,
+    concurrency=2,
+) as dag:
+  quarantine_task_group = TaskGroup(
+      group_id="Quarantine", dag=dag, prefix_group_id=False
+  )
+
+  # GPU AoT tests
+  cmd = "bash src/MaxText/configs/a3/llama_2_7b/8vm.sh EXECUTABLE=train_compile M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=8"
+  stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
+      time_out_in_min=300,
+      test_name="maxtext-aot-a3-stable",
+      run_model_cmds=(cmd,),
+      num_slices=1,
+      cluster=XpkClusters.GPU_A3PLUS_CLUSTER,
+      docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE_STACK.value,
+      test_owner=test_owner.NUOJIN_C,
+  ).run_with_quarantine(quarantine_task_group)


### PR DESCRIPTION
### Description
This PR refactors the `maxtext_configs_aot` DAG by splitting it into two more focused DAGs:
1.  **`maxtext_configs_aot`**: Now exclusively handles all TPU configuration tests.
2.  **`maxtext_configs_aot_gpu`**: A new DAG dedicated to running GPU AOT tests.

### Why is this change being made?
* **Isolation**: Separates TPU and GPU test runs, allowing them to be triggered, monitored, and re-run independently.

### Validation Summary

This refactor was tested in the `ml-automation-solutions-dev` environment. The TPU tests have been validated, while the GPU tests will be addressed later according to team priorities.

### Test Results

* **TPU DAG ([maxtext_configs_aot](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/maxtext_configs_aot_1014_1/grid?dag_run_id=manual__2025-10-14T07%3A21%3A00.243506%2B00%3A00)): Success ✅**
    * All test cases in the refactored TPU DAG passed successfully.

* **GPU DAG ( [maxtext_configs_aot_gpu](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/maxtext_configs_aot_gpu_1015/grid?search=maxtext_configs_aot_gpu_1015&dag_run_id=manual__2025-10-15T01%3A26%3A33.168612%2B00%3A00&task_id=maxtext-aot-a3-stable-h100-mega-80gb-8.run_model.launch_workload.run_workload&tab=logs)): Failed (Deprioritized) ⚠️**
    * The new, dedicated GPU DAG failed during its run.
    * **Next Steps:** Since the team's current focus is on TPU stability, this failure is acknowledged.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.