### PR TITLE
Fix JobSet Pod Discovery and Implement GCS-Driven JobSet Configuration

### DIFF
--- a/dags/tpu_observability/configs/common.py
+++ b/dags/tpu_observability/configs/common.py
@@ -24,3 +24,7 @@ class MachineConfigMap(enum.Enum):
 GCS_CONFIG_PATH = (
     "gs://ml-auto-solutions-dag-configs/tpu_observability/dag_config.yaml"
 )
+
+GCS_JOBSET_CONFIG_PATH = (
+    "gs://ml-auto-solutions-dag-configs/tpu_observability/jobset_config.yaml"
+)

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -25,7 +25,12 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import JobSet, Workload
-from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+
 
 _DISK_SIZE_INCREMENT = 100
 
@@ -47,7 +52,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     ],
     description=(
         "This DAG tests the JobSet time-to-recover metric by triggering a "
-        "node pool disk resize, then polls the metric to check if it is updated."
+        "node pool disk resize, then polls the metric to check "
+        "if it is updated."
     ),
     doc_md="""
       # JobSet Time-To-Recover (TTR) Test Using Node Pool Disk Resize
@@ -73,27 +79,16 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    jobset_config = JobSet(
-        jobset_name="ttr-res-v6e",
-        namespace="default",
-        max_restarts=10,
-        replicated_job_name="tpu-job-slice",
-        replicas=1,
-        backoff_limit=0,
-        completions=4,
-        parallelism=4,
-        tpu_accelerator_type="tpu-v6e-slice",
-        tpu_topology="4x4",
-        container_name="jax-tpu-worker",
-        image="python:3.11",
-        tpu_cores_per_pod=4,
-    )
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name="jobset_ttr_node_pool_resize",
+      )
+
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
@@ -110,17 +105,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       start_workload = jobset.run_workload.override(task_id="start_workload")(
           node_pool=cluster_info,
-          yaml_config=jobset_config.generate_yaml(
-              workload_script=Workload.JAX_TPU_BENCHMARK
-          ),
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
       ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
           task_id="ensure_all_pods_running"
       )(
-          num_pods=(jobset_config.replicas * jobset_config.parallelism),
           node_pool=cluster_info,
+          jobset_config=jobset_config,
       )
 
       node_pool_resize = node_pool.update.override(task_id="node_pool_resize")(
@@ -134,16 +127,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_jobset_ttr_to_be_found"
       )(
           node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
-          start_time=node_pool_resize,
+          jobset_config=jobset_config,
       )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
       )(
           node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
       ).as_teardown(
           setups=start_workload
       )
@@ -155,6 +146,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          jobset_config,
           cluster_info,
           create_node_pool,
           start_workload,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -24,8 +24,12 @@ from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
-from dags.tpu_observability.utils.jobset_util import JobSet, Workload
-from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -70,27 +74,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    jobset_config = JobSet(
-        jobset_name="ttr-delete-v6e-workload",
-        namespace="default",
-        max_restarts=5,
-        replicated_job_name="tpu-job-slice",
-        replicas=1,
-        backoff_limit=0,
-        completions=4,
-        parallelism=4,
-        tpu_accelerator_type="tpu-v6e-slice",
-        tpu_topology="4x4",
-        container_name="jax-tpu-worker",
-        image="python:3.11",
-        tpu_cores_per_pod=4,
-    )
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH, dag_name="jobset_ttr_pod_delete"
+      )
+
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
@@ -107,37 +99,34 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       start_workload = jobset.run_workload.override(task_id="start_workload")(
           node_pool=cluster_info,
-          yaml_config=jobset_config.generate_yaml(
-              workload_script=Workload.JAX_TPU_BENCHMARK
-          ),
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
       ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
           task_id="ensure_all_pods_running"
       )(
-          num_pods=(jobset_config.replicas * jobset_config.parallelism),
           node_pool=cluster_info,
+          jobset_config=jobset_config,
       )
 
       delete_random_pod = jobset.delete_one_random_pod.override(
           task_id="delete_random_pod"
-      )(node_pool=cluster_info, namespace=jobset_config.namespace)
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      )
 
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
           task_id="wait_for_jobset_ttr_to_be_found"
       )(
           node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
+          jobset_config=jobset_config,
       )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
-          namespace=jobset_config.namespace,
-      ).as_teardown(
+      )(node_pool=cluster_info, jobset_config=jobset_config).as_teardown(
           setups=start_workload
       )
 
@@ -148,6 +137,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          jobset_config,
+          cluster_info,
           create_node_pool,
           start_workload,
           ensure_all_pods_running,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -24,8 +24,12 @@ from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
-from dags.tpu_observability.utils.jobset_util import JobSet, Workload
-from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -72,27 +76,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    jobset_config = JobSet(
-        jobset_name="ttr-rollback-v6e-workload",
-        namespace="default",
-        max_restarts=5,
-        replicated_job_name="tpu-job-slice",
-        replicas=1,
-        backoff_limit=0,
-        completions=4,
-        parallelism=4,
-        tpu_accelerator_type="tpu-v6e-slice",
-        tpu_topology="4x4",
-        container_name="jax-tpu-worker",
-        image="python:3.11",
-        tpu_cores_per_pod=4,
-    )
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH, dag_name="jobset_rollback_ttr"
+      )
+
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
@@ -103,36 +95,39 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create(
+      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
       )
 
-      start_workload = jobset.run_workload(
+      start_workload = jobset.run_workload.override(task_id="start_workload")(
           node_pool=cluster_info,
-          yaml_config=jobset_config.generate_yaml(
-              workload_script=Workload.JAX_TPU_BENCHMARK
-          ),
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      ensure_all_pods_running = jobset.wait_for_all_pods_running(
-          num_pods=(jobset_config.replicas * jobset_config.parallelism),
+      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
+          task_id="ensure_all_pods_running"
+      )(
           node_pool=cluster_info,
+          jobset_config=jobset_config,
       )
 
-      rollback_node_pool = node_pool.rollback(node_pool=cluster_info)
+      rollback_node_pool = node_pool.rollback.override(
+          task_id="rollback_node_pool"
+      )(node_pool=cluster_info)
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found(
+      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+          task_id="wait_for_jobset_ttr_to_be_found"
+      )(
           node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
+          jobset_config=jobset_config,
       )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
       )(
           node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
       ).as_teardown(
           setups=start_workload
       )
@@ -144,6 +139,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          jobset_config,
           cluster_info,
           create_node_pool,
           start_workload,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -27,10 +27,11 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import tpu_monitoring_sdk_util as sdk
 from dags.tpu_observability.utils import node_pool_util as node_pool
-from dags.tpu_observability.utils.jobset_util import JobSet, Workload
+from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.configs.common import (
     MachineConfigMap,
     GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
 )
 
 
@@ -118,28 +119,16 @@ with models.DAG(
   for machine in MachineConfigMap:
     config = machine.value
 
-    jobset_config = JobSet(
-        jobset_name="sdk-monitoring-v6e-workload",
-        namespace="default",
-        max_restarts=5,
-        replicated_job_name="tpu-job-slice",
-        replicas=1,
-        backoff_limit=0,
-        completions=4,
-        parallelism=4,
-        tpu_accelerator_type="tpu-v6e-slice",
-        tpu_topology="4x4",
-        container_name="jax-tpu-worker",
-        image="asia-northeast1-docker.pkg.dev/cienet-cmcs/"
-        "yuna-docker/tpu-info:v0.8.1",
-        tpu_cores_per_pod=4,
-    )
-
   # Keyword arguments are generated dynamically at runtime (pylint does not
   # know this signature).
   with TaskGroup(  # pylint: disable=unexpected-keyword-arg
       group_id=f"v{config.tpu_version.value}"
   ):
+    jobset_config = jobset.build_jobset_from_gcs_yaml(
+        gcs_path=GCS_JOBSET_CONFIG_PATH,
+        dag_name="tpu_sdk_monitoring_validation",
+    )
+
     cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
         task_id="build_node_pool_info_from_gcs_yaml"
     )(
@@ -156,15 +145,13 @@ with models.DAG(
 
     apply_time = jobset.run_workload.override(task_id="run_workload")(
         node_pool=cluster_info,
-        yaml_config=jobset_config.generate_yaml(
-            workload_script=Workload.JAX_TPU_BENCHMARK
-        ),
-        namespace=jobset_config.namespace,
+        jobset_config=jobset_config,
+        workload_type=Workload.JAX_TPU_BENCHMARK,
     )
 
     pod_names = jobset.list_pod_names.override(task_id="list_pod_names")(
         node_pool=cluster_info,
-        namespace=jobset_config.namespace,
+        jobset_config=jobset_config,
     )
 
     wait_for_jobset_started = jobset.wait_for_jobset_started.override(
@@ -185,8 +172,7 @@ with models.DAG(
         task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
     )(
         node_pool=cluster_info,
-        jobset_name=jobset_config.jobset_name,
-        namespace=jobset_config.namespace,
+        jobset_config=jobset_config,
     ).as_teardown(
         setups=apply_time
     )
@@ -198,6 +184,8 @@ with models.DAG(
     )
 
     chain(
+        jobset_config,
+        cluster_info,
         create_node_pool,
         apply_time,
         pod_names,


### PR DESCRIPTION
# Description

This PR addresses reliability issues in JobSet management by introducing a configuration-driven lifecycle and transitioning to official Kubernetes label selectors for pod discovery.

* 1. Resolution of Naming Inconsistency
**Issue**: Previously, using {{ ti.job_id }} in the jobset_name caused the name to increment between tasks (e.g., ...425 for creation, ...426 for listing, and ...427 for deletion). This prevented downstream tasks from locating the resources created by the upstream task. 
**Solution**: **Task-Based Configuration Inheritance**


    - **Dynamic Naming**: Implemented `build_jobset_from_gcs_yaml` as an Airflow `@task`. It generates a unique jobset_name (e.g., ttr-pod-delete-workload-20260130...) once per DAG run.

    - **Layered Config**: Merges base `jobset_defaults` with specific DAG overrides defined in GCS YAML.

    - **XCom Stability**: By using an Airflow task, the JobSet object is generated at execution time and shared across all tasks (`start_workload`, `delete_random_pod`, etc.), ensuring name consistency.
   

* 2. Enhanced Pod Discovery via Label Selectors
**Issue**: The previous method of retrieving pod names did not align with the JobSet controller's hierarchical structure, making it difficult to target all pods managed by the JobSet. 
**Solution**: **Label-Based Filtering**
Updated `k8s_get_pod_name_command` and `get_running_pods` to use the official Kubernetes SIGs label: `-l jobset.sigs.k8s.io/jobset-name={jobset_name}`.

# Tests

- GCP Composer name: [ml-automation-solutions-dev](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/tpu_info_format_validation_dag/grid?dag_run_id=manual__2026-01-29T09%3A46%3A16.768528%2B00%3A00&task_id=v6e.list_pod_names&tab=logs) (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.