### PR TITLE
feat: Add gspo support for RL DAG

### DIFF
--- a/dags/post_training/util/test_config_util.py
+++ b/dags/post_training/util/test_config_util.py
@@ -1,6 +1,7 @@
 """Test Configuration Class utility for post training testcases."""
 
 from dataclasses import dataclass
+from enum import Enum
 
 from dags import gcs_bucket
 from dags.common.vm_resource import XpkClusters, DockerImage
@@ -14,6 +15,13 @@ POST_TRAINING_DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_POST_TRAINING_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_POST_TRAINING_NIGHTLY),
 ]
+
+
+class LossAlgo(Enum):
+  """Enum for RL loss algorithms."""
+
+  GRPO = "grpo"
+  GSPO = "gspo"
 
 
 @dataclass
@@ -36,6 +44,7 @@ class RLTestConfig:
         path or local path).
     load_parameters_path: GCS path to load model parameters
         from.
+    loss_algos: List of loss algorithms to test (e.g., [LossAlgo.GRPO]).
     rl_config_path: Path to the RL configuration YAML file
         (relative to MaxText root).
   """
@@ -48,6 +57,7 @@ class RLTestConfig:
   base_dir: str
   tokenizer_path: str
   load_parameters_path: str
+  loss_algos: list[LossAlgo]
   rl_config_path: str = "src/MaxText/configs/rl.yml"
 
   def __init__(
@@ -60,6 +70,7 @@ class RLTestConfig:
       base_dir: str,
       tokenizer_path: str,
       load_parameters_path: str,
+      loss_algos: list[LossAlgo],
       rl_config_path: str = "src/MaxText/configs/rl.yml",
   ):
     """Initializes the RL test configurations.
@@ -77,6 +88,7 @@ class RLTestConfig:
           model path).
       load_parameters_path: GCS path to load pretrained model
           parameters from.
+      loss_algos: List of loss algorithms to test.
       rl_config_path: Path to the RL configuration YAML file
           (default: src/MaxText/configs/rl.yml).
     """
@@ -88,4 +100,40 @@ class RLTestConfig:
     self.base_dir = base_dir
     self.tokenizer_path = tokenizer_path
     self.load_parameters_path = load_parameters_path
+    self.loss_algos = loss_algos
     self.rl_config_path = rl_config_path
+
+  def generate_rl_training_command(
+      self, loss_algo: LossAlgo, run_name: str, hf_token: str
+  ) -> tuple[str]:
+    """Generates the RL training command as a tuple for GKE compatibility.
+
+    Args:
+      loss_algo: The loss algorithm to use (e.g., LossAlgo.GRPO).
+      run_name: The run name for the training job.
+      hf_token: The HuggingFace token for authentication.
+
+    Returns:
+      A tuple containing the RL training command string.
+    """
+    command = (
+        f"export HF_TOKEN={hf_token} && "
+        "export TPU_MIN_LOG_LEVEL=0 && "
+        "export TF_CPP_MIN_LOG_LEVEL=0 && "
+        "export TPU_STDERR_LOG_LEVEL=0 && "
+        "export JAX_PLATFORMS=proxy,cpu && "
+        "export JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 && "
+        "export ENABLE_PATHWAYS_PERSISTENCE='1' && "
+        f"python -m src.MaxText.rl.train_rl "
+        f"{self.rl_config_path} run_name={run_name} "
+        f"model_name={self.model_name} "
+        f"tokenizer_path={self.tokenizer_path} "
+        f"load_parameters_path={self.load_parameters_path} "
+        f"base_output_directory={self.base_dir}"
+    )
+
+    if loss_algo == LossAlgo.GSPO:
+      command += f" loss_algo={loss_algo.value}-token"
+
+    # Return as tuple for k8s yaml compatibility.
+    return (command,)

--- a/dags/post_training/util/validation_util.py
+++ b/dags/post_training/util/validation_util.py
@@ -4,15 +4,41 @@ This module provides validation functions specific to post training
 workflows, reusing generic utilities from the orbax module where applicable.
 """
 
+from airflow.decorators import task
+from airflow.exceptions import AirflowException
+
 # Re-export commonly used validation functions from orbax
 from dags.orbax.util.validation_util import (
-    generate_run_name,
     generate_timestamp,
     validate_log_exist,
 )
 
 __all__ = [
-    "generate_run_name",
+    "generate_posttraining_run_name",
     "generate_timestamp",
     "validate_log_exist",
 ]
+
+
+@task
+def generate_posttraining_run_name(
+    short_id: str,
+    checkpointing_type: str,
+    slice_number: int,
+    mode: str,
+) -> str:
+  """
+  Generates a short run name for a post-training run.
+
+  Args:
+      short_id: A short identifier for the specific model or experiment.
+      checkpointing_type: The name of the checkpointing strategy (e.g., 'grpo').
+      slice_number: The number of TPU slices used.
+      mode: The setup mode (e.g., 'nightly').
+
+  Returns:
+      A short string formatted as
+      '{short_id}-{checkpointing_type}-{mode}-{slice_number}'.
+  """
+  run_name = f"{short_id}-{checkpointing_type}-{mode}-{slice_number}"
+  return run_name


### PR DESCRIPTION
# Description
This pull request expands and refactors the MaxText RL (Reinforcement Learning) post-training pipeline to support both GRPO and GSPO algorithms, improves configurability, and enhances validation utilities. The changes also generalize the use of Docker images for post-training, introduce a more robust run name generator, and improve pod listing logic in TPU observability DAGs.

#  Airflow/Composer
- GCP Composer name: `jackyf-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

**List links for your tests (use go/shortn-gen for any internal link):**

jacky-test (Success) https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_rl/grid?dag_run_id=manual__2025-12-31T08%3A55%3A02.858131%2B00%3A00

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.