### PR TITLE
fix: Implement Persistent OS Login Authentication for TPU SSH

### DIFF
--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -374,6 +374,16 @@ def ssh_tpu(
       client.get_node(name=os.path.join(node.parent, 'nodes', node.node_id))
       for node in queued_resource.tpu.node_spec
   ]
+  node_metadata = nodes[0].metadata
+  is_oslogin_enabled = node_metadata.get('enable-oslogin', '') == 'TRUE'
+
+  user = 'ml-auto-solutions'
+  if is_oslogin_enabled:
+    logging.info('Auto-detected OS Login enabled on node {nodes[0].name}..')
+    # get private key from  Airflow Variable
+    user = Variable.get('os-login-ssh-user')
+    ssh_keys.private = Variable.get('os-login-ssh-private-key')
+    ssh_keys.public = Variable.get('os-login-ssh-public-key')
 
   if all_workers:
     endpoints = itertools.chain.from_iterable(
@@ -397,7 +407,7 @@ def ssh_tpu(
       *ip_addresses,
       connect_kwargs={
           'auth_strategy': paramiko.auth_strategy.InMemoryPrivateKey(
-              'ml-auto-solutions', pkey
+              user, pkey
           ),
           # See https://stackoverflow.com/a/59453832
           'banner_timeout': 200,


### PR DESCRIPTION
# PR Description

This PR transitions the TPU SSH connection mechanism from **ephemeral key injection** to a **persistent OS Login architecture**. By leveraging long-lived SSH keys stored in the Service Account's OS Login profile, we eliminate the race conditions (409 Conflict) frequently encountered when running multiple concurrent TPU tasks in Airflow.

Please ensure the following Airflow Variables are configured in the production environment:

* `os-login-ssh-private-key`, `os-login-ssh-user`, `os-login-ssh-public-key`

# Tests
* [jax_gce_tests_aiden_os2](https://516e2bebde0f475291b786c886653104-dot-europe-west1.composer.googleusercontent.com/dags/jax_gce_tests_aiden_os2/grid?dag_run_id=manual__2026-01-23T08%3A07%3A46.584910%2B00%3A00&task_id=jax-distributed-initialize-gce-stable-v4-8.provision.setup&tab=logs)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.