### PR TITLE
Update maxtext tpu docker image

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -340,16 +340,12 @@ class DockerImage(enum.Enum):
       "us-docker.pkg.dev/tpu-prod-env-multipod/bite/gpu/jax_nightly:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXTEXT_TPU_JAX_STABLE_STACK = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:"
+  MAXTEXT_TPU_JAX_NIGHTLY = (
+      "gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
-  MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_stable_stack_nightly_jax:"
-      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
-  )
-  MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_stable_stack_candidate:"
+  MAXTEXT_TPU_JAX_STABLE = (
+      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXDIFFUSION_TPU_JAX_STABLE_STACK = (
@@ -365,10 +361,6 @@ class DockerImage(enum.Enum):
   )
   MAXDIFFUSION_TPU_JAX_STABLE_STACK_CANDIDATE = (
       "gcr.io/tpu-prod-env-multipod/maxdiffusion_stable_stack_candidate:"
-      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
-  )
-  MAXTEXT_TPU_JAX_NIGHTLY = (
-      "gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:"
       f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
   )
   MAXTEXT_GPU_JAX_STABLE_STACK = (

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -48,7 +48,7 @@ with models.DAG(
           time_out_in_min=60,
           base_output_directory=base_output_directory,
           num_slices=[1],
-          docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
+          docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
           run_name_prefix="maxtext-16b",
           base_run_model_cmds=base_run_model_cmds,
           sweep_params={"M_PER_DEVICE_BATCH_SIZE": [2, 4, 8]},

--- a/dags/multipod/jax_functional_tests.py
+++ b/dags/multipod/jax_functional_tests.py
@@ -38,7 +38,7 @@ with models.DAG(
   v5p_runtime_version = RuntimeVersion.V2_ALPHA_TPUV5.value
   test_modes_with_docker_images = [
       (SetupMode.STABLE, None),
-      (SetupMode.JAX_STABLE_STACK, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+      (SetupMode.JAX_STABLE_STACK, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
 

--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -47,8 +47,8 @@ with models.DAG(
   current_time = datetime.datetime.now()
   current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE),
-      (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
+      (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
 
   for mode, image in docker_images:

--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -64,7 +64,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   }
   num_slices = [1, 2]
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
 

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -84,7 +84,7 @@ with models.DAG(
         time_out_in_min=300,
         test_name=test_name,
         run_model_cmds=run_command,
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE.value,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
         test_owner=test_owner.MATT_D,
         base_output_directory=base_output_directory,
         metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -99,7 +99,7 @@ with models.DAG(
         time_out_in_min=60,
         test_name=f"{test_name_prefix}-stable-{model}",
         run_model_cmds=model_cmds,
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE.value,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
         cluster=XpkClusters.TPU_V5P_8_CLUSTER,
         test_owner=test_config["owner"],
     ).run_with_quarantine(quarantine_task_group)
@@ -107,7 +107,7 @@ with models.DAG(
         time_out_in_min=60,
         test_name=f"{test_name_prefix}-nightly-{model}",
         run_model_cmds=model_cmds,
-        docker_image=DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
         cluster=XpkClusters.TPU_V5P_8_CLUSTER,
         test_owner=test_config["owner"],
     ).run_with_quarantine(quarantine_task_group)
@@ -179,8 +179,8 @@ with models.DAG(
       return conversion_cpu, training_tpu
 
   docker_image = {
-      "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE.value,
-      "nightly": DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
+      "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
+      "nightly": DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
   }
   tests = []
   for model, test_scripts_details in multicluster_test_models.items():

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -45,7 +45,7 @@ with models.DAG(
   base_output_directory = f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext_profiling"
   dataset_path = gcs_bucket.MAXTEXT_DIR
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
 

--- a/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
+++ b/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
@@ -38,7 +38,7 @@ with models.DAG(
   )
   dataset_path = gcs_bucket.MAXTEXT_DIR
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
   test_configs = {

--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -44,8 +44,8 @@ with models.DAG(
 ) as dag:
   base_output_directory = f'{gcs_bucket.BASE_OUTPUT_DIR}/maxtext_sft_trainer'
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE),
-      (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
+      (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
   test = []
   for mode, image in docker_images:

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -29,7 +29,7 @@ from xlml.apis import metric_config, mlcompass
 # Run once a day at 3 am UTC (7 pm PST / 8 pm PDT)
 CONIFGS_SCHEDULED_TIME = "30 10 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
-    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
     (SetupMode.TPU_RECIPES, DockerImage.MAXTEXT_JAX_052_RECIPES_012),
 ]
@@ -77,9 +77,9 @@ with models.DAG(
         continue
       if (
           model in need_stable_candidate_set
-          and image == DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK
+          and image == DockerImage.MAXTEXT_TPU_JAX_STABLE
       ):
-        image = DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE
+        image = DockerImage.MAXTEXT_TPU_JAX_STABLE
 
       base_run_model_cmds = [
           f"python3 -m benchmarks.benchmark_runner on-device --base_output_directory={BASE_OUTPUT_DIRECTORY} --model_name={model.value} --libtpu_type=maxtext-docker --num_steps=15",

--- a/dags/multipod/maxtext_v5e_configs_perf.py
+++ b/dags/multipod/maxtext_v5e_configs_perf.py
@@ -29,7 +29,7 @@ from xlml.apis import metric_config
 # Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
 SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
-    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
 ]
 QUANTIZATION_SWEEP = {"M_QUANTIZATION": ["", "int8"]}

--- a/dags/multipod/maxtext_v5p_configs_perf.py
+++ b/dags/multipod/maxtext_v5p_configs_perf.py
@@ -29,7 +29,7 @@ from xlml.apis import metric_config
 # Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
 SCHEDULED_TIME = "0 1 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
-    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
 ]
 QUANTIZATION_SWEEP = {"M_QUANTIZATION": ["", "int8"]}

--- a/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
@@ -65,7 +65,7 @@ with models.DAG(
   )
 
   maxtext_docker_images = [
-      (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX),
+      (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
 
   maxdiffusion_docker_images = [

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -52,8 +52,8 @@ with models.DAG(
       group_id="Quarantine", dag=dag, prefix_group_id=False
   )
   docker_image = {
-      "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
-      "nightly": DockerImage.MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX.value,
+      "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
+      "nightly": DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
   }
 
   # Unchained tests
@@ -74,10 +74,6 @@ with models.DAG(
   unchained_tests = []
   for model, test_scripts_details in test_models_tpu.items():
     for image in docker_image.keys():
-      # TODO(shuningjin): remove this once stable image is upgraded
-      # gpt-oss with flash attention requires jax>=0.7.2, skip stable image
-      if model.startswith("gpt-oss") and image == "stable":
-        continue
       training_tpu = gke_config.get_gke_config(
           time_out_in_min=test_scripts_details["time_out_in_min"],
           test_name=f"{test_name_prefix}_{image}_{model}",


### PR DESCRIPTION
# Description

Due to maxtext docker build [change](https://github.com/AI-Hypercomputer/maxtext/commit/eddf738c018b72c98e91db394384a802634fb4b4#diff-c0263d29e4849d2a3dec28f159eb677bd372a147b66bb383787e2add11313940), the images are being deprecated: maxtext_stable_stack_nightly_jax, maxtext_stable_stack_candidate, maxtext_jax_stable_stack. Consequently, we are migrating images for DAGs.

FIX: b/471026900, b/471026903

migrate: nightly - 1 -> 4,  stable - 2 & 3 -> 5
```
# OLD
# 1
  MAXTEXT_TPU_STABLE_STACK_NIGHTLY_JAX = (
      "gcr.io/tpu-prod-env-multipod/maxtext_stable_stack_nightly_jax:"
      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
  )
# 2
  MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE = (
      "gcr.io/tpu-prod-env-multipod/maxtext_stable_stack_candidate:"
      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
  )
# 3
  MAXTEXT_TPU_JAX_STABLE_STACK = (
      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:"
      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
  )

# NEW
# 4
  MAXTEXT_TPU_JAX_NIGHTLY = (
      "gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:"
      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
  )
# 5
  MAXTEXT_TPU_JAX_STABLE = (
      "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable:"
      f"{datetime.datetime.today().strftime('%Y-%m-%d')}"
  )
```

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.