### PR TITLE
fix: Bigger eval_interval to avoid timeout

### DIFF
--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -51,11 +51,13 @@ with models.DAG(
   steps = 10200  # Half Chinchilla
   loss_threshold = 2.7
   per_device_batch_size = 2.0  # 256 chips * 2 pdb = 512 gbs.
+  eval_interval = 5000
 
   base_convergence_command = (
       "bash tests/end_to_end/tpu/test_convergence_1b_params.sh"
       f" OUTPUT_PATH={base_output_directory} DATASET_PATH={dataset_path}"
       f" LOSS_THRESHOLD={loss_threshold} STEPS={steps}"
+      f" EVAL_INTERVAL={eval_interval}"
       f" PER_DEVICE_BATCH_SIZE={per_device_batch_size}"
   )
   convergence_tests = {


### PR DESCRIPTION
# Description
The training jobs of the DAG are timing out recently. Upon reviewing the logs from our jax-tpu container, we have identified a main performance issues:

Periodic Slowdowns: We observe significant, recurring slowdowns in the training speed approximately every 100 training steps (e.g., around steps 100, 200, etc., up to the total of 10199 steps). While some slowdown at these intervals is also present in successful runs, the duration of these delays is much longer in the runs that eventually time out.

Impact: The exacerbated periodic slowdowns is causing our training jobs to exceed their allocated time and fail with timeouts. The logs indicate that runs are timing out, whereas previously, they would complete.

This PR increased the eval period (`eval_interval`) to 5000 to prevent periodic slowdowns in the training.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.