### PR TITLE
change sft.yml path

### DIFF
--- a/dags/post_training/maxtext_sft.py
+++ b/dags/post_training/maxtext_sft.py
@@ -141,7 +141,7 @@ with models.DAG(
           f"{test_config_util.DEFAULT_BUCKET}/llama3.1-70b-Instruct/"
           "scanned-pathways/0/items/"
       ),
-      sft_config_path="src/MaxText/configs/sft.yml",
+      sft_config_path="src/maxtext/configs/post_train/sft.yml",
   )
   # HF token retrieved from Airflow Variables for secure credential management
   HF_TOKEN_CIENET = models.Variable.get("HF_TOKEN_CIENET", None)

--- a/dags/post_training/util/test_config_util.py
+++ b/dags/post_training/util/test_config_util.py
@@ -215,7 +215,7 @@ class SFTTestConfig:
   base_dir: str
   tokenizer_path: str
   load_parameters_path: str
-  sft_config_path: str = "src/MaxText/configs/sft.yml"
+  sft_config_path: str = "src/maxtext/configs/post_train/sft.yml"
 
   def __init__(
       self,
@@ -228,7 +228,7 @@ class SFTTestConfig:
       base_dir: str,
       tokenizer_path: str,
       load_parameters_path: str,
-      sft_config_path: str = "src/MaxText/configs/sft.yml",
+      sft_config_path: str = "src/maxtext/configs/post_train/sft.yml",
   ):
     """Initializes the SFT test configurations.
 
@@ -245,7 +245,7 @@ class SFTTestConfig:
       load_parameters_path: GCS path to load pretrained model parameters
         from.
       sft_config_path: Path to the SFT configuration YAML file (default:
-        src/MaxText/configs/sft.yml).
+        src/maxtext/configs/post_train/sft.yml).
     """
     self.cluster = cluster
     self.accelerator = accelerator


### PR DESCRIPTION
# Description

Move the sft.yml path from src/MaxText/configs to src/maxtext/configs/post_train. In the https://github.com/AI-Hypercomputer/maxtext/pull/3044, maxText move all config files from src/MaxText/configs to src/maxtext/configs. We need to modify the sft.yml path for this.

XLML DAGs failed for using src/maxtext/configs/sft.yml, error:

FileNotFoundError: [Errno 2] No such file or directory: '/deps/src/maxtext/configs/sft.yml'

# Tests

No need to test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.