### PR TITLE
Feat: Update xpk pinned version to delete workaround

### DIFF
--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -30,9 +30,9 @@ from xlml.apis import metric_config
 from xlml.utils import gke, composer
 from dags.common.vm_resource import GpuVersion
 
-# b/411426745 - Using sed workaround to comment out validate_dependencies()
-# in xpk main.py to upgrade the version from 0.4.1 to 0.12.0.
-MAIN_BRANCH = "v0.12.0"
+# NOTE: This version needs to be pinned to ensure compatibility when using
+# xpk.py for workload creation.
+MAIN_BRANCH = "v0.15.0"
 
 # Duration = past 7 days
 LOGGING_URL_FORMAT = (
@@ -59,14 +59,10 @@ def get_xpk_setup_cmd(tmpdir, branch: str = MAIN_BRANCH):
 
   pip_install = "pip install ruamel.yaml docker"
 
-  # b/411426745 - Workaround: Comment out validate_dependencies() call to avoid dependency validation issues
-  comment_out_validation = f"sed -i '/validate_dependencies()/s/^/## /' {tmpdir}/xpk/src/xpk/main.py || true"
-
   cmds = [
       bash_setup,
       clone_branch,
       pip_install,
-      comment_out_validation,
   ]
   return cmds
 
@@ -144,6 +140,7 @@ def run_workload(
         f" --{multi_keyword}={num_slices} --docker-image={docker_image}"
         f" --project={cluster_project} --zone={zone}"
         f" --env {metric_config.SshEnvVars.GCS_OUTPUT.name}={gcs_path}"
+        f" --skip-validation"
     )
 
     if ramdisk_directory and not use_pathways:


### PR DESCRIPTION
# Description

This pull request updates the `xlml/utils/xpk.py` utility to improve compatibility and simplify the workload setup process. The main changes include upgrading the pinned `xpk` version, removing a previous workaround for dependency validation, and ensuring validation is consistently skipped via a command-line flag.

# Tests
> [!CAUTION] 
> Test fails due to XPK regression. Requires upstream fix and subsequent dependency update to resolve.

Run one for the Orbax regular DAG to test the xpk workload create functionality

**List links for your tests (use go/shortn-gen for any internal link):** .
[test link](https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_regular_save/grid?dag_run_id=manual__2025-12-03T07%3A59%3A02.484213%2B00%3A00)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.