### PR TITLE
Add a new DAG that tests the status of node pool when update node poo…

### DIFF
--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -1,0 +1,100 @@
+"""A DAG to update the label of a node pool to make node pool unavailable for a while"""
+
+import datetime
+
+from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
+
+from dags.common.vm_resource import Project, Region, Zone
+from dags.map_reproducibility.utils import constants
+from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.configs.common import MachineConfigMap
+
+
+with models.DAG(
+    dag_id="gke_node_pool_label_update",
+    start_date=datetime.datetime(2025, 8, 1),
+    schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
+    catchup=False,
+    tags=["gke", "tpu-observability", "node-pool-status"],
+    description=(
+        "This DAG tests whether the status of a GKE node pool changes as "
+        "expected after its labels are updated, triggering reconciliation."
+    ),
+    doc_md="""
+      # GKE Node Pool Label Update Status Validation DAG
+
+      ### Description
+      This DAG automates the process of going through the lifecycle of a GKE
+      node pool and verifies whether the node pool status is reported correctly
+      after a configuration change (label update) is applied.
+
+      ### Prerequisites
+      This test requires an existing cluster.
+
+      ### Procedures
+      It creates a node pool, waits for it to be running, updates a label to
+      trigger reconciliation, waits for it to become running again (recovering
+      from the update), and finally cleans up by deleting the node pool.
+    """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+    node_pool_info = node_pool.Info(
+        project_id="cienet-cmcs",
+        cluster_name=models.Variable.get(
+            "CLUSTER_NAME", default_var="tpu-observability-automation"
+        ),
+        node_pool_name=models.Variable.get(
+            "NODE_POOL_NAME", default_var="update-node-pool-label-v6e-autotest"
+        ),
+        location=models.Variable.get(
+            "LOCATION", default_var=Region.US_CENTRAL1.value
+        ),
+        node_locations=models.Variable.get(
+            "NODE_LOCATIONS", default_var=Zone.US_CENTRAL1_B.value
+        ),
+        num_nodes=models.Variable.get("NUM_NODES", default_var=4),
+        machine_type=config.machine_version.value,
+        tpu_topology=config.tpu_topology,
+    )
+
+    LABELS_TO_UPDATE = {"env": "prod"}
+
+    with TaskGroup(group_id=f"v{config.tpu_version.value}"):
+      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+          node_pool=node_pool_info,
+          reservation="cloudtpu-20251107233000-1246578561",
+      )
+
+      wait_for_availability = node_pool.wait_for_availability.override(
+          task_id="wait_for_initial_availability"
+      )(node_pool=node_pool_info, availability=True)
+
+      update_node_pool_label = node_pool.update_labels.override(
+          task_id="update_node_pool_label"
+      )(node_pool=node_pool_info, node_labels=LABELS_TO_UPDATE)
+
+      wait_for_unavailable = node_pool.wait_for_availability.override(
+          task_id="wait_for_unavailability_after_update"
+      )(node_pool=node_pool_info, availability=False)
+
+      wait_node_pool_recovered = node_pool.wait_for_availability.override(
+          task_id="wait_for_recovery"
+      )(node_pool=node_pool_info, availability=True)
+
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=node_pool_info).as_teardown(
+          setups=[create_node_pool],
+      )
+
+      (
+          create_node_pool
+          >> wait_for_availability
+          >> update_node_pool_label
+          >> wait_for_unavailable
+          >> wait_node_pool_recovered
+          >> cleanup_node_pool
+      )


### PR DESCRIPTION
# Description

This change adds a new DAG designed to manage GKE node pools by adding specific labels to the node pool and monitoring for the unavailability during the update process.

# Tests

* Dag Name : gke_node_pool_label_update
* Airflow test results: https://701b396453e9434fb98fa48158aa48a5-dot-us-east5.composer.googleusercontent.com/dags/gke_node_pool_label_update/grid?dag_run_id=manual__2025-11-17T06%3A44%3A44.800369%2B00%3A00&task_id=v6e.create_node_pool

## Airflow/Composer
* GCP Composer name: `daniel-test` (under GCP project: `cienet-cmcs`)
* GCP Composer version: `2.13.1`

## Required Variables
* Cluster Information (This DAG requires an existing cluster)
  * PROJECT_ID: The GCP project ID where the cluster resides. (Default to tpu-prod-env-one-vm)
  * CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation)
  * LOCATION: The region of the GKE cluster. (Default to us-central1)
* Node Pool Configurations
  * NODE_POOL_NAME: The base name for the new node pool. (Default to update-node-pool-label-v6e-autotest)
  * NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  * NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  * MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  * TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.