### PR TITLE
fix: Fixed DAG maxtext_emc_save_gcs. Change pod pattern regex.

### DIFF
--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -133,7 +133,7 @@ with models.DAG(
             location=zone_to_region(test_config.cluster.zone),
             cluster_name=test_config.cluster.name,
             ram_disk="gcs",
-            pod_pattern=".*-0-0",
+            pod_pattern=f"{test_config.short_id}-emc.*-0-\d+-",
             start_time=start_time,
             end_time=end_time,
             steps_to_validate=steps_to_validate,


### PR DESCRIPTION
# Description

This PR fix the failure of maxtext_emc_save_gcs DAG.
It corrects the pod_pattern regex from .*-0-0 -> {test_config.short_id}-emc.*-0-\d+ . We need to check in all pods in first slice (Slice 0) isntead on ONLY the first pod in first slice.

# Tests to be fixed 
- Dag Name: `maxtext_emc_save_gcs`

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.