### PR TITLE
Fix: Refine the wasted time during retries for DAG jetstream_benchmark_serving

### DIFF
--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -109,12 +109,18 @@ def run_queued_resource_test(
           task_test_config,
       )
 
-      queued_resource_op >> tpu.ssh_tpu.override(task_id="setup")(
+      setup_task = tpu.ssh_tpu.override(
+          task_id="setup",
+          # Setup/install retries don’t need a long cooldown.
+          # 30s is enough for network connection problem; longer delays do not make sense.
+          retry_delay=datetime.timedelta(seconds=30),
+      )(
           queued_resource_name,
           task_test_config.setup_script,
           ssh_keys,
           True if task_test_config.test_name.startswith("tf_") else all_workers,
       )
+      queued_resource_op >> setup_task
 
     run_model = tpu.ssh_tpu.override(
         task_id="run_model",


### PR DESCRIPTION
# Description

With 57 TaskGroups across four parallel branches, the retry wait alone wastes ~570 minutes (~9.5 hours) This change improves the error handling within the ssh_tpu Airflow task to distinguish between critical SSH authentication failures and other command execution errors.

Solution:
- If any host fails with an `AuthenticationException`, the task is failed with a non-retryable `AirflowFailException`.
- If hosts fail due to other exceptions (e.g., `invoke.UnexpectedExit`), the original `fabric.group.GroupException` is re-raised. This allows Airflow's retry mechanism to handle these potentially transient issues as configured for the task.
- Reduce the setup waiting time between  task retries from 5 mins to 30 secs.

# Tests

Ran test on the [ml-automation-solutions-dev composer](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/test_jetstream/grid?dag_run_id=manual__2025-11-25T05%3A53%3A40.403793%2B00%3A00&task_id=max-js-mixtral-8x7b-instruct-w-i8-kv-i8-headsanddkv-rate0_0-pdbs258-dot-0123-1203-1203-v5p-8.provision.setup&tab=logs).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.