### PR TITLE
fix: Prevent DEADLINE_EXCEEDED errors in multi-slice TPU jobs

### DIFF
--- a/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_tpu_e2e.py
@@ -107,6 +107,8 @@ with models.DAG(
             cluster=cluster,
             time_out_in_min=60,
             run_model_cmds=(
+                "export JAX_COORDINATION_SERVICE_HEARTBEAT_TIMEOUT_SECONDS=1200 "
+                "JAX_ENABLE_COMPILATION_CACHE=false "
                 f"JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true TPU_SLICE_BUILDER_DUMP_CHIP_FORCE=true TPU_SLICE_BUILDER_DUMP_ICI=true JAX_FORCE_TPU_INIT=true ENABLE_TPUNETD_CLIENT=true && "
                 f"pip install . && python src/maxdiffusion/train_sdxl.py src/maxdiffusion/configs/base_xl.yml "
                 f"pretrained_model_name_or_path=gs://maxdiffusion-github-runner-test-assets/checkpoints/models--stabilityai--stable-diffusion-xl-base-1.0 "


### PR DESCRIPTION
# Problem
Multi-slice TPU tasks were failing with `DEADLINE_EXCEEDED` and `Heartbeat` timeouts. Log analysis showed an observed 327s compilation window which exceeded the default JAX RPC timeout, causing nodes to be dropped before the training loop started.

# Solution
Optimized JAX coordination settings to ensure stability during heavy compilation:

`"JAX_COORDINATION_SERVICE_HEARTBEAT_TIMEOUT_SECONDS=1200 "`: Prevents task termination during intensive computation.

# Tests
update version: [jax_ai_image_tpu_e2e_time10_prcache](https://516e2bebde0f475291b786c886653104-dot-europe-west1.composer.googleusercontent.com/dags/jax_ai_image_tpu_e2e_time10_prcache/grid?search=jax_ai_image_tpu_e2e_time10_prcache&tab=code)

# Fixes
[b/475103757](https://buganizer.corp.google.com/issues/475103757)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.