### PR TITLE
fix gcs path error for  jax_ai_image_candidate_tpu_e2e DAGs

### DIFF
--- a/dags/sparsity_diffusion_devx/jax_ai_image_candidate_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/jax_ai_image_candidate_tpu_e2e.py
@@ -106,7 +106,8 @@ with models.DAG(
                 f"pip install . && python src/maxdiffusion/train_sdxl.py src/maxdiffusion/configs/base_xl.yml "
                 f"pretrained_model_name_or_path=gs://maxdiffusion-github-runner-test-assets/checkpoints/models--stabilityai--stable-diffusion-xl-base-1.0 "
                 f"revision=refs/pr/95 activations_dtype=bfloat16 weights_dtype=bfloat16 "
-                f"dataset_name=jfacevedo-maxdiffusion-v5p/pokemon-datasets/pokemon-gpt4-captions_sdxl resolution=1024 per_device_batch_size=1 "
+                f"dataset_name=gs://jfacevedo-maxdiffusion-v5p/pokemon-datasets/pokemon-gpt4-captions_sdxl "
+                f"resolution=1024 per_device_batch_size=1 "
                 f"jax_cache_dir=gs://jfacevedo-maxdiffusion/cache_dir/ max_train_steps=20 attention=flash enable_profiler=True "
                 f"run_name={slice_num}slice-V{cluster.device_version}_{cores}-maxdiffusion-jax-stable-stack-{current_datetime} "
                 f"output_dir={gcs_bucket.BASE_OUTPUT_DIR}/maxdiffusion-jax-stable-stack-{mode.value}-{accelerator}-{slice_num}/automated/{current_datetime}",


### PR DESCRIPTION
# Description

Path for jfacevedo-maxdiffusion-v5p/pokemon-datasets/pokemon-gpt4-captions_sdxl is wrong. It is in gcs bucket.

XLML error:

raise FileNotFoundError(f"Couldn't find any data file at {relative_to_absolute_path(path)}.")

FileNotFoundError: Couldn't find any data file at /deps/jfacevedo-maxdiffusion-v5p/pokemon-datasets/pokemon-gpt4-captions_sdxl.

# Tests

No need to test.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.