### PR TITLE
fix: Extend the timeout for `maxtext_convergence`

### DIFF
--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -84,9 +84,12 @@ with models.DAG(
 
   sequential_tests = []
   for test_name, run_command in convergence_tests.items():
+    # The grain dataset takes longer to run, so we give it a longer timeout. The other tests are expected to complete within 5 hours.
+    timeout_in_min = 360 if test_name == "maxtext-convergence-grain" else 300
+
     test_task = gke_config.get_gke_config(
         cluster=XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
-        time_out_in_min=300,
+        time_out_in_min=timeout_in_min,
         test_name=test_name,
         run_model_cmds=run_command,
         docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,


### PR DESCRIPTION
# Description

The convergence test using the grain dataset frequently exceeds the previous 5-hour limit. Observations show that this specific task often requires more than 5 hours to reach completion.

This change extends the timeout to 6 hours to ensure the DAG can finish successfully without manual intervention.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.