### PR TITLE
Fix incorrect "pod_pattern" for log validation

### DIFF
--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -141,7 +141,7 @@ with models.DAG(
                 project_id=test_config.cluster.project,
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
-                pod_pattern=f"{test_config.short_id}-emc.*1-0",
+                pod_pattern=f"{test_config.short_id}-emc.*0-0",
                 interrupt_at_step=step_to_interrupt,
                 start_time=start_time,
                 end_time=end_time,


### PR DESCRIPTION
# Description
Fix incorrect "pod_pattern" for log validation.

# Tests
- Airflow Test Results: https://00bd7f16ee7e45da99e04dee351b40d8-dot-us-east1.composer.googleusercontent.com/dags/maxtext_emc_orbax_res_gcs/grid?dag_run_id=manual__2025-11-20T01%3A13%3A11.963897%2B00%3A00&tab=graph
- 
#  Airflow/Composer
- GCP Composer name: `ml-automation-solutions-orbax` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.