### PR TITLE
Restructure DAG to iterate over MachineConfigMap and group tasks into…

### DIFF
--- a/dags/tpu_observability/configs/common.py
+++ b/dags/tpu_observability/configs/common.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+import enum
+
+from dags.common.vm_resource import MachineVersion, TpuVersion
+
+
+@dataclass(frozen=True)
+class TpuConfig:
+  tpu_version: TpuVersion
+  tpu_topology: str
+  machine_version: MachineVersion
+
+
+# Only one version of the machine is supported at the moment.
+# Other versions (e.g., "ct5p-hightpu-4t") may be introduced later.
+class MachineConfigMap(enum.Enum):
+  V6E_16 = TpuConfig(
+      tpu_version=TpuVersion.TRILLIUM,
+      tpu_topology="4x4",
+      machine_version=MachineVersion.CT6E_STAND_4T,
+  )

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -5,10 +5,12 @@ import datetime
 
 from airflow import models
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
 
 from dags.common.vm_resource import Project, Region, Zone
 from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.configs.common import MachineConfigMap
 
 
 with models.DAG(
@@ -40,123 +42,125 @@ with models.DAG(
       All node-pool will be cleaned up clean it up after the tests.
     """,
 ) as dag:
-  node_pool_info = node_pool.Info(
-      project_id=models.Variable.get(
-          "PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
-      ),
-      cluster_name=models.Variable.get(
-          "CLUSTER_NAME", default_var="tpu-observability-automation"
-      ),
-      node_pool_name=models.Variable.get(
-          "NODE_POOL_NAME", default_var="node-pool-status-v6e-autotest"
-      ),
-      location=models.Variable.get(
-          "LOCATION", default_var=Region.US_EAST5.value
-      ),
-      node_locations=models.Variable.get(
-          "NODE_LOCATIONS", default_var=Zone.US_EAST5_B.value
-      ),
-      num_nodes=models.Variable.get("NUM_NODES", default_var=4),
-      machine_type=models.Variable.get(
-          "MACHINE_TYPE", default_var="ct6e-standard-4t"
-      ),
-      tpu_topology=models.Variable.get("TPU_TOPOLOGY", default_var="4x4"),
-  )
+  for machine in MachineConfigMap:
+    config = machine.value
+    node_pool_info = node_pool.Info(
+        project_id=models.Variable.get(
+            "PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
+        ),
+        cluster_name=models.Variable.get(
+            "CLUSTER_NAME", default_var="tpu-observability-automation"
+        ),
+        node_pool_name=models.Variable.get(
+            "NODE_POOL_NAME", default_var="node-pool-status-v6e-autotest"
+        ),
+        location=models.Variable.get(
+            "LOCATION", default_var=Region.US_EAST5.value
+        ),
+        node_locations=models.Variable.get(
+            "NODE_LOCATIONS", default_var=Zone.US_EAST5_B.value
+        ),
+        num_nodes=models.Variable.get("NUM_NODES", default_var=4),
+        machine_type=config.machine_version.value,
+        tpu_topology=config.tpu_topology,
+    )
 
-  problematic_node_pool_info = copy.deepcopy(node_pool_info)
-  problematic_node_pool_info.node_pool_name += "-wrong"
-  # Choosing a region that is different from the cluster location but still
-  # compatible with the specified TPU cause the cluster creation to fail
-  # due to mismatched node locations.
-  problematic_node_pool_info.node_locations = models.Variable.get(
-      "WRONG_NODE_LOCATION", default_var=Zone.ASIA_EAST1_C.value
-  )
+    problematic_node_pool_info = copy.deepcopy(node_pool_info)
+    problematic_node_pool_info.node_pool_name += "-wrong"
+    # Choosing a region that is different from the cluster location but still
+    # compatible with the specified TPU cause the cluster creation to fail
+    # due to mismatched node locations.
+    problematic_node_pool_info.node_locations = models.Variable.get(
+        "WRONG_NODE_LOCATION", default_var=Zone.ASIA_EAST1_C.value
+    )
 
-  task_id = "create_node_pool"
-  create_node_pool = node_pool.create.override(task_id=task_id)(
-      node_pool=node_pool_info, reservation="cloudtpu-20250131131310-2118578099"
-  )
+    with TaskGroup(group_id=f"v{config.tpu_version.value}"):
+      task_id = "create_node_pool"
+      create_node_pool = node_pool.create.override(task_id=task_id)(
+          node_pool=node_pool_info,
+          reservation="cloudtpu-20250131131310-2118578099",
+      )
 
-  task_id = "wait_for_provisioning"
-  wait_for_provisioning = node_pool.wait_for_status.override(task_id=task_id)(
-      node_pool=node_pool_info, status=node_pool.Status.PROVISIONING
-  )
+      task_id = "wait_for_provisioning"
+      wait_for_provisioning = node_pool.wait_for_status.override(
+          task_id=task_id
+      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-  task_id = "wait_for_running"
-  wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
-      node_pool=node_pool_info, status=node_pool.Status.RUNNING
-  )
+      task_id = "wait_for_running"
+      wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+          node_pool=node_pool_info, status=node_pool.Status.RUNNING
+      )
 
-  task_id = "delete_node"
-  delete_node = node_pool.delete_one_random_node.override(task_id=task_id)(
-      node_pool=node_pool_info
-  )
+      task_id = "delete_node"
+      delete_node = node_pool.delete_one_random_node.override(task_id=task_id)(
+          node_pool=node_pool_info
+      )
 
-  task_id = "wait_for_repair"
-  wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
-      node_pool=node_pool_info, status=node_pool.Status.RECONCILING
-  )
+      task_id = "wait_for_repair"
+      wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
+          node_pool=node_pool_info, status=node_pool.Status.RECONCILING
+      )
 
-  task_id = "wait_for_recovered"
-  wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
-      node_pool=node_pool_info, status=node_pool.Status.RUNNING
-  )
+      task_id = "wait_for_recovered"
+      wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
+          node_pool=node_pool_info, status=node_pool.Status.RUNNING
+      )
 
-  task_id = "delete_node_pool"
-  delete_node_pool = node_pool.delete.override(task_id=task_id)(
-      node_pool=node_pool_info
-  )
+      task_id = "delete_node_pool"
+      delete_node_pool = node_pool.delete.override(task_id=task_id)(
+          node_pool=node_pool_info
+      )
 
-  task_id = "wait_for_stopping"
-  wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
-      node_pool=node_pool_info, status=node_pool.Status.STOPPING
-  )
+      task_id = "wait_for_stopping"
+      wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
+          node_pool=node_pool_info, status=node_pool.Status.STOPPING
+      )
 
-  task_id = "cleanup_node_pool"
-  cleanup_node_pool = node_pool.delete.override(
-      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-  )(node_pool=node_pool_info).as_teardown(
-      setups=create_node_pool,
-  )
+      task_id = "cleanup_node_pool"
+      cleanup_node_pool = node_pool.delete.override(
+          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=node_pool_info).as_teardown(
+          setups=create_node_pool,
+      )
 
-  # Intentionally create a node pool with problematic configurations
-  # to validate that it enters the ERROR state.
-  task_id = "create_problematic_node_pool_info"
-  create_problematic_node_pool_info = node_pool.create.override(
-      task_id=task_id
-  )(
-      node_pool=problematic_node_pool_info,
-      # The failure is intentionally ignored because we want to validate
-      # that the status of the node pool (which fails to be created) is "ERROR".
-      ignore_failure=True,
-  )
+      # Intentionally create a node pool with problematic configurations
+      # to validate that it enters the ERROR state.
+      task_id = "create_problematic_node_pool_info"
+      create_problematic_node_pool_info = node_pool.create.override(
+          task_id=task_id
+      )(
+          node_pool=problematic_node_pool_info,
+          # The failure is intentionally ignored because we want to validate
+          # that the status of the node pool (which fails to be created) is "ERROR".
+          ignore_failure=True,
+      )
 
-  task_id = "wait_for_error"
-  wait_for_error = node_pool.wait_for_status.override(task_id=task_id)(
-      node_pool=problematic_node_pool_info, status=node_pool.Status.ERROR
-  )
+      task_id = "wait_for_error"
+      wait_for_error = node_pool.wait_for_status.override(task_id=task_id)(
+          node_pool=problematic_node_pool_info, status=node_pool.Status.ERROR
+      )
 
-  task_id = "cleanup_wrong_node_pool"
-  cleanup_wrong_node_pool = node_pool.delete.override(
-      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-  )(node_pool=problematic_node_pool_info).as_teardown(
-      setups=create_problematic_node_pool_info,
-  )
+      task_id = "cleanup_wrong_node_pool"
+      cleanup_wrong_node_pool = node_pool.delete.override(
+          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=problematic_node_pool_info).as_teardown(
+          setups=create_problematic_node_pool_info,
+      )
 
-  normal_flow = (
-      create_node_pool
-      >> wait_for_provisioning
-      >> wait_for_running
-      >> delete_node
-      >> wait_for_repair
-      >> wait_for_recovered
-      >> delete_node_pool
-      >> wait_for_stopping
-      >> cleanup_node_pool
-  )
+      normal_flow = (
+          create_node_pool
+          >> wait_for_provisioning
+          >> wait_for_running
+          >> delete_node
+          >> wait_for_repair
+          >> wait_for_recovered
+          >> delete_node_pool
+          >> wait_for_stopping
+          >> cleanup_node_pool
+      )
 
-  flow_for_error_state = (
-      create_problematic_node_pool_info
-      >> wait_for_error
-      >> cleanup_wrong_node_pool
-  )
+      flow_for_error_state = (
+          create_problematic_node_pool_info
+          >> wait_for_error
+          >> cleanup_wrong_node_pool
+      )


### PR DESCRIPTION
… task group per configuration

Refactors `gke_node_pool_status`, `multi_host_nodepool_rollback`, and `tpu_info_format_validation_dag` to use a loop over a predefined map.

Each machine type's workflow is now contained in its own TaskGroup for clear parallelism and graph organization.

# Description

Please include a summary of relevant context/issue and your changes.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.