### PR TITLE
Change default bucket for Orbax DAGs

### DIFF
--- a/dags/gcs_bucket.py
+++ b/dags/gcs_bucket.py
@@ -26,4 +26,4 @@ BASE_OUTPUT_DIR = "gs://ml-auto-solutions/output"
 
 # Multi-tier checkpointing need special permission for GCS Bucket
 # For further question reach out to  Multi-tier Checkpointing Owners.
-MTC_AUTOMATION_BUCKET = "gs://mtc-automation-bucket"
+ORBAX_AUTOMATION_BUCKET_EUROPE_WEST4 = "gs://orbax-automation-europe-west4"

--- a/dags/orbax/util/test_config_util.py
+++ b/dags/orbax/util/test_config_util.py
@@ -16,7 +16,7 @@ from dags.orbax.util import checkpoint_util
 from dags.multipod.configs.common import SetupMode
 
 
-DEFAULT_BUCKET = gcs_bucket.MTC_AUTOMATION_BUCKET
+DEFAULT_BUCKET = gcs_bucket.ORBAX_AUTOMATION_BUCKET_EUROPE_WEST4
 DEFAULT_RAM_DISK = "/local"
 
 # Only one version of the Docker image is supported at the moment.
@@ -132,7 +132,7 @@ class TestConfig:
         project_id=self.cluster.project,
         region=zone_to_region(self.cluster.zone),
         cluster_name=self.cluster.name,
-        gcs_bucket=gcs_bucket.MTC_AUTOMATION_BUCKET.removeprefix("gs://"),
+        gcs_bucket=DEFAULT_BUCKET.removeprefix("gs://"),
         ramdisk_memory_in_mi=self.ram_disk_size,
         machine_type=self.machine_type,
     )
@@ -166,7 +166,6 @@ class TestConfig:
         f"base_output_directory={posixpath.join(self.base_dir, out_folder)} "
         "dataset_type=synthetic "
         f"steps={self.steps} "
-        "per_device_batch_size=1 "
         "max_target_length=256 "
         f"model_name={self.model_name} "
         "per_device_batch_size=2 "


### PR DESCRIPTION
# Description
Change default bucket for Orbax DAGs

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.