### PR TITLE
Fix: Adjust the schedule of clean up DAGs

### DIFF
--- a/dags/map_reproducibility/internal_runs/cleanup_dags.py
+++ b/dags/map_reproducibility/internal_runs/cleanup_dags.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""DAG to cleanup leftover workloads"""
+
 import datetime
 from airflow import models
 from dags import composer_env
-from dags.map_reproducibility.utils.constants import Schedule
 from dags.map_reproducibility.utils.common_utils import get_cluster
 from dags.map_reproducibility.utils.internal_aotc_workload import cleanup_cml_workloads
 
@@ -34,9 +35,7 @@ dag_default_args = {
 
 for hypercomputer in ["a3mega", "a3ultra", "a4"]:
   cluster, cluster_region = get_cluster(hypercomputer)
-  schedule = (
-      Schedule.WEEKDAY_PDT_6AM_7AM_EXCEPT_THURSDAY if not TEST_RUN else None
-  )
+  schedule = "0 13 * * *" if not TEST_RUN else None
   with models.DAG(
       dag_id=f"new_internal_cleanup_{hypercomputer}",
       default_args=dag_default_args,


### PR DESCRIPTION
# Description

This PR aims to optimize the execution frequency of a set of stable DAGs as recommended by the Test Team. The goal is to reduce resource usage by changing these DAGs from their current twice-daily schedule to a more efficient once-per-day execution.

# Changes Implemented

| DAG ID | Original BorgCron timespec | **New BorgCron timespec** | Frequency Change |
| :--- | :--- | :--- | :--- |
| `new_internal_cleanup_a3mega` | `0 13,14 * * 2,3,4,6` | **`0 13 * * *`** | Twice daily -> Once daily (13:00 UTC) |
| `new_internal_cleanup_a3ultra` | `0 13,14 * * 2,3,4,6` | **`0 13 * * *`** | Twice daily -> Once daily (13:00 UTC) |
| `new_internal_cleanup_a4` | `0 13,14 * * 2,3,4,6` | **`0 13 * * *`** | Twice daily -> Once daily (13:00 UTC) |

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.