### PR TITLE
Fix: adjust DAGs schedules

### DIFF
--- a/dags/framework3p/microbenchmarks_dag.py
+++ b/dags/framework3p/microbenchmarks_dag.py
@@ -6,7 +6,7 @@ from dags.framework3p.configs.microbenchmarks_config import get_microbenchmark_c
 
 
 # Run once a day at 2 am
-SCHEDULED_TIME = "0 1 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 0 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(

--- a/dags/maxtext_pathways/pw_mcjax_dags.py
+++ b/dags/maxtext_pathways/pw_mcjax_dags.py
@@ -247,7 +247,7 @@ RECIPE_NAME = RECIPE_INSTANCE.value.lower()
 with models.DAG(
     dag_id=RECIPE_NAME,
     start_date=datetime.datetime(2025, 1, 1),
-    schedule_interval="00 10 * * *",
+    schedule_interval="0 10 * * *",
     catchup=False,
     default_args={
         "retries": 0,

--- a/dags/multipod/jax_functional_tests.py
+++ b/dags/multipod/jax_functional_tests.py
@@ -22,7 +22,7 @@ from dags.multipod.configs import jax_tests_gce_config, jax_tests_gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)
-SCHEDULED_TIME = "0 14 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 19 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="jax_functional_tests",

--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -24,7 +24,7 @@ from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)
-SCHEDULED_TIME = "30 11 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "45 5 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="maxtext_checkpointing",

--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -25,7 +25,7 @@ from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 5 am UTC (9 pm PST / 10 pm PDT)
-SCHEDULED_TIME = "0 5 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "15 1 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(

--- a/dags/multipod/maxtext_configs_aot_hybridsim.py
+++ b/dags/multipod/maxtext_configs_aot_hybridsim.py
@@ -29,7 +29,7 @@ from xlml.apis import metric_config
 
 
 # Run once a day at 1 pm UTC (5 am PST / 6 am PDT)
-SCHEDULED_TIME = "0 13 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 2 * * *" if composer_env.is_prod_env() else None
 
 
 def hybridsim_compile_and_run(test_group_id):

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -25,7 +25,7 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import gcp_config, metric_config, task, test_config
 
 # Run once a day at 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 19 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="maxtext_convergence",

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -26,7 +26,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 4 am UTC (8 pm PST)
-SCHEDULED_TIME = "30 4 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 11 * * *" if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 
 

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -29,7 +29,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import gke
 
 # Run once a day at 4 am UTC (8 pm PST)
-SCHEDULED_TIME = "30 5 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 5 * * *" if composer_env.is_prod_env() else None
 
 # Number of nodes on A3 cluster to be scaled up to
 A3_NUM_NODES = 10

--- a/dags/multipod/maxtext_multi_tier_checkpointing.py
+++ b/dags/multipod/maxtext_multi_tier_checkpointing.py
@@ -23,7 +23,7 @@ from dags.common.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode  # Run once a day at 10 am UTC (2 am PST)
 
-SCHEDULED_TIME = "0 11 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "15 5 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="maxtext_muti_tier_checkpointing",

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -24,7 +24,7 @@ from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="maxtext_profiling",

--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -23,7 +23,7 @@ from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)
-SCHEDULED_TIME = '30 12 * * *' if composer_env.is_prod_env() else None
+SCHEDULED_TIME = '45 6 * * *' if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get('HF_TOKEN', None)
 
 with models.DAG(

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -27,7 +27,7 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config, mlcompass
 
 # Run once a day at 3 am UTC (7 pm PST / 8 pm PDT)
-CONIFGS_SCHEDULED_TIME = "0 10 * * *" if composer_env.is_prod_env() else None
+CONIFGS_SCHEDULED_TIME = "30 10 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),

--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -27,7 +27,7 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config
 
 # Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
-SCHEDULED_TIME = "0 7 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),

--- a/dags/multipod/maxtext_v5p_configs_perf.py
+++ b/dags/multipod/maxtext_v5p_configs_perf.py
@@ -27,7 +27,7 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config
 
 # Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
-SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 1 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),

--- a/dags/multipod/mxla_gpt3_6b_nightly_gke.py
+++ b/dags/multipod/mxla_gpt3_6b_nightly_gke.py
@@ -25,7 +25,7 @@ from dags.multipod.configs import gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
 # Pause test on GKE
-SCHEDULED_TIME = "0 1 * * *"
+SCHEDULED_TIME = "15 0 * * *"
 
 with models.DAG(
     dag_id="mxla_gpt_6b_nightly_gke",

--- a/dags/multipod/mxla_maxtext_nightly_gke.py
+++ b/dags/multipod/mxla_maxtext_nightly_gke.py
@@ -24,7 +24,7 @@ from dags.common.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters, 
 from dags.multipod.configs import gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
-SCHEDULED_TIME = "0 9 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="mxla_maxtext_nightly_gke",

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -18,7 +18,7 @@ from dags.orbax.util import validation_util
 from xlml.utils.gke import zone_to_region
 
 DAG_TEST_NAME = "maxtext_emc_orbax_res_gcs"
-SCHEDULE = "0 10 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "45 3 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id=DAG_TEST_NAME,

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -15,7 +15,7 @@ from dags.orbax.util import checkpoint_util, test_config_util, validation_util
 from xlml.utils.gke import zone_to_region
 
 DAG_TEST_NAME = "maxtext_emc_orbax_res_local"
-SCHEDULE = "0 11 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "30 4 * * *" if composer_env.is_prod_env() else None
 
 
 with models.DAG(

--- a/dags/orbax/maxtext_emc_resume_gcs.py
+++ b/dags/orbax/maxtext_emc_resume_gcs.py
@@ -21,7 +21,7 @@ from dags.orbax.util import test_config_util
 from dags.orbax.util import checkpoint_util
 from xlml.utils.gke import zone_to_region
 
-SCHEDULE = "0 19 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "15 9 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_emc_resume_from_gcs"
 
 with models.DAG(

--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -19,7 +19,7 @@ from xlml.utils.gke import zone_to_region
 from dags.orbax.util import test_config_util
 
 
-SCHEDULE = "0 14 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "30 6 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_emc_save_gcs"
 
 

--- a/dags/orbax/maxtext_mtc_emergency_save_local.py
+++ b/dags/orbax/maxtext_mtc_emergency_save_local.py
@@ -23,7 +23,7 @@ from xlml.utils.gke import zone_to_region
 from dags.orbax.util import test_config_util
 
 
-SCHEDULE = "0 13 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "45 5 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_emc_and_mtc_orbax_save_local"
 
 

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -18,7 +18,7 @@ from dags.orbax.util import validation_util
 from xlml.utils.gke import zone_to_region
 
 DAG_TEST_NAME = "maxtext_mtc_orbax_res_local"
-SCHEDULE = "0 16 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "30 7 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id=DAG_TEST_NAME,

--- a/dags/orbax/maxtext_mtc_resume_gcs.py
+++ b/dags/orbax/maxtext_mtc_resume_gcs.py
@@ -21,7 +21,7 @@ from dags.orbax.util import test_config_util
 from dags.orbax.util import checkpoint_util
 from xlml.utils.gke import zone_to_region
 
-SCHEDULE = "0 20 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "45 9 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_mtc_resume_from_gcs"
 
 with models.DAG(

--- a/dags/orbax/maxtext_mtc_save_gcs.py
+++ b/dags/orbax/maxtext_mtc_save_gcs.py
@@ -19,7 +19,7 @@ from xlml.utils.gke import zone_to_region
 from dags.orbax.util import test_config_util
 
 
-SCHEDULE = "0 15 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "0 7 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_mtc_orbax_save_gcs"
 
 

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -19,7 +19,7 @@ from dags.orbax.util import validation_util, test_config_util
 from xlml.utils.xpk import MAIN_BRANCH
 from xlml.utils.gke import zone_to_region
 
-SCHEDULE = "0 17 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "0 8 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_regular_restore_with_node_disruption"
 
 

--- a/dags/orbax/maxtext_reg_restore_gcs_with_resumed_workload.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_resumed_workload.py
@@ -18,7 +18,7 @@ from dags.orbax.util import validation_util, test_config_util
 from xlml.utils.xpk import MAIN_BRANCH
 from xlml.utils.gke import zone_to_region
 
-SCHEDULE = "0 18 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "45 8 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_regular_restore_with_resumed_workload"
 
 

--- a/dags/orbax/maxtext_reg_save_gcs.py
+++ b/dags/orbax/maxtext_reg_save_gcs.py
@@ -18,7 +18,7 @@ from dags.orbax.util import validation_util, test_config_util
 from xlml.utils.xpk import MAIN_BRANCH
 from xlml.utils.gke import zone_to_region
 
-SCHEDULE = "0 12 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "15 5 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_regular_save"
 
 with models.DAG(

--- a/dags/pytorch_xla/nightly-gpu.py
+++ b/dags/pytorch_xla/nightly-gpu.py
@@ -21,7 +21,7 @@ from dags.common.vm_resource import Project, Zone, V5_NETWORKS, V5E_SUBNETWORKS,
 
 
 # Run once a day at 2 pm UTC (6 am PST)
-SCHEDULED_TIME = "0 16 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 11 * * *" if composer_env.is_prod_env() else None
 
 US_CENTRAL1 = gcp_config.GCPConfig(
     Project.CLOUD_ML_AUTO_SOLUTIONS.value,

--- a/dags/pytorch_xla/nightly-tpu.py
+++ b/dags/pytorch_xla/nightly-tpu.py
@@ -21,7 +21,7 @@ from dags.common.vm_resource import Project, Zone, V5_NETWORKS, V5E_SUBNETWORKS,
 
 
 # Run once a day at 2 pm UTC (6 am PST)
-SCHEDULED_TIME = "0 14 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 9 * * *" if composer_env.is_prod_env() else None
 
 US_CENTRAL1_C = gcp_config.GCPConfig(
     Project.CLOUD_ML_AUTO_SOLUTIONS.value,

--- a/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
@@ -27,7 +27,7 @@ from xlml.utils import name_format
 from xlml.apis import metric_config
 
 # Run once a day at 3 am UTC (7 pm PST)
-SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "15 1 * * *" if composer_env.is_prod_env() else None
 BASE_OUTPUT_DIRECTORY = gcs_bucket.BASE_OUTPUT_DIR
 
 

--- a/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
@@ -27,7 +27,7 @@ from xlml.apis import metric_config
 from xlml.utils import name_format
 
 # Run once a day at 4 am UTC (8 pm PST)
-SCHEDULED_TIME = "30 6 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "45 15 * * *" if composer_env.is_prod_env() else None
 
 BASE_OUTPUT_DIRECTORY = gcs_bucket.BASE_OUTPUT_DIR
 

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -26,7 +26,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 1 am UTC (5 pm PST)
-SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 
 

--- a/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/project_bite_tpu_e2e.py
@@ -24,7 +24,7 @@ from airflow.utils.task_group import TaskGroup
 
 
 # Run once a day at 6 pm UTC (11 am PST)
-SCHEDULED_TIME = '0 18 * * *' if composer_env.is_prod_env() else None
+SCHEDULED_TIME = '30 12 * * *' if composer_env.is_prod_env() else None
 
 trillium_conf = {
     'tpu_version': TpuVersion.TRILLIUM,


### PR DESCRIPTION
# Description

The test team identified several DAGs that share the same cluster and have schedules that are too close to each other. This proximity was causing resource conflicts and potential instability.

This PR staggers the DAG schedules to reduce resource contention, stabilize the cluster, and improve DAG reliability.

# Action

Manually updated the cron schedules for the DAGs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.