### PR TITLE
fix: Update loss_algo attribute format in RLTestConfig

### DIFF
--- a/dags/post_training/util/test_config_util.py
+++ b/dags/post_training/util/test_config_util.py
@@ -133,7 +133,7 @@ class RLTestConfig:
         f"tokenizer_path={self.tokenizer_path} "
         f"load_parameters_path={self.load_parameters_path} "
         f"base_output_directory={self.base_dir} "
-        f"loss_algo={loss_algo.loss_name}"
+        f"rl.loss_algo={loss_algo.loss_name}"
     )
 
     # Return as tuple for k8s yaml compatibility.


### PR DESCRIPTION
# Description


This pull request makes a small but important update to the RL training command generation logic, ensuring that the loss algorithm parameter is properly namespaced for downstream compatibility.

# Tests

Test on the composer with `2026-01-15` image [log](https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_rl/grid?dag_run_id=manual__2026-01-15T01%3A42%3A06.265062%2B00%3A00)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.