### PR TITLE
Chore: update reservation value

### DIFF
--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -73,7 +73,7 @@ with models.DAG(
     with TaskGroup(group_id=f"v{config.tpu_version.value}"):
       create_node_pool = node_pool.create(
           node_pool=node_pool_info,
-          reservation="cloudtpu-20250131131310-2118578099",
+          reservation="cloudtpu-20251107233000-1246578561",
       )
 
       wait_node_pool_available = node_pool.wait_for_availability(

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -78,7 +78,7 @@ with models.DAG(
       task_id = "create_node_pool"
       create_node_pool = node_pool.create.override(task_id=task_id)(
           node_pool=node_pool_info,
-          reservation="cloudtpu-20250131131310-2118578099",
+          reservation="cloudtpu-20251107233000-1246578561",
       )
 
       task_id = "wait_for_provisioning"

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -369,7 +369,7 @@ with models.DAG(
             retries=2,
         )(
             node_pool=cluster_info,
-            reservation="cloudtpu-20250131131310-2118578099",
+            reservation="cloudtpu-20251107233000-1246578561",
         )
 
         create_second_node_pool = node_pool.create.override(
@@ -377,7 +377,7 @@ with models.DAG(
             retries=2,
         )(
             node_pool=cluster_info_2,
-            reservation="cloudtpu-20250131131310-2118578099",
+            reservation="cloudtpu-20251107233000-1246578561",
         )
 
       apply_time = jobset.run_workload(


### PR DESCRIPTION
# Description

This Pull Request updates the `reservation` parameter in the GCS-based configuration used by the TPU Observability GKE DAGs.

The value has been updated to: `cloudtpu-20251107233000-1246578561`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.