### PR TITLE
fix: patch jobset_uptime_validation scheduling/selector and standardize DAG_ID

### DIFF
--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -45,12 +45,13 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "jobset_rollback_ttr": dt.timedelta(minutes=90),
         "jobset_ttr_node_pool_resize": dt.timedelta(minutes=90),
         "jobset_ttr_pod_delete": dt.timedelta(minutes=90),
-        "multi-host-availability-rollback": dt.timedelta(minutes=30),
+        "multi_host_nodepool_rollback": dt.timedelta(minutes=30),
         "node_pool_ttr_disk_size": dt.timedelta(minutes=90),
         "node_pool_ttr_update_label": dt.timedelta(minutes=90),
         "tpu_info_format_validation_dag": dt.timedelta(minutes=30),
         "tpu_sdk_monitoring_validation": dt.timedelta(minutes=30),
         "jobset_ttr_kill_process": dt.timedelta(minutes=90),
+        "jobset_uptime_validation": dt.timedelta(minutes=90),
     },
 }
 

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -131,7 +131,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name="jobset_ttr_kill_process",
+          dag_name=DAG_ID,
           node_pool_selector=selector,
       )
 
@@ -139,7 +139,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="jobset_ttr_kill_process",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -95,7 +95,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name="jobset_ttr_node_pool_resize",
+          dag_name=DAG_ID,
           node_pool_selector=selector,
       )
 
@@ -103,7 +103,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="jobset_ttr_node_pool_resize",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -90,7 +90,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name="jobset_ttr_pod_delete",
+          dag_name=DAG_ID,
           node_pool_selector=selector,
       )
 
@@ -98,7 +98,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="jobset_ttr_pod_delete",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -92,7 +92,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name="jobset_rollback_ttr",
+          dag_name=DAG_ID,
           node_pool_selector=selector,
       )
 
@@ -100,7 +100,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="jobset_rollback_ttr",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -31,7 +31,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
 
-DAG_ID = "multi-host-availability-rollback"
+DAG_ID = "multi_host_nodepool_rollback"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
@@ -91,7 +91,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="multi_host_nodepool_rollback",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -91,7 +91,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="gke_node_pool_status",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -78,7 +78,7 @@ with models.DAG(
     with TaskGroup(group_id=f"v{config.tpu_version.value}"):
       node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="node_pool_ttr_disk_size",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -77,7 +77,7 @@ with models.DAG(
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="node_pool_ttr_update_label",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -357,7 +357,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     ):
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name="tpu_info_format_validation_dag",
+          dag_name=DAG_ID,
           node_pool_selector=selector,
       )
 
@@ -365,7 +365,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="tpu_info_format_validation_dag",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -137,7 +137,7 @@ with models.DAG(
 
     jobset_config = jobset.build_jobset_from_gcs_yaml(
         gcs_path=GCS_JOBSET_CONFIG_PATH,
-        dag_name="tpu_sdk_monitoring_validation",
+        dag_name=DAG_ID,
         node_pool_selector=selector,
     )
 
@@ -145,7 +145,7 @@ with models.DAG(
         task_id="build_node_pool_info_from_gcs_yaml"
     )(
         gcs_path=GCS_CONFIG_PATH,
-        dag_name="tpu_sdk_monitoring_validation",
+        dag_name=DAG_ID,
         is_prod=composer_env.is_prod_env(),
         machine_type=config.machine_version.value,
         tpu_topology=config.tpu_topology,

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -79,7 +79,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="gke_node_pool_label_update",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,


### PR DESCRIPTION
# Description

This PR provides critical patches for the jobset_uptime_validation DAG to ensure proper scheduling and resource selection. Additionally, it refactors the tpu_observability module to use a unified DAG_ID constant, eliminating hard-coded strings.

### **Key Changes**

#### **1. JobSet Uptime Validation Patches**
* **Scheduling Helper Integration**: Fixed the issue where this DAG was not utilizing the centralized scheduling system.
    * Registered `jobset_uptime_validation` with a **90-minute timeout** in `scheduling_helper.py`.
    * Updated the DAG to dynamically fetch configurations via `get_dag_timeout(DAG_ID)` and `SchedulingHelper.arrange_schedule_time(DAG_ID)`.
* **Node Pool Selector Alignment**: 
    * **Fix**: Added the missing `node_pool_selector=selector` parameter to the `build_node_pool_info_from_gcs_yaml` task.
    * **Impact**: Ensures the task accurately targets the correct selector (e.g., `"jobset-rollback-ttr"`), preventing configuration drift during metadata retrieval.

#### **2. Unified DAG_ID & Naming Refactoring**
* **Global DAG_ID Standardization**: Introduced a `DAG_ID` constant across all DAGs within the `tpu_observability` directory. This replaces redundant hard-coded strings in `models.DAG`, `get_dag_timeout`, and `build_jobset_from_gcs_yaml`.
* **Naming Consistency Fix**: Standardized the multi-host rollback naming convention across the project.
    * **Correction**: Renamed instances of `multi-host-availability-rollback` to **`multi_host_nodepool_rollback`**.

    
# Tests

- GCP Composer name: [ml-automation-solutions-dev](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/tpu_info_format_validation_dag/grid?dag_run_id=manual__2026-01-29T09%3A46%3A16.768528%2B00%3A00&task_id=v6e.list_pod_names&tab=logs) (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.