### PR TITLE
Fix validation of the post-training, notebook DAGs

### DIFF
--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -234,10 +234,15 @@ def build_notebook_execution_command(
       f"{export_prefix}papermill {output_nb} {output_nb} --log-output"
   )
 
+  # Verify the success message exists in the notebook's output.
+  # We 'grep -v "print("' to ignore the Python source code line
+  # and ensure we are matching an actual execution result.
+  expected_completed_message = "Training Completed Successfully!"
   verification_script = textwrap.dedent(
       f"""
-      if ! grep -q "Training Completed Successfully!" {output_nb}; then
-        echo "Error: Notebook did not report successful completion."
+      set -o pipefail
+      if ! grep "{expected_completed_message}" {output_nb} | grep -vq "print("; then
+        echo "Error: Notebook did not report '{expected_completed_message}'."
         exit 1
       fi
       """


### PR DESCRIPTION
# Description
Fix validation of post-training for notebook not working as expected.
Before this fix, the validation always passes because grep will find the source code that contains the success message but we want the actual success message in the output.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.