### PR TITLE
Implement GCS-based DAG Configuration

### DIFF
--- a/dags/tpu_observability/configs/common.py
+++ b/dags/tpu_observability/configs/common.py
@@ -19,3 +19,8 @@ class MachineConfigMap(enum.Enum):
       tpu_topology="4x4",
       machine_version=MachineVersion.CT6E_STAND_4T,
   )
+
+
+GCS_CONFIG_PATH = (
+    "gs://ml-auto-solutions-dag-configs/tpu_observability/dag_config.yaml"
+)

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -20,16 +20,14 @@ pool as expected.
 import datetime
 
 from airflow import models
-from airflow.models import Variable
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
 from dags.map_reproducibility.utils import constants
-from dags.common.vm_resource import Region, Zone
+from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
-from dags.tpu_observability.configs.common import MachineConfigMap
 
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -74,21 +72,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 ) as dag:
   for machine in MachineConfigMap:
     config = machine.value
-    cluster_name = "tpu-observability-automation"
-    cluster_name += "-prod" if composer_env.is_prod_env() else "-dev"
-    node_pool_info = node_pool.Info(
-        project_id="cienet-cmcs",
-        cluster_name=cluster_name,
-        node_pool_name=Variable.get(
-            "NODE_POOL_NAME", default_var="multi-host-nodepool-rollback-auto"
-        ),
-        location=Variable.get("LOCATION", default_var=Region.US_CENTRAL1.value),
-        node_locations=Variable.get(
-            "NODE_LOCATIONS", default_var=Zone.US_CENTRAL1_B.value
-        ),
-        num_nodes=Variable.get("NUM_NODES", default_var=4),
-        machine_type=config.machine_version.value,
-        tpu_topology=config.tpu_topology,
+    LABELS_TO_UPDATE = (
+        {"env": "prod"} if composer_env.is_prod_env() else {"env": "dev"}
     )
 
     # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -96,9 +81,18 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="multi_host_nodepool_rollback",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
       create_node_pool = node_pool.create.override(owner=test_owner.QUINN_M)(
           node_pool=node_pool_info,
-          reservation="cloudtpu-20251107233000-1246578561",
       )
 
       wait_node_pool_available = node_pool.wait_for_availability(
@@ -127,7 +121,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       # Airflow uses >> for task chaining, which is pointless for pylint.
       # pylint: disable=pointless-statement
       (
-          create_node_pool
+          node_pool_info
+          >> create_node_pool
           >> wait_node_pool_available
           >> rollback_node_pool
           >> wait_node_pool_unavailable

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -24,9 +24,8 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
-from dags.common.vm_resource import Region, Zone
 from dags.map_reproducibility.utils import constants
-from dags.tpu_observability.configs.common import MachineConfigMap
+from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -60,38 +59,30 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 ) as dag:
   for machine in MachineConfigMap:
     config = machine.value
-    cluster_name = "tpu-observability-automation"
-    cluster_name += "-prod" if composer_env.is_prod_env() else "-dev"
-    node_pool_info = node_pool.Info(
-        project_id="cienet-cmcs",
-        cluster_name=cluster_name,
-        node_pool_name=models.Variable.get(
-            "NODE_POOL_NAME", default_var="update-node-pool-label-v6e-autotest"
-        ),
-        location=models.Variable.get(
-            "LOCATION", default_var=Region.US_CENTRAL1.value
-        ),
-        node_locations=models.Variable.get(
-            "NODE_LOCATIONS", default_var=Zone.US_CENTRAL1_B.value
-        ),
-        num_nodes=models.Variable.get("NUM_NODES", default_var=4),
-        machine_type=config.machine_version.value,
-        tpu_topology=config.tpu_topology,
+    LABELS_TO_UPDATE = (
+        {"env": "prod"} if composer_env.is_prod_env() else {"env": "dev"}
     )
-
-    LABELS_TO_UPDATE = {"env": "prod"}
 
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="gke_node_pool_label_update",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
       create_node_pool = node_pool.create.override(
           task_id="create_node_pool",
           owner=test_owner.YUNA_T,
       )(
           node_pool=node_pool_info,
-          reservation="cloudtpu-20251107233000-1246578561",
       )
 
       wait_for_availability = node_pool.wait_for_availability.override(
@@ -119,7 +110,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       # Airflow uses >> for task chaining, which is pointless for pylint.
       # pylint: disable=pointless-statement
       (
-          create_node_pool
+          node_pool_info
+          >> create_node_pool
           >> wait_for_availability
           >> update_node_pool_label
           >> wait_for_unavailable


### PR DESCRIPTION
# Description
feat: Implement GCS-based DAG Configuration with Airflow TaskFlow

This Pull Request refactors the configuration management for several TPU observability DAGs to use a centralized YAML file stored in Google Cloud Storage. This approach replaces hardcoded parameters and cumbersome Airflow Variables, enabling more flexible and manageable DAG configurations.

## Implementation Details

### Technical Architecture

The configuration loading is designed to be executed within an Airflow task:

-   **GCS Configuration Loader as a Normal Function**: The core logic to load and parse YAML from GCS is now encapsulated in `load_yaml_from_gcs` in `xlml/apis/gcs.py`. This is a *normal Python function* (not an `@task`). 

-   **`@task build_node_pool_info_from_gcs_yaml`**: This new `@task` in `dags/tpu_observability/utils/node_pool_util.py` is responsible for building the `node_pool.Info` dataclass. Crucially, it *calls* the normal function `gcs.load_yaml_from_gcs(gcs_path)` *within its execution*. This ensures that the GCS file is read only when this task runs, not during DAG parsing.

-   **XComArg Lazy Evaluation**: When DAGs call `node_pool.build_node_pool_info_from_gcs_yaml`, it returns an `XComArg`. Subsequent tasks that depend on the `node_pool.Info` object will receive the fully resolved dataclass instance from XCom.

-   **Task-based Calculations**: All operations and dataclass instantiations that depend on the loaded configuration are now properly wrapped within `@task` decorators, ensuring they execute within the Airflow runtime context.

## Key Changes

*   **`xlml/apis/gcs.py` - Normal Function for GCS YAML Loading:**
    *   Introduced `load_yaml_from_gcs(gcs_path)`, a standard Python function. It securely fetches `dag_config.yaml` from `gs://ml-auto-solutions-configs`.

*   **`dags/tpu_observability/utils/node_pool_util.py` - Flexible Node Pool Info Management:**
    *   New `@task build_node_pool_info_from_gcs_yaml`: This task *calls* `gcs.load_yaml_from_gcs` to get the `config dict`. It then merges values from the 'common' section, a DAG-specific `section_name`, and `**overrides` to create a `node_pool.Info` dataclass. Includes warnings for unknown fields and uses `.get()` for safe dictionary access.
    *   New `@task copy_node_pool_info_with_override`: Safely creates modified `node_pool.Info` copies using `dataclasses.replace`.

*   **Refactored TPU Observability DAGs:**
    *   The following DAGs now use `node_pool.build_node_pool_info_from_gcs_yaml.override()` as a task:
        *   `dags/tpu_observability/node_pool_status.py`
        *   `dags/tpu_observability/multi_host_nodepool_rollback_dag.py`
        *   `dags/tpu_observability/update_node_pool_label.py`
        *   `dags/tpu_observability/tpu_info_format_validation_dags.py`
    *   This task returns an `XComArg` representing the `node_pool.Info`, which is then passed to subsequent tasks.
    *   Configuration details are accessed within these tasks, where the `dag_config` dictionary is fully resolved.

*   **Centralized YAML Configuration:** Configurations are sourced from `gs://ml-auto-solutions-dag-configs/tpu_observability/dag_config.yaml` (`GCS_CONFIG_PATH`). The YAML includes a `env` section and `dag` section.

# Tests

- GCP Composer name: [tony-test](https://de173bfeed494edaade7b4b5cdc284d8-dot-us-east1.composer.googleusercontent.com) (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.