### PR TITLE
fix: Resolve DAG validation errors triggered by unexpected log output.

### DIFF
--- a/dags/orbax/maxtext_emc_resume_gcs.py
+++ b/dags/orbax/maxtext_emc_resume_gcs.py
@@ -205,7 +205,7 @@ with models.DAG(
                 project_id=test_config.cluster.project,
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
-                pod_pattern="max.*-job-0-0",
+                pod_pattern=f"{test_config.short_id}.*-job-0-0",
                 interrupt_at_step=first_training_step - 1,
                 start_time=start_time,
                 end_time=end_time,

--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -100,7 +100,7 @@ with models.DAG(
         workload_command = test_config.generate_workload_command(
             checkpoint_dir=test_config_util.DEFAULT_RAM_DISK,
             run_name=run_name,
-            out_folder=f"maxtext_emc_orbax_save_gcs",
+            out_folder="maxtext_emc_orbax_save_gcs",
             enable_multi_tier_checkpointing=checkpointing.enable_multi_tier_checkpointing,
             slice_num=slice_num,
         )

--- a/dags/orbax/maxtext_mtc_resume_gcs.py
+++ b/dags/orbax/maxtext_mtc_resume_gcs.py
@@ -202,7 +202,7 @@ with models.DAG(
                 project_id=test_config.cluster.project,
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
-                pod_pattern="max.*-job-0-0",
+                pod_pattern=f"{test_config.short_id}.*-job-0-0",
                 interrupt_at_step=local_checkpoint_period,
                 check_last_two_local_saves=False,
                 start_time=start_time,

--- a/dags/orbax/maxtext_mtc_save_gcs.py
+++ b/dags/orbax/maxtext_mtc_save_gcs.py
@@ -103,7 +103,7 @@ with models.DAG(
             checkpoint_dir=test_config_util.DEFAULT_RAM_DISK,
             run_name=run_name,
             slice_num=slice_num,
-            out_folder=f"maxtext_mtc_orbax_save_gcs",
+            out_folder="maxtext_mtc_orbax_save_gcs",
             enable_multi_tier_checkpointing=checkpointing.enable_multi_tier_checkpointing,
         )
 

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -149,7 +149,7 @@ with models.DAG(
                 project_id=test_config.cluster.project,
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
-                pod_pattern=".*0-0",
+                pod_pattern=f"{test_config.short_id}.*0-0",
                 interrupt_at_step=step_to_interrupt,
                 start_time=start_time,
                 end_time=end_time,

--- a/dags/orbax/maxtext_reg_restore_gcs_with_resumed_workload.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_resumed_workload.py
@@ -158,7 +158,7 @@ with models.DAG(
                 project_id=test_config.cluster.project,
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
-                pod_pattern="max.*-job-0-0",
+                pod_pattern=f"{test_config.short_id}.*-job-0-0",
                 interrupt_at_step=initial_step - 1,
                 start_time=start_time,
                 end_time=end_time,


### PR DESCRIPTION
# Description
Resolve DAG validation errors triggered by unexpected log output from the pod_pattern regex.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.