### PR TITLE
Fix: jobset based push node_pool_name to nodeselector

### DIFF
--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -127,9 +127,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      selector = jobset.generate_node_pool_selector("jobset-ttr-kill-process")
+
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name="jobset_ttr_kill_process",
+          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
@@ -140,6 +143,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
@@ -190,6 +194,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          selector,
           jobset_config,
           cluster_info,
           create_node_pool,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -89,9 +89,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      selector = jobset.generate_node_pool_selector(
+          "jobset-ttr-node-pool-resize"
+      )
+
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name="jobset_ttr_node_pool_resize",
+          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
@@ -102,6 +107,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
@@ -151,6 +157,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          selector,
           jobset_config,
           cluster_info,
           create_node_pool,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -86,8 +86,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      selector = jobset.generate_node_pool_selector("jobset-ttr-pod-delete")
+
       jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH, dag_name="jobset_ttr_pod_delete"
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name="jobset_ttr_pod_delete",
+          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
@@ -98,6 +102,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
@@ -144,6 +149,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          selector,
           jobset_config,
           cluster_info,
           create_node_pool,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -88,8 +88,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      selector = jobset.generate_node_pool_selector("jobset-rollback-ttr")
+
       jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH, dag_name="jobset_rollback_ttr"
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name="jobset_rollback_ttr",
+          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
@@ -100,6 +104,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
@@ -146,6 +151,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          selector,
           jobset_config,
           cluster_info,
           create_node_pool,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -131,9 +131,14 @@ with models.DAG(
   with TaskGroup(  # pylint: disable=unexpected-keyword-arg
       group_id=f"v{config.tpu_version.value}"
   ):
+    selector = jobset.generate_node_pool_selector(
+        "tpu-sdk-monitoring-validation"
+    )
+
     jobset_config = jobset.build_jobset_from_gcs_yaml(
         gcs_path=GCS_JOBSET_CONFIG_PATH,
         dag_name="tpu_sdk_monitoring_validation",
+        node_pool_selector=selector,
     )
 
     cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
@@ -144,6 +149,7 @@ with models.DAG(
         is_prod=composer_env.is_prod_env(),
         machine_type=config.machine_version.value,
         tpu_topology=config.tpu_topology,
+        node_pool_selector=selector,
     )
 
     create_node_pool = node_pool.create.override(task_id="create_node_pool")(
@@ -191,6 +197,7 @@ with models.DAG(
     )
 
     chain(
+        selector,
         jobset_config,
         cluster_info,
         create_node_pool,


### PR DESCRIPTION
# Description

This PR fixes a critical scheduling issue where JobSet pods were being dispatched to arbitrary node pools instead of the intended ones, and extends the fix to support multi-node-pool environments.

Problem: Previously, the JobSet YAML template had no nodeSelector for the GKE node pool. In environments with multiple node pools, Kubernetes would schedule pods on any available nodes. This led to cases where a Rollback was performed on Node Pool A, but the JobSet pods were actually running on Node Pool B, resulting in inaccurate TTR (Time To Recovery) metrics. Additionally, for DAGs like `tpu_info_format_validation_dag` that create two node pools for the same workload, pinning to a single node pool name would leave the second pool unused.

# Technical Implementation
Added a dynamic `$node_pool_selector` to the JobSet YAML template that supports scheduling modes:
* Uses a custom label `tpu-observability/jobset-group: <jobset_name>` applied to all participating node pools via `gcloud --node-labels` at creation time, allowing the K8s scheduler to dispatch pods across multiple pools.


# Test

- GCP Composer name: chris-test (under GCP project: cienet-cmcs)
- GCP Composer version: 2.13.1
- `jobset_ttr_rollback.py` test result: https://3450723b279f4f47af5e5f22135026a7-dot-us-central1.composer.googleusercontent.com/dags/jobset_rollback_ttr/grid?tab=logs&dag_run_id=manual__2026-02-10T12%3A20%3A29.774345%2B00%3A00&task_id=v6e.create_node_pool
- `tpu_info_format_validation_dag.py` test result: https://3450723b279f4f47af5e5f22135026a7-dot-us-central1.composer.googleusercontent.com/dags/tpu_info_format_validation_dag/grid?dag_run_id=manual__2026-02-09T14%3A12%3A31.677533%2B00%3A00&tab=graph&task_id=v6e.create_node_pool


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.