### PR TITLE
Revert "Feat: Update xpk pinned version to delete workaround (#1024)"

### DIFF
--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -30,9 +30,9 @@ from xlml.apis import metric_config
 from xlml.utils import gke, composer
 from dags.common.vm_resource import GpuVersion
 
-# NOTE: This version needs to be pinned to ensure compatibility when using
-# xpk.py for workload creation.
-MAIN_BRANCH = "v0.15.0"
+# b/411426745 - Using sed workaround to comment out validate_dependencies()
+# in xpk main.py to upgrade the version from 0.4.1 to 0.12.0.
+MAIN_BRANCH = "v0.12.0"
 
 # Duration = past 7 days
 LOGGING_URL_FORMAT = (
@@ -59,10 +59,14 @@ def get_xpk_setup_cmd(tmpdir, branch: str = MAIN_BRANCH):
 
   pip_install = "pip install ruamel.yaml docker"
 
+  # b/411426745 - Workaround: Comment out validate_dependencies() call to avoid dependency validation issues
+  comment_out_validation = f"sed -i '/validate_dependencies()/s/^/## /' {tmpdir}/xpk/src/xpk/main.py || true"
+
   cmds = [
       bash_setup,
       clone_branch,
       pip_install,
+      comment_out_validation,
   ]
   return cmds
 
@@ -140,7 +144,6 @@ def run_workload(
         f" --{multi_keyword}={num_slices} --docker-image={docker_image}"
         f" --project={cluster_project} --zone={zone}"
         f" --env {metric_config.SshEnvVars.GCS_OUTPUT.name}={gcs_path}"
-        f" --skip-validation"
     )
 
     if ramdisk_directory and not use_pathways:


### PR DESCRIPTION
This reverts commit 9e87e6925c15c1f5777e5932de6c57b12a185424.

# Description

This pull request introduces a workaround to address dependency validation issues when using `xpk.py` for workload creation, specifically related to upgrading the version of the main branch. The most important changes include pinning the `MAIN_BRANCH` to a compatible version, adding a command to comment out the problematic `validate_dependencies()` call, and removing the `--skip-validation` flag from the workload command.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.