### PR TITLE
fix: correct docstring for get_active_pods task

### DIFF
--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -403,19 +403,19 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           namespace=jobset_config.namespace,
       )
 
-      active_pods = jobset.get_active_pods.override(task_id="get_active_pod")(
+      pod_names = jobset.list_pod_names.override(task_id="list_pod_names")(
           node_pool=cluster_info,
           namespace=jobset_config.namespace,
       )
 
       wait_for_job_start = jobset.wait_for_jobset_started.override(
           task_id="wait_for_job_start"
-      )(cluster_info, pod_name_list=active_pods, job_apply_time=apply_time)
+      )(cluster_info, pod_name_list=pod_names, job_apply_time=apply_time)
 
       outputs_of_tpu_info = (
           get_tpu_info_from_pod.override(task_id="get_tpu_info")
           .partial(info=cluster_info)
-          .expand(pod_name=active_pods)
+          .expand(pod_name=pod_names)
       )
 
       output_of_tpu_info = (
@@ -514,7 +514,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           >> cluster_info_2
           >> create_node_pool
           >> apply_time
-          >> active_pods
+          >> pod_names
           >> wait_for_job_start
           >> outputs_of_tpu_info
           >> output_of_tpu_info

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -420,20 +420,24 @@ def end_workload(node_pool: node_pool_info, jobset_name: str, namespace: str):
 
 
 @task
-def get_active_pods(node_pool: node_pool_info, namespace: str) -> list[str]:
+def list_pod_names(node_pool: node_pool_info, namespace: str) -> list[str]:
   """
-  Deletes all JobSets from the GKE cluster to clean up resources.
+  Retrieves a list of active pod names from a specific GKE cluster namespace.
 
-  This task executes a bash script to:
-  1. Authenticate `gcloud` with the specified GKE cluster.
-  2. Delete all JobSets in the `default` namespace using `kubectl`.
+  This task executes a series of shell commands to:
+  1. Authenticate `gcloud` and generate a temporary kubeconfig for the cluster.
+  2. Query `kubectl` to fetch pod names filtered by the provided namespace.
 
   Args:
     node_pool: Configuration object with cluster details.
-    namespace: The YamlConfig object containing namespace information.
+    namespace: The Kubernetes namespace to query for pods.
 
   Returns:
-    A list of pod names.
+    A list of strings representing the names of the active pods.
+
+  Raises:
+    AirflowFailException: If the command returns an empty output or fails to
+      retrieve any pod names.
   """
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()


### PR DESCRIPTION
# Description

This PR renames the @task function from get_active_pods to list_pod_names to more accurately reflect its behavior (returning a list of strings rather than pod objects). It also cleans up the Docstring which contained redundant and conflicting information about JobSet deletion.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.