### PR TITLE
Feat(schedule): add schedule times for three DAGs 

### DIFF
--- a/dags/inference/jetstream_inference_e2e.py
+++ b/dags/inference/jetstream_inference_e2e.py
@@ -49,7 +49,7 @@ CKPT = {
 
 with models.DAG(
     dag_id="jetstream_e2e_inference",
-    schedule=None,
+    schedule="0 0 * * *",
     tags=[
         "inference_team",
         "jetstream",

--- a/dags/inference/maxtext_inference_microbenchmark.py
+++ b/dags/inference/maxtext_inference_microbenchmark.py
@@ -227,7 +227,7 @@ with models.DAG(
     dag_id=dag_id,
     tags=tags,
     start_date=datetime.datetime(2024, 1, 19),
-    schedule=None,
+    schedule="0 6 * * *",
     catchup=False,
 ) as dag:
   test_name_prefix = (

--- a/dags/multipod/mxla_gpt3_6b_nightly_gke.py
+++ b/dags/multipod/mxla_gpt3_6b_nightly_gke.py
@@ -25,7 +25,7 @@ from dags.multipod.configs import gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
 # Pause test on GKE
-SCHEDULED_TIME = None
+SCHEDULED_TIME = "0 1 * * *"
 
 with models.DAG(
     dag_id="mxla_gpt_6b_nightly_gke",


### PR DESCRIPTION
### Summary

This PR adds the requested BorgCron schedules to three key test and E2E DAGs within the production testing environment. This change is implemented at the request of the Test Team to enable stable, scheduled runs for continuous monitoring, particularly following a recent regression issue encountered during manual triggers.

### Scheduled DAGs

| DAG ID | Suggested BorgCron Timespec | Action |
| :--- | :--- | :--- |
| `jetstream_e2e_inference` | `0 0 * * *` | Changed `schedule=None` to the cron time. |
| `maxtext-inference-microbenchmark` | `0 6 * * *` | Changed `schedule=None` to the cron time. |
| `mxla_gpt_6b_nightly_gke` | `0 1 * * *` | Changed `SCHEDULED_TIME = None` to the cron time. |
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.