### PR TITLE
Fix: Update DAG schedule for "validate_interruption_count*" DAGs

### DIFF
--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -487,7 +487,7 @@ def create_interruption_dag(
   Returns:
     An Airflow DAG object."""
   dag_schedule = get_staggered_schedule(
-      Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY, schedule_offset_minutes
+      Schedule.DAILY_PST_6PM, schedule_offset_minutes
   )
   with models.DAG(
       dag_id=dag_id,


### PR DESCRIPTION
# Description

This change updates the schedule of DAGs with prefix "validate_interruption_count" (14 DAGs in total), ensures the DAG runs at the intended daily time.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.