### PR TITLE
Adjust dag schedule 14

### DIFF
--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -24,7 +24,7 @@ from dags.multipod.configs import gke_config
 from xlml.apis import metric_config
 
 # Run once a day at 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "30 19 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 16 * * *" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="maxtext_convergence",

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -27,7 +27,7 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config, mlcompass
 
 # Run once a day at 3 am UTC (7 pm PST / 8 pm PDT)
-CONIFGS_SCHEDULED_TIME = "30 10 * * *" if composer_env.is_prod_env() else None
+CONIFGS_SCHEDULED_TIME = "45 9 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),

--- a/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
@@ -27,7 +27,7 @@ from xlml.utils import name_format
 from xlml.apis import metric_config
 
 # Run once a day at 3 am UTC (7 pm PST)
-SCHEDULED_TIME = "15 1 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 1 * * *" if composer_env.is_prod_env() else None
 BASE_OUTPUT_DIRECTORY = gcs_bucket.BASE_OUTPUT_DIR
 
 

--- a/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
@@ -27,7 +27,7 @@ from xlml.apis import metric_config
 from xlml.utils import name_format
 
 # Run once a day at 4 am UTC (8 pm PST)
-SCHEDULED_TIME = "45 15 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "45 13 * * *" if composer_env.is_prod_env() else None
 
 BASE_OUTPUT_DIRECTORY = gcs_bucket.BASE_OUTPUT_DIR
 

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -26,7 +26,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 1 am UTC (5 pm PST)
-SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 
 


### PR DESCRIPTION
# Description

The test team identified several DAGs that share the same cluster and have schedules that are too close to each other. This proximity was causing resource conflicts and potential instability.

This PR staggers the DAG schedules to reduce resource contention, stabilize the cluster, and improve DAG reliability.

# Action

Manually updated the cron schedules for the following DAGs:

-- `jax_ai_image_tpu_e2e`: `01:15` UTC → `01:30` UTC
-- `maxtext_moe_tpu_e2e`: `04:00` UTC → `03:00` UTC
-- `maxtext_trillium_configs_perf`: `10:30` UTC → `09:45` UTC
-- `maxdiffusion_tpu_e2e`: `15:45` UTC → `13:45` UTC
-- `maxtext_convergence`: `19:30` UTC → `16:30` UTC

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.