### PR TITLE
Add a new dag that test EMC feature resume training from gcs

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -325,7 +325,8 @@ class DockerImage(enum.Enum):
 
   XPK_JAX_TEST = "gcr.io/cloud-ml-auto-solutions/xpk_jax_test:latest"
   MAXTEXT_TPU_JAX_ORBAX_HEAD = (
-      "gcr.io/cloud-tpu-multipod-dev/maxtext-orbax-custom:latest"
+      "gcr.io/cloud-tpu-multipod-dev/maxtext-orbax-custom:"
+      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   PYTORCH_NIGHTLY = (
       "us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/"

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -6,6 +6,7 @@ Validates the GCS checkpoints are restored as expected
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
@@ -88,7 +89,7 @@ with models.DAG(
     for test_config in test_configs:
       for slice_num in test_config.slices:
         wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done"
+            trigger_rule=TriggerRule.ALL_DONE
         )(test_config.cpc_config)
 
         apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
@@ -176,7 +177,8 @@ with models.DAG(
         )
         # Final CPC cleanup to ensure symmetric start/end
         wait_delete_cpc_final = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done", task_id="wait_delete_cpc_final"
+            trigger_rule=TriggerRule.ALL_DONE,
+            task_id="wait_delete_cpc_final",
         )(test_config.cpc_config).as_teardown(setups=apply_cpc)
 
         (

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -5,6 +5,7 @@ Validates the local checkpoints are restored as expected
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
@@ -86,7 +87,7 @@ with models.DAG(
     for test_config in test_configs:
       for slice_num in test_config.slices:
         wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done"
+            trigger_rule=TriggerRule.ALL_DONE
         )(test_config.cpc_config)
 
         apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
@@ -173,7 +174,8 @@ with models.DAG(
 
         # Final CPC cleanup to ensure symmetric start/end
         wait_delete_cpc_final = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done", task_id="wait_delete_cpc_final"
+            trigger_rule=TriggerRule.ALL_DONE,
+            task_id="wait_delete_cpc_final",
         )(test_config.cpc_config).as_teardown(setups=apply_cpc)
 
         (

--- a/dags/orbax/maxtext_emc_resume_gcs.py
+++ b/dags/orbax/maxtext_emc_resume_gcs.py
@@ -1,0 +1,262 @@
+"""
+A DAG to run MaxText multi-tier checkpointing tests.
+
+This DAG performs a series of tests to save and validate checkpoints
+for the MaxText model. It runs tests in two modes: one with the replicator
+service enabled (Multi-tier Checkpointing). The tests are executed on a TPU
+multi-pod cluster.
+"""
+
+import datetime
+
+from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
+
+from dags import composer_env
+from dags.common import test_owner
+from dags.common.vm_resource import XpkClusters
+from dags.multipod.configs import gke_config
+from dags.orbax.util import validation_util
+from dags.orbax.util import test_config_util
+from dags.orbax.util import checkpoint_util
+from xlml.utils.xpk import BRANCH_ABHINAV_MTC
+from xlml.utils.gke import zone_to_region
+
+SCHEDULE = "0 17 * * *" if composer_env.is_prod_env() else None
+DAG_TEST_NAME = "maxtext_emc_resume_from_gcs"
+
+with models.DAG(
+    dag_id=DAG_TEST_NAME,
+    start_date=datetime.datetime(2025, 6, 12),
+    schedule_interval=SCHEDULE,
+    catchup=False,
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "emergency_checkpointing",
+        "nightly",
+        "orbax",
+    ],
+    description="A DAG to test MaxText Emergency Checkpoint Manager GCS restore functionality.",
+    doc_md="""
+      # Emergency Checkpoint Manager GCS Restore Validation DAG
+
+      ### Description
+      This DAG (Directed Acyclic Graph) automates the process of validating
+      that the **Emergency Checkpoint Manager (ECM)** can successfully save
+      checkpoints to GCS and restore from them when local checkpoints are unavailable.
+
+      ### Test Scenario
+      The DAG tests the critical scenario where:
+      1. Training runs normally with emergency checkpoints saved to GCS
+      2. Local checkpoints are deleted (simulating failure/preemption)
+      3. Training resumes and successfully restores from GCS emergency checkpoints
+
+      ### Prerequisites
+      - An existing GKE cluster with the necessary CSI driver for RAM disk (`/local`).
+      - A GCS bucket with HNS (Hierarchical Namespace) enabled
+      - Emergency Checkpoint Manager functionality enabled
+
+      ### Test Flow
+      1. **Apply Configuration:** Deploy Checkpoint Configuration YAML to set up the test environment.
+      2. **Initial Training (0-100 steps):** Run MaxText with emergency checkpointing enabled
+         - Saves regular checkpoints to GCS every 25 steps (0, 25, 50, 75, 99)
+         - Saves local checkpoints to RAM disk for faster access
+      3. **Simulate Failure:** The initial training job completes, and its pods (with local checkpoints) are deleted.
+      4. **Resume Training (100-200 steps):** Continue training from where it left off
+         - A new job is started, which restores from the latest GCS checkpoint since local ones are gone.
+         - Training continues and saves additional checkpoints (100, 125, 150, 175, 199)
+      5. **Final Cleanup:** Clean up RAM disk resources
+      6. **Comprehensive Validation:**
+         - **Log Validation:** Verify checkpoint save/restore events in logs
+         - **GCS Restore Validation:** Confirm restoration from GCS occurred
+         - **File Validation:** Verify all expected checkpoint files exist in GCS
+
+      ### Key Parameters
+      - **checkpoint_period=25:** Regular checkpoint interval for GCS saves
+      - **local_checkpoint_period=20:** Local checkpoint interval for RAM disk
+      - **Initial training:** 100 steps, **Resume training:** 200 steps total
+      - **Emergency checkpointing:** Enabled throughout the test
+
+      ### Success Criteria
+      The test passes when:
+      1. All expected checkpoints are saved to GCS during initial training
+      2. Local checkpoints are successfully removed during cleanup
+      3. Training successfully resumes from GCS checkpoints (not from scratch)
+      4. All checkpoint files are verified to exist in the expected GCS locations
+      5. Log validation confirms proper save and restore events occurred
+    """,
+    concurrency=2,
+) as dag:
+  first_training_step = 100
+  second_training_step = 200
+  out_folder = "maxtext_emc_orbax_resume_gcs"
+
+  checkpointing = test_config_util.Checkpointing(
+      name="emc", enable_multi_tier_checkpointing=False
+  )
+
+  test_configs = [
+      test_config_util.TestConfig(
+          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          machine_type="ct5p-hightpu-4t",
+          accelerator="v5p-128",
+          slices=[2],
+          model_name="llama2-7b",
+          short_id="max-emc-resume-gcs",
+          steps=first_training_step,
+          local_checkpoint_period=20,
+          checkpoint_period=25,
+          base_dir=test_config_util.DEFAULT_BUCKET,
+      ),
+  ]
+
+  for mode, image in test_config_util.DOCKER_IMAGES:
+    for test_config in test_configs:
+      for slice_num in test_config.slices:
+        # We conditionally set the trigger_rule on the first task.
+        # If first task group failed the next one can execute.
+        wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
+            trigger_rule=TriggerRule.ALL_DONE
+        )(test_config.cpc_config)
+        apply_first_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
+
+        # Generate consistent run name for both training phases
+        run_name = validation_util.generate_run_name(
+            short_id=test_config.short_id,
+            checkpointing_type=checkpointing.name,
+            slice_number=slice_num,
+            accelerator=test_config.accelerator,
+        )
+
+        # First training phase - train to step 100
+        initial_workload_command = test_config.generate_workload_command(
+            checkpoint_dir=test_config_util.DEFAULT_RAM_DISK,
+            run_name=run_name,
+            slice_num=slice_num,
+            out_folder=out_folder,
+            enable_multi_tier_checkpointing=checkpointing.enable_multi_tier_checkpointing,
+        )
+
+        start_time = validation_util.generate_timestamp.override(
+            task_id="generate_start_time"
+        )()
+
+        initial_training_run = gke_config.get_gke_config(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}",
+            run_model_cmds=initial_workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+        ).run(
+            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+            mtc_enabled=True,
+            xpk_branch=BRANCH_ABHINAV_MTC,
+            skip_post_process=True,
+        )
+
+        wait_delete_first_cpc = checkpoint_util.wait_for_cpc_deletion.override(
+            trigger_rule=TriggerRule.ALL_DONE
+        )(test_config.cpc_config)
+        apply_second_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
+
+        # Second training phase - continue from checkpoint and reach step 200
+        test_config.steps = second_training_step
+        resume_workload_command = test_config.generate_workload_command(
+            checkpoint_dir=test_config_util.DEFAULT_RAM_DISK,
+            run_name=run_name,
+            slice_num=slice_num,
+            out_folder=out_folder,
+            enable_multi_tier_checkpointing=checkpointing.enable_multi_tier_checkpointing,
+        )
+
+        resume_training_run = gke_config.get_gke_config(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}-restore",
+            run_model_cmds=resume_workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+        ).run(
+            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+            mtc_enabled=True,
+            xpk_branch=BRANCH_ABHINAV_MTC,
+            skip_post_process=True,
+        )
+
+        end_time = validation_util.generate_timestamp.override(
+            task_id="generate_end_time"
+        )()
+
+        # Validation steps for entire training process (0 to 200)
+        # Get validation steps for the full 200-step run
+        steps_to_validate = test_config.generate_step_to_validate(
+            is_local=False
+        )
+        # Add the end of the first training phase (step 99) to the list
+        steps_to_validate.append(100 - 1)
+        steps_to_validate = sorted(list(set(steps_to_validate)))
+
+        # Validate that GCS restore happened during the second training run
+        validate_gcs_restore = (
+            validation_util.validate_restored_correct_checkpoint(
+                project_id=test_config.cluster.project,
+                location=zone_to_region(test_config.cluster.zone),
+                cluster_name=test_config.cluster.name,
+                pod_pattern="max.*-job-0-0",
+                interrupt_at_step=first_training_step - 1,
+                start_time=start_time,
+                end_time=end_time,
+            )
+        )
+
+        log_filters = [
+            "jsonPayload.message:\"'event_type': 'emergency_restore'\"",
+            "jsonPayload.message:\"'is_restoring_slice': True\"",
+            "jsonPayload.message:\"'directory': 'gs://\"",
+        ]
+        validate_restore_source = validation_util.validate_log_exist.override(
+            task_id="validate_emc_restored_from_gcs"
+        )(
+            project_id=test_config.cluster.project,
+            location=zone_to_region(test_config.cluster.zone),
+            cluster_name=test_config.cluster.name,
+            text_filter=" AND ".join(log_filters),
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        # Validate that checkpoint files exist in GCS bucket
+        validate_saved_checkpoints_steps_gcs = (
+            validation_util.validate_gcs_checkpoint_files(
+                bucket_path=(
+                    f"{test_config_util.DEFAULT_BUCKET}/{out_folder}/{run_name}"
+                ),
+                steps_to_validate=steps_to_validate,
+            )
+        )
+
+        # Final CPC cleanup to ensure symmetric start/end
+        wait_delete_cpc_final = checkpoint_util.wait_for_cpc_deletion.override(
+            trigger_rule=TriggerRule.ALL_DONE,
+            task_id="wait_delete_cpc_final",
+        )(test_config.cpc_config).as_teardown(setups=apply_first_cpc)
+
+        (
+            wait_delete_cpc
+            >> apply_first_cpc
+            >> run_name
+            >> start_time
+            >> initial_training_run
+            >> wait_delete_first_cpc
+            >> apply_second_cpc
+            >> resume_training_run
+            >> end_time
+            >> validate_gcs_restore
+            >> validate_restore_source
+            >> validate_saved_checkpoints_steps_gcs
+            >> wait_delete_cpc_final
+        )

--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -7,6 +7,7 @@ with HNS (Hierarchical Namespace)
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
@@ -83,7 +84,7 @@ with models.DAG(
         # We conditionally set the trigger_rule on the first task.
         # If first task group failed the next one can execute.
         wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done"
+            trigger_rule=TriggerRule.ALL_DONE
         )(test_config.cpc_config)
         apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
 
@@ -146,7 +147,8 @@ with models.DAG(
 
         # Final CPC cleanup to ensure symmetric start/end
         wait_delete_cpc_final = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done", task_id="wait_delete_cpc_final"
+            trigger_rule=TriggerRule.ALL_DONE,
+            task_id="wait_delete_cpc_final",
         )(test_config.cpc_config).as_teardown(setups=apply_cpc)
 
         (

--- a/dags/orbax/maxtext_mtc_emergency_save_local.py
+++ b/dags/orbax/maxtext_mtc_emergency_save_local.py
@@ -10,6 +10,7 @@ multi-pod cluster.
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
 from dags import composer_env
@@ -110,7 +111,7 @@ with models.DAG(
             # We conditionally set the trigger_rule on the first task.
             # If first task group failed the next one can execute.
             wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
-                trigger_rule="all_done"
+                trigger_rule=TriggerRule.ALL_DONE
             )(test_config.cpc_config)
             apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
 
@@ -167,7 +168,8 @@ with models.DAG(
             # Final CPC cleanup to ensure symmetric start/end
             wait_delete_cpc_final = (
                 checkpoint_util.wait_for_cpc_deletion.override(
-                    trigger_rule="all_done", task_id="wait_delete_cpc_final"
+                    trigger_rule=TriggerRule.ALL_DONE,
+                    task_id="wait_delete_cpc_final",
                 )(test_config.cpc_config).as_teardown(setups=apply_cpc)
             )
 

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -6,6 +6,7 @@ Validates the local checkpoints are restored as expected
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
@@ -84,7 +85,7 @@ with models.DAG(
     for test_config in test_configs:
       for slice_num in test_config.slices:
         wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done"
+            trigger_rule=TriggerRule.ALL_DONE
         )(test_config.cpc_config)
         apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
 
@@ -170,7 +171,8 @@ with models.DAG(
 
         # Final CPC cleanup to ensure symmetric start/end
         wait_delete_cpc_final = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done", task_id="wait_delete_cpc_final"
+            trigger_rule=TriggerRule.ALL_DONE,
+            task_id="wait_delete_cpc_final",
         )(test_config.cpc_config).as_teardown(setups=apply_cpc)
 
         (

--- a/dags/orbax/maxtext_mtc_save_gcs.py
+++ b/dags/orbax/maxtext_mtc_save_gcs.py
@@ -7,6 +7,7 @@ with HNS (Hierarchical Namespace)
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
@@ -85,7 +86,7 @@ with models.DAG(
         # We conditionally set the trigger_rule on the first task.
         # If first task group failed the next one can execute.
         wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done"
+            trigger_rule=TriggerRule.ALL_DONE
         )(test_config.cpc_config)
         apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
 
@@ -152,7 +153,8 @@ with models.DAG(
 
         # Final CPC cleanup to ensure symmetric start/end
         wait_delete_cpc_final = checkpoint_util.wait_for_cpc_deletion.override(
-            trigger_rule="all_done", task_id="wait_delete_cpc_final"
+            trigger_rule=TriggerRule.ALL_DONE,
+            task_id="wait_delete_cpc_final",
         )(test_config.cpc_config).as_teardown(setups=apply_cpc)
 
         (

--- a/dags/orbax/util/validation_util.py
+++ b/dags/orbax/util/validation_util.py
@@ -21,41 +21,33 @@ def validate_checkpoint_at_steps_are_saved(
     project_id: str,
     location: str,
     cluster_name: str,
-    steps_to_validate: list,
+    steps_to_validate: list[int],
     ram_disk: str = "/local",
     pod_pattern: Optional[str] = ".*",
     start_time: Optional[datetime] = None,
     end_time: Optional[datetime] = None,
 ) -> None:
   """
-  Validates that checkpoints are successfully saved at expected training steps.
+  Validates that a workload is training correctly by checking for specific log steps.
 
-  This function searches GKE cluster logs for checkpoint save completion messages
-  containing 'Finished async_save (blocking + background)' and extracts the step
-  numbers from the directory paths. It then verifies that all expected steps have
-  corresponding checkpoint save operations.
+  This function queries logs from a specified GKE cluster and namespace.
+  It searches for a log entry containing the string '(blocking + background)'
+  and then compares the number of steps found against an expected list of steps.
 
-  The function supports both local checkpoints (e.g., /local/123) and GCS checkpoints
-  (e.g., gs://bucket/path/checkpoints/123) by using different regex patterns based
-  on the directory parameter.
+  A mismatch in the number of steps will cause the validation to fail. This can
+  happen if, for example, a restore operation causes the step count to restart
+  from zero, leading to `len(steps_to_validate) != len(found_steps)`.
 
   Args:
-    project_id: The Google Cloud project ID containing the GKE cluster.
-    location: The GKE cluster location (e.g., 'us-central1-a').
-    cluster_name: The name of the GKE cluster to query logs from.
-    steps_to_validate: List of training step numbers that should have saved checkpoints.
-    ram_disk: The checkpoint directory path. Use "/local" for local checkpoints or
-      "gcs" for GCS bucket checkpoints. Defaults to "/local".
-    pod_pattern: Regex pattern to match pod names in logs. Defaults to ".*" (all pods).
-    start_time: Start time for log query window. Defaults to 12 hours ago if not provided.
-    end_time: End time for log query window. Defaults to current time if not provided.
-
+    project_id: The Google Cloud project ID
+    location: GKE cluster location
+    cluster_name: GKE cluster name
+    start_time: Optional start time for log retrieval
+      (defaults to 12 hours ago)
+    end_time: Optional end time for log retrieval (defaults to now)
+    steps_to_validate: Optional to validate list of steps
   Returns:
-    None: Function completes successfully if all expected steps are found.
-
-  Raises:
-    AirflowFailException: If any expected checkpoint steps are missing from the logs,
-      if log entries cannot be parsed, or if the checkpoint save pattern is not found.
+    None: This function does not return a value.
   """
 
   directory_pattern = (
@@ -267,7 +259,7 @@ def validate_gcs_checkpoint_files(
   are properly saved in the bucket for each expected step.
   Args:
     bucket_path: The full gs:// path to the GCS bucket
-    vali_step_list: Optional list of steps to validate
+    steps_to_validate: Optional list of steps to validate
   Returns:
     None: Raises AirflowFailException if checkpoint validation fails
   """


### PR DESCRIPTION
# Description
A DAG to test MaxText EMC feature resume training from gcs.
- Training for 100 steps
- Clear local cache
- Training for 200 steps
- Expect second training start from the 99 step

# Tests
- Dag Name: `maxtext_emc_resume_from_gcs`
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/dags/maxtext_emc_resume_from_gcs/grid

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.