### PR TITLE
Feat: Configure tpu-obs DAGs to run daily

### DIFF
--- a/dags/map_reproducibility/utils/constants.py
+++ b/dags/map_reproducibility/utils/constants.py
@@ -42,6 +42,11 @@ class Schedule:
   SATURDAY_PDT_12AM = "0 7 * * 6"
   SATURDAY_PDT_3AM = "0 10 * * 6"
 
+  # Daily at 6:00 PM PST => 2:00 AM UTC next day
+  DAILY_PST_6PM = "0 2 * * *"
+  DAILY_PST_6_30PM = "30 2 * * *"
+  DAILY_PST_7PM = "0 3 * * *"
+
 
 class Image:
   MAXTEXT_JAX_STABLE_NIGHTLY = (

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -7,8 +7,8 @@ from airflow.models import Variable
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
-from dags.common.vm_resource import Project, Region, Zone
 from dags.map_reproducibility.utils import constants
+from dags.common.vm_resource import Project, Region, Zone
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.configs.common import MachineConfigMap
 
@@ -16,7 +16,7 @@ from dags.tpu_observability.configs.common import MachineConfigMap
 with models.DAG(
     dag_id="multi-host-availability-rollback",
     start_date=datetime.datetime(2025, 8, 10),
-    schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
+    schedule=constants.Schedule.DAILY_PST_6_30PM,
     catchup=False,
     tags=[
         "cloud-ml-auto-solutions",

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -7,8 +7,8 @@ from airflow import models
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
-from dags.common.vm_resource import Project, Region, Zone
 from dags.map_reproducibility.utils import constants
+from dags.common.vm_resource import Project, Region, Zone
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.configs.common import MachineConfigMap
 
@@ -16,7 +16,7 @@ from dags.tpu_observability.configs.common import MachineConfigMap
 with models.DAG(
     dag_id="gke_node_pool_status",
     start_date=datetime.datetime(2025, 8, 1),
-    schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
+    schedule=constants.Schedule.DAILY_PST_6PM,
     catchup=False,
     tags=["gke", "tpu-observability", "node-pool-status", "TPU", "v6e-16"],
     description=(

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -20,8 +20,8 @@ from dags.common.vm_resource import MachineVersion
 from dags.common.vm_resource import Project
 from dags.common.vm_resource import Region
 from dags.common.vm_resource import Zone
-from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.configs.common import MachineConfigMap, TpuConfig
+from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils import tpu_info_util as tpu_info
@@ -274,7 +274,7 @@ with models.DAG(
     dag_id="tpu_info_format_validation_dag",
     start_date=datetime.datetime(2025, 8, 15),
     default_args={"retries": 0},
-    schedule=constants.Schedule.WEEKDAY_PDT_6AM_7AM_EXCEPT_THURSDAY,
+    schedule=constants.Schedule.DAILY_PST_7PM,
     catchup=False,
     tags=["gke", "tpu-observability", "tpu-info", "TPU", "v6e-16"],
     description=(


### PR DESCRIPTION
# Description

Configure TPU-observability DAGs to run daily at staggered times.

This refactors the DAG schedules from a fixed four times a week to daily execution, using distinct times to prevent simultaneous runs. 

# Airflow/Composer

- GCP Composer name: [ml-automation-solutions-dev](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/home?lastrun=failed)
- GCP Composer version: `2.13.1`


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.