### PR TITLE
Fix: Unify TPU SSH mechanism to resolve race conditions

### DIFF
--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -102,7 +102,7 @@ def run_queued_resource_test(
         tpu_name = tpu.generate_tpu_name(
             task_test_config.benchmark_id, tpu_name_env_var
         )
-        ssh_keys = ssh.generate_ssh_keys()
+        ssh_keys = ssh.obtain_persist_ssh_keys()
         output_location = name_format.generate_gcs_folder_location(
             task_test_config.gcs_subfolder,
             task_test_config.benchmark_id,


### PR DESCRIPTION
# PR Description

This PR transitions the TPU SSH connection mechanism from **ephemeral key injection** to a **persistent OS Login architecture**. By leveraging long-lived SSH keys stored in the Service Account's OS Login profile, we eliminate the race conditions (409 Conflict) frequently encountered when running multiple concurrent TPU tasks in Airflow.

**Key Change: Simplified Login Strategy**

Previously, we attempted to dynamically detect whether to use OS Login or traditional SSH keys. However, this approach introduced unnecessary complexity and detection failures. In this PR, we have unified the login mechanism.


Please ensure the following Airflow Variables are configured in the production environment:

* `os-login-ssh-private-key`, `os-login-ssh-user`, `os-login-ssh-public-key`

# Tests

[jax_functional_tests2](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/jax_functional_tests2/grid?task_id=jax-distributed-initialize-gce-stable-v4-8.provision.setup&tab=logs&dag_run_id=manual__2026-02-10T04%3A07%3A09.938507%2B00%3A00)
[jax_functional_tests3](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/jax_functional_tests3/grid?search=jax_functional_tests3&dag_run_id=manual__2026-02-11T02%3A57%3A48.236923%2B00%3A00&task_id=jax-distributed-initialize-gke-jax_stable_stack-v4-8.run_model.launch_workload.run_workload&tab=logs)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.