### PR TITLE
Fix orbax mtc resume validation issue

### DIFF
--- a/dags/orbax/maxtext_mtc_resume_gcs.py
+++ b/dags/orbax/maxtext_mtc_resume_gcs.py
@@ -90,6 +90,7 @@ with models.DAG(
 ) as dag:
   first_training_step = 200
   second_training_step = 400
+  local_checkpoint_period = 100
   out_folder = "maxtext_mtc_orbax_resume_gcs"
 
   checkpointing = test_config_util.Checkpointing(
@@ -107,7 +108,7 @@ with models.DAG(
           short_id="max-mtc-resume-gcs",
           multi_tier_checkpointing_backup_interval_minutes=1,
           steps=first_training_step,
-          local_checkpoint_period=100,
+          local_checkpoint_period=local_checkpoint_period,
           base_dir=test_config_util.DEFAULT_BUCKET,
       ),
   ]
@@ -200,7 +201,8 @@ with models.DAG(
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
                 pod_pattern="max.*-job-0-0",
-                interrupt_at_step=first_training_step - 1,
+                interrupt_at_step=local_checkpoint_period,
+                check_last_two_local_saves=False,
                 start_time=start_time,
                 end_time=end_time,
             )

--- a/dags/orbax/util/validation_util.py
+++ b/dags/orbax/util/validation_util.py
@@ -514,6 +514,14 @@ def validate_restored_correct_checkpoint(
             "in the last two saved steps."
         )
 
+      if (
+          not check_last_two_local_saves
+          and restored_step not in local_saved_steps_before_restore
+      ):
+        raise AirflowFailException(
+            f"Restored step {restored_step} should be in the saved steps."
+        )
+
       logging.info("Restoration happened at the expected step.")
       return
 


### PR DESCRIPTION
# Description
Fix orbax mtc resume validation (b/458578088)

For mtc checkpoint in GCS, we cannot assume that the bucket will always contain the latest checkpoint, since the mechanism of MTC copy the local checkpoint to the bucket is timer-based.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.