### PR TITLE
Fix DAG maxtext_emc_save_gcs pod pattern regex.

### DIFF
--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -133,7 +133,7 @@ with models.DAG(
             location=zone_to_region(test_config.cluster.zone),
             cluster_name=test_config.cluster.name,
             ram_disk="gcs",
-            pod_pattern=".*-0-0",
+            pod_pattern=f"{test_config.short_id}-emc.*-0",
             start_time=start_time,
             end_time=end_time,
             steps_to_validate=steps_to_validate,


### PR DESCRIPTION


# Description

This PR fix the failure of maxtext_emc_save_gcs DAG.
It corrects the pod_pattern regex from `.*-0-0` -> `{test_config.short_id}.*-0` . We need to check in all pods in first slice (Slice 0)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [ ] I have made or will make corresponding changes to the doc if needed.