### PR TITLE
Add schedule for the one click automation DAG for Pathways

### DIFF
--- a/dags/maxtext_pathways/configs/parameters.py
+++ b/dags/maxtext_pathways/configs/parameters.py
@@ -38,19 +38,22 @@ PARAMETERS = {
         description="User name is used to confirm the first three characters of the pod in the cluster.",
     ),
     "cluster_name": Param(
-        "pw-scale-test-v5e-32",
+        "juliekuo-v5e-32",
         type="string",
         title="Cluster Name",
         description="GCP cluster name for training model.",
     ),
     "project": Param(
-        "cloud-tpu-multipod-dev",
+        "cienet-cmcs",
         type="string",
         title="Project",
         description="GCP project ID for training model.",
     ),
     "zone": Param(
-        "us-south1-a", type="string", title="Zone", description="Cluster zone."
+        "us-central1-a",
+        type="string",
+        title="Zone",
+        description="Cluster zone.",
     ),
     "device_version": Param(
         "v5litepod",
@@ -66,7 +69,7 @@ PARAMETERS = {
         description='Device core count for the cluster. ex: v5litepod-"32"',
     ),
     "service_account": Param(
-        "one-click@cloud-tpu-multipod-dev.iam.gserviceaccount.com",
+        "one-click@cienet-cmcs.iam.gserviceaccount.com",
         type="string",
         title="Service account",
         description="Service account of the project.",
@@ -78,7 +81,7 @@ PARAMETERS = {
         description="Number of benchmark steps.",
     ),
     "num_slices_list": Param(
-        2,
+        1,
         type="integer",
         title="Number Slices",
         description="Number of slices",

--- a/dags/maxtext_pathways/pw_mcjax_dags.py
+++ b/dags/maxtext_pathways/pw_mcjax_dags.py
@@ -247,7 +247,7 @@ RECIPE_NAME = RECIPE_INSTANCE.value.lower()
 with models.DAG(
     dag_id=RECIPE_NAME,
     start_date=datetime.datetime(2025, 1, 1),
-    schedule_interval=None,
+    schedule_interval="00 10 * * *",
     catchup=False,
     default_args={
         "retries": 0,


### PR DESCRIPTION
# Description
Add schedule and change to use cluster in CMCS

### Prerequisites
- This test requires an existing cluster.
- This test requires that a dataset with the same name as the UI parameter "[BigQuery Database Dataset]".
- Create a service account named `one-click` with the following roles: `Artifact Registry Reader`, `Kubernetes Engine Admin`, `Monitoring Viewer`.
    - Generate a new service account key and download the JSON file to retrieve its contents. 
    Next, create a secret manager named `one-click-key` and store the key contents there for use when switching service accounts.
    - Make sure the default service account has the `Secret Manager Secret Accessor` role.  
    ex: [PROJECT_NUMBER]-compute@developer.gserviceaccount.com
- If you're using a service account to pull an image from a different project, you need to grant the service account the `Artifact Registry Reader` role in that project.

### Procedures
An Airflow Composer environment must be created, and the required DAG code must be deployed to the associated GCS bucket.  
To initiate the recipe, the user must access the Airflow UI, locate the specific DAG, and trigger its execution.  

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.