### PR TITLE
fix: Push the schedule of `mxla_gpt_6b_nightly_gke` later to avoid potential timing conflicts with the image build

### DIFF
--- a/dags/multipod/mxla_gpt3_6b_nightly_gke.py
+++ b/dags/multipod/mxla_gpt3_6b_nightly_gke.py
@@ -18,14 +18,13 @@ A DAG to run MXLA MaxText tests.
 import datetime
 from airflow import models
 from airflow.utils.task_group import TaskGroup
-from dags import composer_env
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters, Project
+from dags.common.vm_resource import DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
 # Pause test on GKE
-SCHEDULED_TIME = "15 0 * * *"
+SCHEDULED_TIME = "30 0 * * *"
 
 with models.DAG(
     dag_id="mxla_gpt_6b_nightly_gke",
@@ -117,14 +116,14 @@ with models.DAG(
       test_owner=test_owner.TONY_C,
   ).run_with_quarantine(quarantine_task_group)
 
-  (
+  _ = (
       gpt3_6b_nightly_1slice_v4_8
       >> gpt3_6b_nightly_2slice_v4_8
       >> gpt3_6b_nightly_4slice_v4_8
       >> gpt3_6b_nightly_8slice_v4_8
   )
 
-  (
+  _ = (
       gpt3_6b_nightly_1slice_v5p_8
       >> gpt3_6b_nightly_2slice_v5p_8
       >> gpt3_6b_nightly_4slice_v5p_8


### PR DESCRIPTION
# Description

The DAG `mxla_gpt_6b_nightly_gke` occasionally encounters random errors. The image build starts at 00:00 UTC and usually completes in about 20 minutes. This DAG is scheduled to start at 00:15 UTC, and it begins using the image around 00:2X UTC.

Although this issue hasn’t commonly occurred before, we should consider pushing the DAG schedule later to avoid potential timing conflicts with the image build.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.