### PR TITLE
Fix notebook file path for post-training DAGs

### DIFF
--- a/dags/post_training/maxtext_rl_notebook.py
+++ b/dags/post_training/maxtext_rl_notebook.py
@@ -83,7 +83,7 @@ with models.DAG(
     rl_notebook_test = notebook_util.initialize_notebook_test(
         test_name=f"{DAG_TEST_NAME}_rl_{loss_algo.value}",
         dag_name=DAG_TEST_NAME,
-        notebook_path="src/MaxText/examples/rl_llama3_demo.ipynb",
+        notebook_path="src/maxtext/examples/rl_llama3_demo.ipynb",
         set_up_script=setup_script,
         parameters={"LOSS_ALGO": loss_algo.loss_name},
         task_owner=test_owner.DEPP_L,

--- a/dags/post_training/maxtext_sft_notebook.py
+++ b/dags/post_training/maxtext_sft_notebook.py
@@ -75,7 +75,7 @@ with models.DAG(
   sft_notebook_test = notebook_util.initialize_notebook_test(
       test_name=f"{DAG_TEST_NAME}_sft",
       dag_name=DAG_TEST_NAME,
-      notebook_path="src/MaxText/examples/sft_llama3_demo.ipynb",
+      notebook_path="src/maxtext/examples/sft_llama3_demo.ipynb",
       set_up_script=setup_script,
       parameters={},
       task_owner=test_owner.DEPP_L,


### PR DESCRIPTION
# Description
Fix notebook file path for post-training DAGs

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.