### PR TITLE
Fix typo in TPU observability tag and cluster name

### DIFF
--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -20,6 +20,7 @@ from airflow import models
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
+from dags import composer_env
 from dags.common.vm_resource import Region, Zone
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
@@ -38,7 +39,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         "cloud-ml-auto-solutions",
         "jobset",
         "time-to-recover",
-        "tpu-obervability",
+        "tpu-observability",
         "rollback",
         "TPU",
         "v6e-16",
@@ -69,12 +70,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       timeout, and fail.
       """,
 ) as dag:
+  cluster_name = "tpu-observability-automation"
+  cluster_name += "-prod" if composer_env.is_prod_env() else "-dev"
+
   for machine in MachineConfigMap:
     config = machine.value
     cluster_info = node_pool.Info(
         project_id=models.Variable.get("PROJECT_ID", default_var="cienet-cmcs"),
         cluster_name=models.Variable.get(
-            "CLUSTER_NAME", default_var="tpu-observability-automation"
+            "CLUSTER_NAME", default_var=cluster_name
         ),
         node_pool_name=models.Variable.get(
             "NODE_POOL_NAME", default_var="jobset-ttr-rollback-v6e"


### PR DESCRIPTION
# Description

- Fix a typo in the tags for "tpu-observability"
- Change cluster name to be "tpu-observability-automation-prod"

# Tests
- DAG Name: jobset_rollback_ttr
- Airflow test runs: https://b371d513bb74418681c3aab7b27bbf12-dot-us-east1.composer.googleusercontent.com/dags/jobset_rollback_ttr/grid?tab=logs&dag_run_id=scheduled__2025-12-08T02%3A00%3A00%2B00%3A00&task_id=v6e.create

## Airflow / Composer Environment
- GCP Project: cloud-ml-auto-solutions
- Composer Environment: ml-automation-solutions
- Composer Version: 2.13.1

## Required Variables
- Cluster Information (This DAG requires an existing cluster)
  - `PROJECT_ID`: cienet-cmcs
  - `CLUSTER_NAME`: tpu-observability-automation-prod
  - `LOCATION`: us-central1
  - `NODE_LOCATIONS`: us-central1-b
 
- Node Pool / Machine Configuration
  - `NODE_POOL_NAME`: jobset-ttr-rollback-v6e
  - `NUM_NODES`: 4
  - `MACHINE_TYPE`: ct6e-standard-4t
  - `TPU_TOPOLOGY`: 4x4

# Checklist

- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.