### PR TITLE
Update CODEOWNERS to allow external reviewers to approve and merge PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default owners for everything in the repo, unless a later match takes precedence.
-* @richardsliu @yixinshi @RissyRan @hyeygit @jiangjy1982 @xibinliu @andrewyct @severus-ho
+* @richardsliu @yixinshi @RissyRan @hyeygit @jiangjy1982 @xibinliu @andrewyct @severus-ho @alfredyu-cienet
 
 dags/common @richardsliu @yixinshi @RissyRan @hyeygit @bhavya01 @pgmoka @qihqi @zhanyong-wan @gobbleturk @shralex @jiangjy1982 @ortibazar @parambole @vipannalla @crankshaw-google @polydier1 @xibinliu @andrewyct @severus-ho
 
 dags/solutions_team/configs/tensorflow @chandrasekhard2 @ZhaoyueCheng @richardsliu
 dags/solutions_team/solutionsteam_tf* @chandrasekhard2 @ZhaoyueCheng @richardsliu
 
-dags/pytorch_xla @bhavya01 @pgmoka @qihqi @zhanyong-wan
+dags/pytorch_xla @bhavya01 @pgmoka @qihqi @zhanyong-wan @xibinliu @andrewyct @severus-ho
 dags/legacy_test/tests/pytorch @bhavya01 @pgmoka @qihqi @zhanyong-wan
 
 dags/mantaray @qihqi @bhavya01 @pgmoka @zhanyong-wan
@@ -25,4 +25,4 @@ dags/map_reproducibility @crankshaw-google @polydier1 @gunjanj007 @stingram @utk
 
 dags/orbax @abhinavclemson @xuefgu @xibinliu @andrewyct @severus-ho @RexBearIU @alfredyu-cienet
 
-dags/tpu_observability @xibinliu @andrewyct @severus-ho
+dags/tpu_observability @xibinliu @andrewyct @severus-ho @alfredyu-cienet


### PR DESCRIPTION
This change updates the CODEOWNERS file to:
- Grant @alfredyu-cienet as a default code owner, allowing approval and merging of DAG-related changes for Orbax, TPU Observability, Pathways, and MaxText.
- Grant @xibinliu, @andrewyct, and @severus-ho as code owner of `dags/pytorch_xla`, allowing approval and merging of DAG-related changes for the "pytorch_xla".

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.