### PR TITLE
Fix v4p and point correctly v5p for DAG to new reservation for GCE for jax_functional_tests

### DIFF
--- a/dags/multipod/jax_functional_tests.py
+++ b/dags/multipod/jax_functional_tests.py
@@ -50,7 +50,7 @@ with models.DAG(
       jax_gce_v4_8 = jax_tests_gce_config.get_jax_distributed_initialize_config(
           tpu_version=TpuVersion.V4,
           tpu_cores=8,
-          tpu_zone=Zone.EUROPE_WEST4_B.value,
+          tpu_zone=Zone.US_CENTRAL2_B.value,
           time_out_in_min=60,
           is_tpu_reserved=False,
           num_slices=num_slices,
@@ -83,7 +83,7 @@ with models.DAG(
               tpu_version=TpuVersion.V5P,
               tpu_cores=8,
               num_slices=num_slices,
-              tpu_zone=Zone.US_EAST5_A.value,
+              tpu_zone=Zone.EUROPE_WEST4_B.value,
               runtime_version=v5p_runtime_version,
               project_name=v5p_project_name,
               time_out_in_min=60,


### PR DESCRIPTION
# Description

Since the reservation in project tpu-prod-env-automated does not exist for zone east5 anymore. It was need it to create a new subnetwork and point to a zone where is enough v5p chips reserved. Point to zone europe-west4-b.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.