### PR TITLE
GCE DAGs for the v6e-8 need to have its location changed

### DIFF
--- a/dags/inference/maxtext_inference_microbenchmark.py
+++ b/dags/inference/maxtext_inference_microbenchmark.py
@@ -185,8 +185,8 @@ def generate_model_configs(
     subnetwork = V5E_SUBNETWORKS
     runtime_version = RuntimeVersion.V2_ALPHA_TPUV5_LITE.value
   if tpu_version == TpuVersion.TRILLIUM:
-    project_name = Project.CLOUD_ML_AUTO_SOLUTIONS.value
-    zone = Zone.EUROPE_WEST4_A.value
+    project_name = Project.TPU_PROD_ENV_AUTOMATED.value
+    zone = Zone.US_EAST5_A.value
     network = V6E_GCE_NETWORK
     subnetwork = V6E_GCE_SUBNETWORK
     runtime_version = RuntimeVersion.V2_ALPHA_TPUV6.value

--- a/dags/inference/maxtext_model_config_generator.py
+++ b/dags/inference/maxtext_model_config_generator.py
@@ -113,9 +113,9 @@ def generate_model_configs(
     network = V5_NETWORKS
     subnetwork = V5P_SUBNETWORKS
   elif tpu_version == TpuVersion.TRILLIUM:
-    zone = Zone.EUROPE_WEST4_A.value
+    zone = Zone.US_EAST5_A.value
     runtime_version = RuntimeVersion.V2_ALPHA_TPUV6.value
-    project_name = Project.CLOUD_ML_AUTO_SOLUTIONS.value
+    project_name = Project.TPU_PROD_ENV_AUTOMATED.value
     network = V6E_GCE_NETWORK
     subnetwork = V6E_GCE_SUBNETWORK
   jetstream_benchmark_serving = (


### PR DESCRIPTION
# Description

Some DAGs were not scheduled and encountered an Insufficient Capacity error on v6e-8. Adjusting the zone (or region) could resolve this.

This changes:
- adjust the zone (or region) from `UROPE_WEST4_A` to `US_EAST5_A`
- change the project from `CLOUD_ML_AUTO_SOLUTIONS` to `TPU_PROD_ENV_AUTOMATED`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.