### PR TITLE
Correct the cluster used by tpu_info_format_validation_dags DAG to align with the standard cluster designated for tpu-observability project.

### DIFF
--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -317,7 +317,7 @@ with models.DAG(
           "TFV_PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
       ),
       cluster_name=models.Variable.get(
-          "TFV_CLUSTER_NAME", default_var="yuna-auto-testing"
+          "TFV_CLUSTER_NAME", default_var="tpu-observability-automation"
       ),
       node_pool_name=models.Variable.get(
           "TFV_NODE_POOL_NAME", default_var="tpu-info-fromat-test-v6e"


### PR DESCRIPTION
# Description

Correct the cluster used by `tpu_info_format_validation_dags` DAG to align with the standard cluster designated for tpu-observability project.


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.