### PR TITLE
Fix: Fixed maxtext_muti_tier_checkpointing. Point to new cluster auto-v5p-8-bodaborg.

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -255,6 +255,13 @@ class XpkClusters:
       project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
       zone=Zone.EUROPE_WEST4_B.value,
   )
+  TPU_V5P_8_CLUSTER_V2 = XpkClusterConfig(
+      name="auto-v5p-8-bodaborg",
+      device_version=TpuVersion.V5P,
+      core_count=8,
+      project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+      zone=Zone.EUROPE_WEST4_B.value,
+  )
   TPU_V5P_128_CLUSTER = XpkClusterConfig(
       name="v5p-128-bodaborg-europe-west4-b",
       device_version=TpuVersion.V5P,

--- a/dags/multipod/maxtext_multi_tier_checkpointing.py
+++ b/dags/multipod/maxtext_multi_tier_checkpointing.py
@@ -53,7 +53,7 @@ with models.DAG(
   }
   clusters = {
       # accelerator: cluster name
-      "v5p-8": XpkClusters.TPU_V5P_8_CLUSTER,
+      "v5p-8": XpkClusters.TPU_V5P_8_CLUSTER_V2,
   }
 
   for mode, image in docker_images:
@@ -72,4 +72,4 @@ with models.DAG(
             run_model_cmds=command,
             docker_image=image.value,
             test_owner=test_owner.ABHINAV_S,
-        ).run(ramdisk_directory="local")
+        ).run(ramdisk_directory="local", mtc_enabled=True)


### PR DESCRIPTION
# Description

Fix maxtext_muti_tier_checkpointing. To point to new created `auto-v5p-8-bodaborg` cluster. Due to overlaping DAG's pointing same cluster it was neccessary create new small 8 slices v5p-8  cluster.
New cluster: [auto-v5p-8-bodaborg](https://pantheon.corp.google.com/kubernetes/clusters/details/europe-west4/auto-v5p-8-bodaborg/nodes?project=cloud-tpu-multipod-dev&pli=1) this cluster has already install GCSFuse and Multi-TierHigh Scale Checkpointing. 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.