### PR TITLE
Chore: switch sensors to poke mode for accurate status duration

### DIFF
--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -458,7 +458,7 @@ def list_pod_names(node_pool: node_pool_info, namespace: str) -> list[str]:
     return pod_list
 
 
-@task.sensor(poke_interval=30, timeout=900, mode="reschedule")
+@task.sensor(poke_interval=30, timeout=900, mode="poke")
 def wait_for_jobset_started(
     node_pool: node_pool_info,
     pod_name_list: str,
@@ -525,7 +525,7 @@ def wait_for_jobset_started(
   return all(p > threshold_value for p in last_n_data_points)
 
 
-@task.sensor(poke_interval=60, timeout=3600, mode="reschedule")
+@task.sensor(poke_interval=60, timeout=3600, mode="poke")
 def wait_for_jobset_ttr_to_be_found(node_pool: node_pool_info) -> bool:
   """
   Polls the jobset time_between_interruptions metric.
@@ -559,7 +559,7 @@ def wait_for_jobset_ttr_to_be_found(node_pool: node_pool_info) -> bool:
   return len(time_series) > 0
 
 
-@task.sensor(poke_interval=30, timeout=600, mode="reschedule")
+@task.sensor(poke_interval=30, timeout=600, mode="poke")
 def wait_for_jobset_status_occurrence(
     replica_type: str, job_name: str, node_pool: node_pool_info
 ):
@@ -581,7 +581,7 @@ def wait_for_jobset_status_occurrence(
   return ready_replicas > 0
 
 
-@task.sensor(poke_interval=30, timeout=600, mode="reschedule")
+@task.sensor(poke_interval=30, timeout=600, mode="poke")
 def wait_for_all_pods_running(num_pods: int, node_pool: node_pool_info):
   num_running = len(get_running_pods(node_pool=node_pool, namespace="default"))
   return num_running == num_pods

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -413,7 +413,7 @@ def _query_status_metric(node_pool: Info) -> Status:
   return Status.from_str(latest_status)
 
 
-@task.sensor(poke_interval=60, timeout=600, mode="reschedule")
+@task.sensor(poke_interval=60, timeout=600, mode="poke")
 def wait_for_status(
     node_pool: Info,
     status: Status,
@@ -465,7 +465,7 @@ def rollback(node_pool: Info) -> None:
   subprocess.run_exec(command)
 
 
-@task.sensor(poke_interval=30, timeout=1200, mode="reschedule")
+@task.sensor(poke_interval=30, timeout=1200, mode="poke")
 def wait_for_availability(
     node_pool: Info,
     availability: bool,
@@ -541,7 +541,7 @@ def wait_for_availability(
   return availability == state
 
 
-@task.sensor(poke_interval=30, timeout=3600, mode="reschedule")
+@task.sensor(poke_interval=30, timeout=3600, mode="poke")
 def wait_for_ttr(
     node_pool: Info,
     operation_start_time: TimeUtil,


### PR DESCRIPTION
 # Description

This PR improves the observability and efficiency of GKE Node Pool and JobSet sensors by switching their operational mode from `reschedule` to `poke`.

# Key Improvements

**1. Enhanced Troubleshooting Visibility**

- **Continuous Duration:** In `poke` mode, the sensor remains active in a single session. This allows the Airflow UI (Gantt Chart & Task Duration views) to show the exact, continuous time spent waiting for TPU resources.

**2. High-Value Resource Prioritization (TPU/Cluster vs. Worker)**

- **Trade-off:** TPU/Cluster resources are far more precious and limited than Airflow worker slots. Using `poke` ensures zero-latency task handoff.

- **Limited Impact:** Holding a worker slot during the poke interval has a negligible impact on cluster capacity unless the system is running a massive number of highly parallelized DAGs.

# Tests

- Functional Verification (Sensor)
  - Dag name: `gke_node_pool_status` (and other relevant observability DAGs).
  - Airflow test results: https://35b13c750f364c56b55b9367bb681dee-dot-us-central1.composer.googleusercontent.com/dags/gke_node_pool_status/grid

# Airflow/Composer

- GCP Composer name: ml-automation-solutions-dev (under GCP project: cloud-ml-auto-solutions)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5

# Required Variables (Shared across 7 DAGs)

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to node-pool-status-v6e-autotest)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.