### PR TITLE
Fix: Correct schedule for gke_node_pool_label_update DAG

### DIFF
--- a/dags/map_reproducibility/utils/constants.py
+++ b/dags/map_reproducibility/utils/constants.py
@@ -46,6 +46,7 @@ class Schedule:
   DAILY_PST_6PM = "0 2 * * *"
   DAILY_PST_6_30PM = "30 2 * * *"
   DAILY_PST_7PM = "0 3 * * *"
+  DAILY_PST_7_30_PM = "30 3 * * *"
 
 
 class Image:

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -15,7 +15,7 @@ from dags.tpu_observability.configs.common import MachineConfigMap
 with models.DAG(
     dag_id="gke_node_pool_label_update",
     start_date=datetime.datetime(2025, 8, 1),
-    schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
+    schedule=constants.Schedule.DAILY_PST_7_30_PM,
     catchup=False,
     tags=["gke", "tpu-observability", "node-pool-status"],
     description=(


### PR DESCRIPTION
# Description

This change corrects the schedule for the gke_node_pool_label_update DAG.

Specifically:
-   A new schedule constant, `DAILY_PST_7_30_PM = "30 3 * * *"` (representing 7:30 PM PST daily), has been added to `dags/map_reproducibility/utils/constants.py`.
-   The gke_node_pool_label_update DAG has been updated to use this new `DAILY_PST_7_30_PM` schedule.

This ensures the DAG runs at the intended daily time.
# Tests

- GCP Composer name: [tony-test](https://de173bfeed494edaade7b4b5cdc284d8-dot-us-east1.composer.googleusercontent.com/dags/gke_node_pool_label_update/grid?search=gke_node_pool_label_update&dag_run_id=manual__2025-11-19T03%3A19%3A18.918008%2B00%3A00) (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.