### PR TITLE
fix: Replace task chaining with `chain` for improved readability

### DIFF
--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -8,6 +8,7 @@ import re
 from airflow import models
 from airflow.decorators import task
 from airflow.exceptions import AirflowSkipException
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 
 from dags.common import test_owner
@@ -567,10 +568,10 @@ def create_interruption_dag(
                 log_records,
             )
 
-            (
-                proper_time_range
-                >> [metric_records, log_records]
-                >> check_event_count
+            chain(
+                proper_time_range,
+                [metric_records, log_records],
+                check_event_count,
             )
 
     return dag

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -17,6 +17,7 @@
 import datetime
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
@@ -141,16 +142,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           setups=create_node_pool,
       )
 
-      # Airflow uses >> for task chaining, which is pointless for pylint.
-      # pylint: disable=pointless-statement
-      (
-          cluster_info
-          >> create_node_pool
-          >> start_workload
-          >> ensure_all_pods_running
-          >> rollback_node_pool
-          >> wait_for_metric_upload
-          >> cleanup_workload
-          >> cleanup_node_pool
+      chain(
+          cluster_info,
+          create_node_pool,
+          start_workload,
+          ensure_all_pods_running,
+          rollback_node_pool,
+          wait_for_metric_upload,
+          cleanup_workload,
+          cleanup_node_pool,
       )
-      # pylint: enable=pointless-statement

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -20,6 +20,7 @@ pool as expected.
 import datetime
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -117,15 +118,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           setups=create_node_pool,
       )
 
-      # Airflow uses >> for task chaining, which is pointless for pylint.
-      # pylint: disable=pointless-statement
-      (
-          node_pool_info
-          >> create_node_pool
-          >> wait_node_pool_available
-          >> rollback_node_pool
-          >> wait_node_pool_unavailable
-          >> wait_node_pool_recovered
-          >> cleanup_node_pool
+      chain(
+          node_pool_info,
+          create_node_pool,
+          wait_node_pool_available,
+          rollback_node_pool,
+          wait_node_pool_unavailable,
+          wait_node_pool_recovered,
+          cleanup_node_pool,
       )
-      # pylint: enable=pointless-statement

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -17,6 +17,7 @@
 import datetime
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -114,13 +115,13 @@ with models.DAG(
           setups=create_node_pool,
       )
 
-      _ = (
-          node_pool_info
-          >> create_node_pool
-          >> wait_for_provisioning
-          >> wait_for_running
-          >> update_node_pool_label
-          >> wait_for_recovered
-          >> wait_for_ttr
-          >> cleanup_node_pool
+      chain(
+          node_pool_info,
+          create_node_pool,
+          wait_for_provisioning,
+          wait_for_running,
+          update_node_pool_label,
+          wait_for_recovered,
+          wait_for_ttr,
+          cleanup_node_pool,
       )

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -19,6 +19,7 @@ A DAG to update the label of a node pool to make node pool unavailable
 import datetime
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -106,15 +107,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           setups=[create_node_pool],
       )
 
-      # Airflow uses >> for task chaining, which is pointless for pylint.
-      # pylint: disable=pointless-statement
-      (
-          node_pool_info
-          >> create_node_pool
-          >> wait_for_availability
-          >> update_node_pool_label
-          >> wait_for_unavailable
-          >> wait_node_pool_recovered
-          >> cleanup_node_pool
+      chain(
+          node_pool_info,
+          create_node_pool,
+          wait_for_availability,
+          update_node_pool_label,
+          wait_for_unavailable,
+          wait_node_pool_recovered,
+          cleanup_node_pool,
       )
-      # pylint: enable=pointless-statement


### PR DESCRIPTION
# Description

This PR update the way to chain tasks in tpu_observability, from pylint  “pointless-statement” into using from airflow.models.baseoperator import chain. Change 7 files for tpu_observability, including `interruption_validation_dag.py`, `jobset_ttr_rollback.py`, `multi_host_nodepool_rollback_dag.py`, `node_pool_status.py`, `node_pool_ttr_update_label.py`, `tpu_info_format_validation_dags.py` and `update_node_pool_label.py` .

# Tests

- GCP Composer name: [chris-test](https://console.cloud.google.com/composer/environments/detail/us-central1/chris-test/monitoring?referrer=search&authuser=1&invt=AcGbhg&project=cienet-cmcs) (under GCP project: `cienet-cmcs`)
- GCP Composer version: `2.13.1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.