### PR TITLE
fix: Repair DAG `pw_mcjax_benchmark_recipe`

### DIFF
--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -56,6 +56,7 @@ RISHABH_B = "notabee"
 NUOJIN_C = "NuojCheng"
 BRANDEN_V = "bvandermoon"
 HENGTAO_G = "hengtaoguo"
+DORA_H = "RUEI4341"
 
 # Multi-tier Checkpointing
 ABHINAV_S = "abhinavclemson"

--- a/dags/maxtext_pathways/configs/parameters.py
+++ b/dags/maxtext_pathways/configs/parameters.py
@@ -32,13 +32,13 @@ DEVICE_VERSION = ["v" + version.value for version in TpuVersion]
 
 PARAMETERS = {
     "user": Param(
-        "username",
+        "root",
         type="string",
         title="User",
         description="User name is used to confirm the first three characters of the pod in the cluster.",
     ),
     "cluster_name": Param(
-        "juliekuo-v5e-32",
+        "pw-v6e-64",
         type="string",
         title="Cluster Name",
         description="GCP cluster name for training model.",
@@ -50,27 +50,27 @@ PARAMETERS = {
         description="GCP project ID for training model.",
     ),
     "zone": Param(
-        "us-central1-a",
+        "us-central1-b",
         type="string",
         title="Zone",
         description="Cluster zone.",
     ),
     "device_version": Param(
-        "v5litepod",
+        "v6e",
         type="string",
         title="Device Version",
         description='Device type for the cluster. ex: "v5litepod"-32',
         enum=DEVICE_VERSION,
     ),
     "core_count": Param(
-        32,
+        64,
         type="integer",
         title="Core Count",
-        description='Device core count for the cluster. ex: v5litepod-"32"',
+        description='Device core count for the cluster. ex: v6e-"64"',
     ),
     "service_account": Param(
-        "one-click@cienet-cmcs.iam.gserviceaccount.com",
-        type="string",
+        None,
+        type=["string", "null"],
         title="Service account",
         description="Service account of the project.",
     ),
@@ -88,21 +88,21 @@ PARAMETERS = {
     ),
     "server_image": Param(
         # TODO(b/451750407): Replace this temporary image with a formal one.
-        "gcr.io/tpu-prod-env-one-vm/lidanny/unsanitized_server:latest",
+        "gcr.io/cienet-cmcs/lidanny/unsanitized_server:latest",
         type="string",
         title="Server Image",
         description="Server image for pathways.",
     ),
     "proxy_image": Param(
         # TODO(b/451750407): Replace this temporary image with a formal one.
-        "gcr.io/tpu-prod-env-one-vm/lidanny/unsanitized_proxy_server:latest",
+        "gcr.io/cienet-cmcs/lidanny/unsanitized_proxy_server:latest",
         type="string",
         title="Proxy Image",
         description="Proxy image for pathways.",
     ),
     "runner": Param(
         # TODO(b/451750407): Replace this temporary image with a formal one.
-        "gcr.io/tpu-prod-env-one-vm/lidanny_latest:latest",
+        "gcr.io/cienet-cmcs/lidanny_latest:latest",
         type="string",
         title="Runner Image",
         description="Runner image for the cluster.",
@@ -115,7 +115,7 @@ PARAMETERS = {
         enum=MODEL_FRAMEWORK,  # dropdown menu
     ),
     "selected_model_names": Param(
-        "llama3_1_8b_8192_v5e_256",
+        "default_basic_1",  # Available model for device type 'v6e'
         type="string",
         title="Model Name",
         description='Select a model name to run. Only when "customized_model_name" is selected for "Model Name", the input value of "customized_model_name" parameter will take effect.',
@@ -141,7 +141,7 @@ PARAMETERS = {
         description="Max restarts for the workload",
     ),
     "bq_enable": Param(
-        True,
+        False,
         type="boolean",
         title="BigQuery Enable",
         description="Enable BigQuery to store metrics data",


### PR DESCRIPTION
# Description

This change repairs the `pw_mcjax_benchmark_recipe` DAG by updating the cluster and refining the installation commands to ensure compatibility with the current environment.

# Tests

**List links for test :** ...](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pw_mcjax_benchmark_recipe/grid?dag_run_id=manual__2025-12-22T09%3A37%3A44%2B00%3A00&tab=logs&task_id=check_recipe_log)

# Required Variables

- DAG conf Parameters (This DAG requires an existing cluster)
  - User: User name is used to confirm the first three characters of the pod in the cluster.
  - Cluster Name: The name of the target GKE cluster. (Default to pw-v6e-64)
  - Project: GCP project ID for training model.
  - Zone: The zone of the GKE cluster. (Default to us-central1-b)
  - Device Version: Device type for the cluster. ex: "v5litepod"-32 (Default to v6e)
  - Core Count: Device core count for the cluster. ex: v6e-"64" (Default to 64)
  - Service account(Optional): Service account of the project.
  - Benchmark Steps: Number of benchmark steps. (Default to 20)
  - Number Slices: Number of slices (Default to 1)
  - Server Image: Server image for pathways.
  - Proxy Image: Proxy image for pathways.
  - Runner Image: Runner image for the cluster.
  - Model Framework : Model framework to run. (Default to pathway)
  - Model Name : Select a model name to run. Only when "customized_model_name" is selected for "Model Name", the input value of "customized_model_name" parameter will take effect.
  - Priority : Priority for the workload (Default to medium)
  - Max Restarts: Max restarts for the workload (Default to 1)
  - BigQuery Enable: Boolen, Enable BigQuery to store metrics data (Default to False)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.