### PR TITLE
Fix sft post-training run name can not be identified

### DIFF
--- a/dags/post_training/maxtext_sft.py
+++ b/dags/post_training/maxtext_sft.py
@@ -152,7 +152,7 @@ with models.DAG(
 
     for slice_num in training_config.slices:
       current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-      run_name = f"{mode.value}-{current_datetime}"
+      run_name = f"sft-{mode.value}-{current_datetime}"
 
       sft_training_command = training_config.generate_sft_training_command(
           run_name=run_name,


### PR DESCRIPTION
# Description
Fix sft post-training run name so it can be identified and upload to vertex.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/dags/maxtext_sft/grid

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.