### PR TITLE
Add TPU observability DAGs node_pool_ttr_disk_size.py

### DIFF
--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to validate GKE node pool Times To Recover(TTR) metrics
+by triggering a disk size update."""
+
+import datetime
+
+from airflow import models
+from airflow.models.baseoperator import chain
+from airflow.utils.task_group import TaskGroup
+from airflow.utils.trigger_rule import TriggerRule
+
+from dags import composer_env
+from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+from dags.tpu_observability.utils import node_pool_util as node_pool
+
+_DISK_SIZE_INCREMENT = 50
+
+
+with models.DAG(
+    dag_id="node_pool_ttr_disk_size",
+    start_date=datetime.datetime(2025, 6, 26),
+    schedule="00 20 * * *" if composer_env.is_prod_env() else None,
+    catchup=False,
+    tags=[
+        "cloud-ml-auto-solutions",
+        "node_pool_ttr_disk_size",
+        "tpu_obervability",
+        "time_to_recover",
+    ],
+    description=(
+        "This DAG verifies the GKE node pool's Times To Recover(TTR) metrics "
+        "by triggering a disk size update and confirming the recovery time "
+        "is recorded"
+    ),
+    doc_md="""
+      # GKE Node Pool Times To Recover (TTR) Metric Validation DAG (Disk Resize)
+
+      ### Description
+      This DAG automates the validation of GKE node pool Times To Recover (TTR) metrics.
+      It creates a temporary node pool, triggers a disk resize operation to force a node
+      pool update, and checks that the TTR metric is correctly generated and reported
+      to Google Cloud Monitoring.
+
+      ### Prerequisites
+      This test requires an existing GKE cluster.
+
+      ### Procedures
+      1. Create a temporary node pool.
+      2. Wait for the node pool to be RUNNING.
+      3. Trigger a disk resize update on the node pool.
+      4. Wait for the node pool to recover and become RUNNING again.
+      5. Wait for the Times To Recover (TTR) metrics to appear in Google Cloud Monitoring.
+      6. Clean up the node pool after the tests.
+    """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+
+    with TaskGroup(group_id=f"v{config.tpu_version.value}"):
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="node_pool_ttr_disk_size",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
+      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+          node_pool=node_pool_info
+      )
+
+      wait_for_provisioning = node_pool.wait_for_status.override(
+          task_id="wait_for_provisioning"
+      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+
+      wait_for_running = node_pool.wait_for_status.override(
+          task_id="wait_for_running"
+      )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
+
+      update_start_time = node_pool.update.override(task_id="update_node_pool")(
+          node_pool=node_pool_info,
+          spec=node_pool.NodePoolUpdateSpec.DiskSize(
+              delta=_DISK_SIZE_INCREMENT
+          ),
+      )
+
+      wait_for_recovered = node_pool.wait_for_status.override(
+          task_id="wait_for_recovered"
+      )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
+
+      wait_for_ttr = node_pool.wait_for_ttr(
+          node_pool=node_pool_info, operation_start_time=update_start_time
+      )
+
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=node_pool_info).as_teardown(
+          setups=create_node_pool,
+      )
+
+      chain(
+          node_pool_info,
+          create_node_pool,
+          wait_for_provisioning,
+          wait_for_running,
+          update_start_time,
+          wait_for_recovered,
+          wait_for_ttr,
+          cleanup_node_pool,
+      )

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -21,7 +21,6 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
-from dags.common.vm_resource import Region, Zone
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 
@@ -93,9 +92,10 @@ with models.DAG(
       )
 
       task_id = "update_node_pool_label"
-      update_node_pool_label = node_pool.update_labels.override(
-          task_id=task_id
-      )(node_pool=node_pool_info, node_labels=LABELS_TO_UPDATE)
+      update_node_pool_label = node_pool.update.override(task_id=task_id)(
+          node_pool=node_pool_info,
+          spec=node_pool.NodePoolUpdateSpec.Label(delta=LABELS_TO_UPDATE),
+      )
 
       task_id = "wait_for_recovered"
       wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -88,9 +88,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_initial_availability"
       )(node_pool=node_pool_info, availability=True)
 
-      update_node_pool_label = node_pool.update_labels.override(
+      update_node_pool_label = node_pool.update.override(
           task_id="update_node_pool_label"
-      )(node_pool=node_pool_info, node_labels=LABELS_TO_UPDATE)
+      )(
+          node_pool=node_pool_info,
+          spec=node_pool.NodePoolUpdateSpec.Label(delta=LABELS_TO_UPDATE),
+      )
 
       wait_for_unavailable = node_pool.wait_for_availability.override(
           task_id="wait_for_unavailability_after_update"


### PR DESCRIPTION
# Description
This DAG verifies the GKE node pool's Times To Recover(TTR) metrics by triggering a disk size update and confirming the recovery time is recorded.

# Tests
- Dag Name: node_pool_ttr_disk_size
- Airflow test results: https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/node_pool_ttr_disk_size/grid

# Airflow/Composer
GCP Composer name: ml-automation-solutions-dev (under GCP project: cloud-ml-auto-solutions)
GCP Composer version: 2.13.1
GCP Airflow version: 2.10.5

# Required Variables
- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-prod)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)
- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to node-pool-ttr-disk-size)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.