### PR TITLE
Feat: update DAG scheduling to Taipei nighttime and disable dev auto-scheduling

### DIFF
--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -12,10 +12,10 @@ from airflow.utils.task_group import TaskGroup
 
 from dags.common import test_owner
 from dags.common.vm_resource import Project
-from dags.map_reproducibility.utils.constants import Schedule
 from dags.multipod.configs.common import Platform
 from dags.tpu_observability.utils import gcp_util, time_util
 from google.cloud import monitoring_v3
+from dags import composer_env
 
 
 _UNKNOWN_RESOURCE_NAME = 'Unknown'
@@ -488,9 +488,10 @@ def create_interruption_dag(
 
   Returns:
     An Airflow DAG object."""
-  dag_schedule = get_staggered_schedule(
-      Schedule.DAILY_PST_6PM, schedule_offset_minutes
-  )
+  if composer_env.is_prod_env():
+    dag_schedule = get_staggered_schedule('0 18 * * *', schedule_offset_minutes)
+  else:
+    dag_schedule = None
   with models.DAG(
       dag_id=dag_id,
       start_date=datetime.datetime(2025, 7, 20),

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -26,13 +26,12 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import JobSet, Workload
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 
-
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id="jobset_rollback_ttr",
     start_date=datetime.datetime(2025, 8, 10),
-    schedule="00 02 * * *",
+    schedule="0 18 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=[
         "cloud-ml-auto-solutions",

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -25,7 +25,6 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
-from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 
@@ -35,7 +34,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id="multi-host-availability-rollback",
     start_date=datetime.datetime(2025, 8, 10),
-    schedule=constants.Schedule.DAILY_PST_6_30PM,
+    schedule="30 18 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=[
         "cloud-ml-auto-solutions",

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -23,7 +23,6 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
-from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 
@@ -33,7 +32,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id="gke_node_pool_status",
     start_date=datetime.datetime(2025, 8, 1),
-    schedule=constants.Schedule.DAILY_PST_6PM,
+    schedule="0 18 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=["gke", "tpu-observability", "node-pool-status", "TPU", "v6e-16"],
     description=(

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -29,7 +29,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 with models.DAG(
     dag_id="node_pool_ttr_update_label",
     start_date=datetime.datetime(2025, 9, 30),
-    schedule="0 4 * * *",
+    schedule="0 20 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=[
         "gke",

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -33,7 +33,6 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
-from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.configs.common import (
     MachineConfigMap,
     TpuConfig,
@@ -292,7 +291,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id="tpu_info_format_validation_dag",
     start_date=datetime.datetime(2025, 8, 15),
     default_args={"retries": 0},
-    schedule=constants.Schedule.DAILY_PST_7PM,
+    schedule="0 19 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=["gke", "tpu-observability", "tpu-info", "TPU", "v6e-16"],
     description=(

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -24,7 +24,6 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
-from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 
@@ -33,7 +32,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id="gke_node_pool_label_update",
     start_date=datetime.datetime(2025, 8, 1),
-    schedule=constants.Schedule.DAILY_PST_7_30_PM,
+    schedule="30 19 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=["gke", "tpu-observability", "node-pool-status", "TPU", "v6e-16"],
     description=(


### PR DESCRIPTION
# Description

This PR optimizes the scheduling for tpu-observability related DAGs and adjusts environment-specific configurations. The core change moves the auto-execution time to Taipei nighttime (TST) to improve observability and ensures the Dev environment does not consume unnecessary resources.

# Tests

- Scheduling Verification:
  - Dag name: `gke_node_pool_status` (and other relevant observability DAGs).
  - Adjustment: Updated `schedule` to `0 18 * * * (UTC)`, targeting **02:00 AM Taipei Time (TST)**.
  - Airflow test results: https://35b13c750f364c56b55b9367bb681dee-dot-us-central1.composer.googleusercontent.com/dags/gke_node_pool_status/grid

- Environment Verification:
  - Dag name: `gke_node_pool_label_update` (and other relevant observability DAGs).
  - Dev Environment Check: Confirmed that the DAG schedule is set to None in the Dev Composer environment.
  - Airflow test results: https://35b13c750f364c56b55b9367bb681dee-dot-us-central1.composer.googleusercontent.com/dags/gke_node_pool_label_update/grid
# Airflow/Composer

- GCP Composer name: ml-automation-solutions-dev (under GCP project: cloud-ml-auto-solutions)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5

# Required Variables (Shared across 7 DAGs)

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to node-pool-status-v6e-autotest)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.