### PR TITLE
fix: Correct tags of `node_pool_ttr_disk_size`

### DIFF
--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -35,10 +35,11 @@ with models.DAG(
     schedule="00 20 * * *" if composer_env.is_prod_env() else None,
     catchup=False,
     tags=[
-        "cloud-ml-auto-solutions",
-        "node_pool_ttr_disk_size",
-        "tpu_obervability",
-        "time_to_recover",
+        "gke",
+        "tpu-observability",
+        "node-pool-ttr-disk-size",
+        "TPU",
+        "v6e-16",
     ],
     description=(
         "This DAG verifies the GKE node pool's Times To Recover(TTR) metrics "


### PR DESCRIPTION
# Description
This PR updates the tags for the `node_pool_ttr_disk_size` DAG.

# Tests
- Dag Name: node_pool_ttr_disk_size
- Airflow test results: https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/node_pool_ttr_disk_size/grid

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.