### PR TITLE
Add a new DAG that validates data provided by the `tpu-info` CLI

### DIFF
--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -52,6 +52,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "tpu_sdk_monitoring_validation": dt.timedelta(minutes=30),
         "jobset_ttr_kill_process": dt.timedelta(minutes=90),
         "jobset_uptime_validation": dt.timedelta(minutes=90),
+        "tpu_info_metrics_verification": dt.timedelta(minutes=30),
     },
 }
 

--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -162,7 +162,7 @@ def fetch_interruption_metric_records(
 
   # key: resource_name, value: EventRecord
   event_records: dict[str, EventRecord] = {}
-  response = gcp_util.query_time_series(
+  response = gcp_util.list_time_series(
       project_id=configs.project_id,
       filter_str=metric_filter,
       start_time=time_util.TimeUtil.from_unix_seconds(time_range.start),

--- a/dags/tpu_observability/tpu_info_metric.py
+++ b/dags/tpu_observability/tpu_info_metric.py
@@ -1,0 +1,547 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Metric verification strategies for the tpu-info CLI tool."""
+
+from abc import ABC, abstractmethod
+import enum
+import logging
+import re
+import textwrap
+from typing import Any
+
+from google.cloud import monitoring_v3
+from google.cloud.monitoring_v3 import types as monitoring_types
+from airflow.exceptions import AirflowException
+
+from dags.tpu_observability.utils import tpu_info_util as tpu_info
+from dags.tpu_observability.utils.time_util import TimeUtil
+from dags.tpu_observability.utils.gcp_util import list_time_series, query_time_series
+
+
+class _Percentiles(enum.Enum):
+  P50 = 50
+  P90 = 90
+  P95 = 95
+  P999 = 99.9
+
+
+class BaseMetricStrategy(ABC):
+  """Abstract Base Class (Interface) for a metric verification strategy.
+
+  It defines the contract that all concrete metric strategies must follow.
+  """
+
+  metric_name: str
+  tpu_info_metric_name: str
+  dag_id_suffix: str
+  tolerance_percent: float = 3.0
+
+  @abstractmethod
+  def list_or_query_metric(
+      self,
+      project_id: str,
+      cluster_name: str,
+      pod_name: str,
+      start_time: TimeUtil,
+      end_time: TimeUtil,
+  ) -> list[monitoring_types.TimeSeries]:
+    """Fetches metric data from Cloud Monitoring via ListTimeSeries or MQL."""
+    pass
+
+  @abstractmethod
+  def parse_from_monitoring(
+      self, time_series_data: list[monitoring_types.TimeSeries], **kwargs
+  ) -> list[float]:
+    """Parses the desired value from a list of TimeSeries objects."""
+    pass
+
+  @abstractmethod
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    """Parses percentile values from the output table of the tpu-info tool.
+
+    Args:
+      tpu_info_metric_output: A list of tables from the tpu-info command output.
+
+    Returns:
+      A list of float values representing the parsed percentiles, ordered by
+      buffer size and then by percentile.
+    """
+    pass
+
+
+class _BaseSimplePointStrategy(BaseMetricStrategy):
+  """Base strategy for parsing single numeric data points from Cloud Monitoring.
+
+  This abstract base class encapsulates the common logic for processing metrics
+  that consist of scalar values (int64 or double). It handles iterating through
+  time series, extracting the value from the first point, type checking,
+  and formatting the final output.
+  """
+
+  def _process_value(self, raw_value: int | float) -> float:
+    """(Optional) Processes the extracted raw value.
+
+    Default behavior: Simply converts it to float.
+
+    Args:
+      raw_value: The raw value extracted from the monitoring data.
+
+    Returns:
+      The processed value as a float.
+    """
+    return float(raw_value)
+
+  def list_or_query_metric(
+      self,
+      project_id: str,
+      cluster_name: str,
+      pod_name: str,
+      start_time: TimeUtil,
+      end_time: TimeUtil,
+  ) -> list[monitoring_types.TimeSeries]:
+    filter_string = [
+        f'metric.type = "{self.metric_name}"',
+        f'resource.labels.cluster_name = "{cluster_name}"',
+        f'resource.labels.pod_name = "{pod_name}"',
+    ]
+
+    return list_time_series(
+        project_id=project_id,
+        filter_str=" AND ".join(filter_string),
+        start_time=start_time,
+        end_time=end_time,
+        view=monitoring_types.ListTimeSeriesRequest.TimeSeriesView.FULL,
+    )
+
+  def parse_from_monitoring(
+      self, time_series_data: list[monitoring_types.TimeSeries]
+  ) -> list[float]:
+    """Parses raw time series data into a sorted list of float values.
+
+    This method iterates through the provided time series, extracts the most
+    recent data point (assuming index 0), and handles type conversion for
+    both `int64` and `double` value types.
+
+    The results are collected into a map keyed by 'accelerator_id' and then
+    returned as a list, sorted by the numeric suffix of the accelerator ID
+    (e.g., ensuring 'chip-10' comes after 'chip-2').
+
+    Args:
+      time_series_data: A list of TimeSeries objects returned from the
+        Cloud Monitoring API.
+
+    Returns:
+      A list of processed metric values (floats rounded to 2 decimal places),
+      ordered by the accelerator ID.
+
+    Raises:
+      AirflowException: If the metric value type is neither 'int64_value' nor
+        'double_value'.
+    """
+    metric_values = {}
+    raw_value: int | float
+
+    for ts in time_series_data:
+      if not ts.points:
+        continue
+
+      accelerator_id = ts.metric.labels["accelerator_id"]
+      point = ts.points[0]
+
+      match monitoring_v3.TypedValue.pb(point.value).WhichOneof("value"):
+        case "int64_value":
+          raw_value = point.value.int64_value
+        case "double_value":
+          raw_value = point.value.double_value
+        case _:
+          raise AirflowException(
+              f"Unexpected metric value type of {self.metric_name}"
+          )
+      processed_value = self._process_value(raw_value)
+      metric_values[accelerator_id] = round(processed_value, 2)
+
+    return [
+        metric_values[key]
+        for key in sorted(
+            metric_values.keys(), key=lambda x: int(x.split("-")[-1])
+        )
+    ]
+
+
+class _BaseDistributionStrategy(BaseMetricStrategy):
+  """Base strategy for parsing distribution (histogram) data and calculating percentiles.
+
+  This abstract base class handles the common logic for processing metrics
+  represented as distributions in Cloud Monitoring. It calculates specific
+  percentiles (e.g., P50, P99) from the raw histogram data and parses
+  corresponding percentile values from `tpu-info` command output tables.
+  """
+
+  _monitoring_group_by_label: str
+  _tpu_info_table_name: str
+  _tpu_info_group_by_key: str
+  percentiles_to_check = list(_Percentiles)
+  uses_mql = True
+
+  def list_or_query_metric(
+      self,
+      project_id: str,
+      cluster_name: str,
+      pod_name: str,
+      start_time: TimeUtil,
+      end_time: TimeUtil,
+  ) -> list[monitoring_types.TimeSeries]:
+    aggregators = []
+    for p in self.percentiles_to_check:
+      aggregators.append(f"{p.name}: percentile(val(), {p.value})")
+
+    aggregator_str = ",\n        ".join(aggregators)
+    target_group_label = f"metric.{self._monitoring_group_by_label}"
+
+    query = textwrap.dedent(
+        f"""
+        fetch k8s_container
+        | metric '{self.metric_name}'
+        | filter (
+            resource.cluster_name == '{cluster_name}'
+            && resource.pod_name == '{pod_name}'
+        )
+        | within {start_time.to_mql_string()}, {end_time.to_mql_string()}
+        | align delta(1m)
+        | every 1m
+        | group_by [resource.pod_name, {target_group_label}],
+            [{aggregator_str}]
+        """
+    ).strip()
+
+    logging.info("Executing MQL Query:\n%s", query)
+    return query_time_series(project_id, query)
+
+  def parse_from_monitoring(
+      self, time_series_data: list[monitoring_types.TimeSeries]
+  ) -> list[float]:
+    """Parses distribution data from Monitoring and calculates requested percentiles.
+
+    This method iterates through time series data, extracting distribution
+    values (count, bucket bounds, bucket counts). It groups these distributions
+    by a specific label (defined in subclasses) and calculates the target
+    percentiles for each group using the histogram data.
+
+    Args:
+      time_series_data: A list of TimeSeries objects containing distribution
+      data.
+
+    Returns:
+      A flattened list of calculated percentile values (floats). The list is
+      ordered first by the sorted group key, and then by the sorted percentiles
+      for each group.
+    """
+
+    if not time_series_data:
+      return []
+
+    parsed_data = {}
+
+    for ts_data in time_series_data:
+      if len(ts_data.label_values) < 2:
+        continue
+
+      group_key_value = ts_data.label_values[1].string_value
+
+      if not ts_data.point_data:
+        continue
+
+      latest_point = ts_data.point_data[0]
+
+      parsed_data[group_key_value] = {}
+
+      for idx, p in enumerate(self.percentiles_to_check):
+        val = latest_point.values[idx].double_value
+        parsed_data[group_key_value][p.name] = val
+
+    monitoring_values = []
+    for group_key in sorted(parsed_data.keys()):
+      for p in self.percentiles_to_check:
+        monitoring_values.append(parsed_data[group_key][p.name])
+
+    return monitoring_values
+
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    """Parses pre-calculated percentile values from `tpu-info` output tables.
+
+    This method locates the specific table (defined in subclasses) in the
+    `tpu-info` output and extracts values for the requested percentiles.
+    It handles parsing numeric values from string cells (e.g., "123.45 us")
+    and mapping specific column names (like "P999" for P99.9).
+
+    Args:
+      tpu_info_metric_output: A list of parsed Table objects from the `tpu-info`
+      command.
+
+    Returns:
+      A flattened list of percentile values (floats) extracted from the table.
+      The list is ordered first by the sorted group key, and then by the sorted
+      percentiles for each group.
+    """
+    parsed_values_by_group: dict[str, dict[float, float]] = {}
+    table_name = self._tpu_info_table_name
+    group_key = self._tpu_info_group_by_key
+
+    for metric_table in tpu_info_metric_output:
+      if metric_table.name == table_name:
+        for row_dict in metric_table.body:
+          group_value = row_dict.get(group_key)
+          if not group_value:
+            continue
+
+          parsed_values_by_group[group_value] = {}
+          for p in self.percentiles_to_check:
+            # Use Enum name as key (e.g. "P999")
+            value_str = row_dict.get(p.name, "")
+
+            match = re.search(r"([\d\.]+)", value_str)
+            if match:
+              parsed_values_by_group[group_value][p.name] = float(
+                  match.group(1)
+              )
+
+    tpu_info_data_values = []
+    for group_value in sorted(parsed_values_by_group.keys()):
+      for p in self.percentiles_to_check:
+        tpu_info_data_values.append(parsed_values_by_group[group_value][p.name])
+
+    return tpu_info_data_values
+
+
+class MemoryUsedStrategy(_BaseSimplePointStrategy):
+  """Strategy for verifying Used HBM Memory."""
+
+  metric_name = "kubernetes.io/container/accelerator/memory_used"
+  tpu_info_metric_name = "hbm_usage"
+  dag_id_suffix = "memory_used"
+  tolerance_percent = 1.0
+  _monitoring_value_type_key = "int64_value"
+
+  def _process_value(self, raw_value: Any) -> float:
+    return raw_value / (1024**3)
+
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    tpu_info_data_values = []
+    for metric_table in tpu_info_metric_output:
+      if metric_table.name == "TPU HBM Usage":
+        for row_dict in metric_table.body:
+          hbm_value = row_dict["HBM Usage (GiB)"]
+          # Parses HBM usage from "USED.XX GiB / TOTAL.XX GiB".
+          # Group 1 captures the USED memory value.
+          # Group 2 captures the TOTAL memory value.
+          match = re.search(
+              r"(\d+\.\d+)\s*GiB\s*\/\s*(\d+\.\d+)\s*GiB", hbm_value
+          )
+          if match:
+            tpu_info_data_values.append(float(match.group(1)))
+    return tpu_info_data_values
+
+
+class MemoryTotalStrategy(_BaseSimplePointStrategy):
+  """Strategy for verifying Total HBM Memory."""
+
+  metric_name = "kubernetes.io/container/accelerator/memory_total"
+  tpu_info_metric_name = "hbm_usage"
+  dag_id_suffix = "memory_total"
+  tolerance_percent = 0.0
+  _monitoring_value_type_key = "int64_value"
+
+  def _process_value(self, raw_value: Any) -> float:
+    return raw_value / (1024**3)
+
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    tpu_info_data_values = []
+    for metric_table in tpu_info_metric_output:
+      if metric_table.name == "TPU HBM Usage":
+        for row_dict in metric_table.body:
+          hbm_value = row_dict["HBM Usage (GiB)"]
+          # Regex to parse the HBM usage string format:
+          # "USED.XX GiB / TOTAL.XX GiB".
+          # Group 1 captures the USED memory value.
+          # Group 2 captures the TOTAL memory value.
+          match = re.search(
+              r"(\d+\.\d+)\s*GiB\s*\/\s*(\d+\.\d+)\s*GiB", hbm_value
+          )
+          if match:
+            tpu_info_data_values.append(float(match.group(2)))
+    return tpu_info_data_values
+
+
+class DutyCycleStrategy(_BaseSimplePointStrategy):
+  """Strategy for verifying Duty Cycle."""
+
+  metric_name = "kubernetes.io/container/accelerator/duty_cycle"
+  tpu_info_metric_name = "duty_cycle_percent"
+  dag_id_suffix = "duty_cycle"
+  tolerance_percent = 1.0
+  _monitoring_value_type_key = "int64_value"
+
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    tpu_info_data_values = []
+    for metric_table in tpu_info_metric_output:
+      if metric_table.name == "TPU Duty Cycle":
+        for row_dict in metric_table.body:
+          dutycycle_value = row_dict["Duty Cycle (%)"]
+          match = re.search(r"(\d+\.\d+)%", dutycycle_value)
+          if match:
+            tpu_info_data_values.append(float(match.group(1)))
+    return tpu_info_data_values
+
+
+class TensorcoreUtilizationStrategy(_BaseSimplePointStrategy):
+  """Strategy for verifying TensorCore Utilization."""
+
+  metric_name = "kubernetes.io/container/accelerator/tensorcore_utilization"
+  tpu_info_metric_name = "tensorcore_utilization"
+  dag_id_suffix = "tensorcore_utilization"
+  tolerance_percent = 15.0
+  _monitoring_value_type_key = "double_value"
+
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    tpu_info_data_values = []
+    for metric_table in tpu_info_metric_output:
+      if metric_table.name == "TensorCore Utilization":
+        for row_dict in metric_table.body:
+          tcu_value = row_dict["TensorCore Utilization"].replace("%", "")
+          tpu_info_data_values.append(float(tcu_value))
+    return tpu_info_data_values
+
+
+class BufferTransferLatencyStrategy(_BaseDistributionStrategy):
+  """Strategy for verifying Buffer Transfer Latency from distribution data."""
+
+  metric_name = (
+      "kubernetes.io/container/multislice/network/dcn_transfer_latencies"
+  )
+  tpu_info_metric_name = "buffer_transfer_latency"
+  dag_id_suffix = "buffer_transfer_latency"
+  tolerance_percent = 3.0
+  _monitoring_group_by_label = "buffer_size"
+  _tpu_info_table_name = "TPU Buffer Transfer Latency"
+  _tpu_info_group_by_key = "Buffer Size"
+
+
+class HostToDeviceTransferLatenciesStrategy(_BaseDistributionStrategy):
+  """Strategy for verifying Host to Device Transfer Latency from distribution data."""
+
+  metric_name = "kubernetes.io/container/multislice/accelerator/host_to_device_transfer_latencies"
+  tpu_info_metric_name = "host_to_device_transfer_latency"
+  dag_id_suffix = "host_to_device_transfer_latency"
+  tolerance_percent = 3.0
+  _monitoring_group_by_label = "buffer_size"
+  _tpu_info_table_name = "TPU Host to Device Transfer Latency"
+  _tpu_info_group_by_key = "Buffer Size"
+
+
+class DeviceToHostTransferLatenciesStrategy(_BaseDistributionStrategy):
+  """
+  Strategy for verifying Device to Host Transfer Latency from distribution data.
+  """
+
+  metric_name = "kubernetes.io/container/multislice/accelerator/device_to_host_transfer_latencies"
+  tpu_info_metric_name = "device_to_host_transfer_latency"
+  dag_id_suffix = "device_to_host_transfer_latency"
+  tolerance_percent = 3.0
+  _monitoring_group_by_label = "buffer_size"
+  _tpu_info_table_name = "TPU Device to Host Transfer Latency"
+  _tpu_info_group_by_key = "Buffer Size"
+
+
+class CollectiveEndToEndLatencyLatenciesStrategy(_BaseDistributionStrategy):
+  """
+  Strategy for verifying Collective End to End Latency from distribution data.
+  """
+
+  metric_name = "kubernetes.io/container/multislice/network/collective_end_to_end_latencies"
+  tpu_info_metric_name = "collective_e2e_latency"
+  dag_id_suffix = "collective_e2e_latency"
+  tolerance_percent = 3.0
+  _monitoring_group_by_label = "collective_type"
+  _tpu_info_table_name = "TPU Collective End to End Latency"
+  _tpu_info_group_by_key = "Buffer Size"
+
+  def parse_from_tpu_info(
+      self, tpu_info_metric_output: list[tpu_info.Table]
+  ) -> list[float]:
+    parsed_values_by_buffer: dict[str, dict[float, float]] = {}
+
+    for metric_table in tpu_info_metric_output:
+      if metric_table.name == self._tpu_info_table_name:
+        for i, row_dict in enumerate(metric_table.body):
+          # The 'Collective Type' column (e.g., ALL_GATHER / ALL_REDUCE) is
+          # missing from the tpu-info output table. This prevents us from
+          # explicitly filtering and distinguishing the two different
+          # operations.
+          #
+          # As a temporary solution, we are fetching the values based on the
+          # 'Buffer Size' label (e.g., '16MB+').
+          # TODO: b/454457878 - This logic must be updated to filter on
+          # 'Collective Type' as soon as the tpu-info column is added to the
+          # table to ensure correctness.
+          buffer_size = row_dict.get(self._tpu_info_group_by_key)
+          if not buffer_size:
+            continue
+
+          buffer_size_name = buffer_size + "(" + str(i) + ")"
+          parsed_values_by_buffer[buffer_size_name] = {}
+          for p in self.percentiles_to_check:
+            value_str = row_dict.get(p.name, "")
+
+            match = re.search(r"([\d\.]+)", value_str)
+            if match:
+              parsed_values_by_buffer[buffer_size_name][p.name] = float(
+                  match.group(1)
+              )
+
+    tpu_info_data_values = []
+    for buffer_size_name in sorted(parsed_values_by_buffer.keys()):
+      for p in self.percentiles_to_check:
+        tpu_info_data_values.append(
+            parsed_values_by_buffer[buffer_size_name][p.name]
+        )
+
+    return tpu_info_data_values
+
+
+ALL_METRIC_STRATEGIES = [
+    MemoryUsedStrategy(),
+    MemoryTotalStrategy(),
+    DutyCycleStrategy(),
+    TensorcoreUtilizationStrategy(),
+    # TODO(b/481177412): Re-enable and validate latency metrics.
+    # Current Monitoring API aggregation differs from tpu-info, making it
+    # unsuitable as a Source of Truth. Investigation for a valid verification
+    # method is ongoing.
+    # BufferTransferLatencyStrategy(),
+    # HostToDeviceTransferLatenciesStrategy(),
+    # DeviceToHostTransferLatenciesStrategy(),
+    # CollectiveEndToEndLatencyLatenciesStrategy(),
+]

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -1,0 +1,431 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script uses a factory pattern to dynamically generate an Airflow DAG for
+each metric verification strategy.
+"""
+
+from dataclasses import replace
+import datetime
+import logging
+import os
+import tempfile
+
+from airflow import models
+from airflow.decorators import task
+from airflow.exceptions import AirflowException
+from airflow.models.baseoperator import chain
+from airflow.utils.task_group import TaskGroup
+from airflow.utils.trigger_rule import TriggerRule
+
+from dags import composer_env
+
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+from dags.tpu_observability.tpu_info_metric import ALL_METRIC_STRATEGIES
+from dags.tpu_observability.tpu_info_metric import BaseMetricStrategy
+from dags.tpu_observability.utils import jobset_util as jobset
+from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.utils import subprocess_util as subprocess
+from dags.tpu_observability.utils import tpu_info_util as tpu_info
+from dags.tpu_observability.utils.node_pool_util import Info
+from dags.tpu_observability.utils.time_util import TimeUtil
+from dags.tpu_observability.utils.jobset_util import Workload
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+
+
+DAG_ID = "tpu_info_metrics_verification"
+DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
+SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+
+def compare_metric_values(
+    cmd_values: list[float],
+    monitoring_values: list[float],
+    pod_name: str,
+    metric_display_name: str,
+    tolerance_percent: float,
+):
+  """Compares two lists of metric values and checks if they are within a tolerance range."""
+  if len(cmd_values) != len(monitoring_values):
+    raise AirflowException(
+        f"For pod {pod_name} ({metric_display_name}), data count mismatch. "
+        f"TPU-Info has {len(cmd_values)} values, Monitoring has "
+        f"{len(monitoring_values)}."
+    )
+
+  logging.info(
+      "--- Comparison Results for pod: %s, Metric: %s ---",
+      pod_name,
+      metric_display_name,
+  )
+  logging.info(
+      "%-12s%-15s%-17s%-12s%-15s%-10s",
+      "Device",
+      "TPU-Info Val",
+      "Monitoring Val",
+      "Difference",
+      "Allowed Diff",
+      "Result",
+  )
+  logging.info("-" * 85)
+
+  all_passed = True
+  for i, (log_val, mon_val) in enumerate(zip(cmd_values, monitoring_values)):
+    diff = abs(log_val - mon_val)
+    allowed_diff = mon_val * (tolerance_percent / 100.0)
+    passed = diff <= allowed_diff
+    if not passed:
+      all_passed = False
+    logging.info(
+        "%-12s%-15.2f%-17.2f%-12.2f%-15.2f%-10s",
+        f"Device {i}",
+        log_val,
+        mon_val,
+        diff,
+        allowed_diff,
+        "PASS" if passed else "FAIL",
+    )
+  logging.info("-" * 70)
+
+  if not all_passed:
+    raise AirflowException(
+        f"Overall Result for Pod {pod_name} ({metric_display_name}): FAIL - "
+        f"Values do not match within {tolerance_percent}% tolerance."
+    )
+  logging.info(
+      "Overall Result for Pod %s (%s): PASS", pod_name, metric_display_name
+  )
+
+
+@task
+def get_tpu_info_metric_from_pod(
+    node_pool: node_pool.Info,
+    pod_name: str,
+    jobset_config: jobset,
+    metric_name: str,
+) -> str:
+  """Executes the 'tpu-info' command in the specified pod and returns its output."""
+  with tempfile.TemporaryDirectory() as tmpdir:
+    kube_dir = tmpdir + "/kubeconfig"
+    env = os.environ.copy()
+    env["KUBECONFIG"] = kube_dir
+
+    cmd = " && ".join([
+        jobset.Command.get_credentials_command(node_pool),
+        (
+            f"kubectl --kubeconfig={kube_dir} "
+            f"exec {pod_name} -n {jobset_config.namespace} "
+            f"-- tpu-info --metric {metric_name}"
+        ),
+    ])
+
+    return subprocess.run_exec(cmd=cmd, env=env)
+
+
+@task
+def run_metric_verification(
+    node_pool: Info,
+    job_apply_time: TimeUtil,
+    metric_strategy: BaseMetricStrategy,
+    comparison_data: tuple[str, list[tpu_info.Table]],
+):
+  """A generic task that uses a strategy object to verify a metric."""
+  pod_name, tpu_info_output = comparison_data
+  metric_name = metric_strategy.metric_name
+  logging.info("Verifying metric '%s' for pod: %s...", metric_name, pod_name)
+
+  start_time = job_apply_time
+  end_time = job_apply_time + datetime.timedelta(minutes=10)
+
+  time_series_data = metric_strategy.list_or_query_metric(
+      project_id=node_pool.project_id,
+      cluster_name=node_pool.cluster_name,
+      pod_name=pod_name,
+      start_time=start_time,
+      end_time=end_time,
+  )
+
+  monitoring_values = metric_strategy.parse_from_monitoring(time_series_data)
+  cmd_values = metric_strategy.parse_from_tpu_info(tpu_info_output)
+
+  tolerance_for_metric = metric_strategy.tolerance_percent
+  logging.info(
+      "Using a tolerance of %.2f%% for metric '%s' comparison.",
+      tolerance_for_metric,
+      metric_strategy.dag_id_suffix,
+  )
+
+  compare_metric_values(
+      cmd_values,
+      monitoring_values,
+      pod_name,
+      metric_display_name=metric_strategy.dag_id_suffix,
+      tolerance_percent=tolerance_for_metric,
+  )
+
+  return True
+
+
+@task
+def summarize_results(
+    verification_results_dict: dict[str, list[bool]], active_pods: list[str]
+):
+  """
+  Summarizes the results of metric verifications for all pods.
+
+  """
+  if not active_pods:
+    raise AirflowException("No active nodes were found. Grand Result: SKIPPED")
+
+  num_expected_pods = len(active_pods)
+  overall_success = True
+  failure_summary = []
+
+  logging.info("--- Overall Verification Summary ---")
+  logging.info("Total pods scheduled for verification: %s", num_expected_pods)
+  logging.info("-" * 70)
+  logging.info("%-35s | %-10s | %-20s", "Metric Name", "Result", "Details")
+  logging.info("-" * 70)
+
+  for metric_name, results in verification_results_dict.items():
+    num_passes = len(results)  # Only successed task return result
+
+    if num_passes < num_expected_pods:
+      status = "FAIL"
+      details = f"Passed {num_passes} of {num_expected_pods} pods."
+      overall_success = False
+      failure_summary.append(f"- {metric_name}: {details}")
+    else:
+      status = "PASS"
+      details = f"All {num_expected_pods} pods passed."
+
+    logging.info("%-35s | %-10s | %-20s", metric_name, status, details)
+
+  logging.info("-" * 70)
+
+  if not overall_success:
+    error_message = (
+        "Grand Result: FAILURE - One or more metric verifications failed.\n"
+        "Failure Details:\n" + "\n".join(failure_summary)
+    )
+    raise AirflowException(error_message)
+
+  logging.info(
+      "Grand Result: SUCCESS - All metric verifications passed for all pods."
+  )
+
+
+# Keyword arguments are generated dynamically at runtime (pylint does not
+# know this signature).
+with models.DAG(
+    dag_id=DAG_ID,
+    start_date=datetime.datetime(2025, 8, 15),
+    default_args={"retries": 0},
+    schedule=SCHEDULE,
+    catchup=False,
+    tags=["gke", "tpu-observability", "tpu-info", "TPU", "v6e-16"],
+    description=(
+        "Validates TPU metric consistency between tpu-info CLI and Cloud "
+        "Monitoring API across dynamically provisioned GKE node pools."
+    ),
+    doc_md="""
+      # Data Validation DAG
+      # This DAG verifies the data value of the tables in the tpu-info output.
+
+      ### Description
+      This DAG automates the cross-validation of TPU performance data. It
+      ensures that the metrics reported directly from the hardware are
+      consistent with the data ingested into the cloud monitoring pipeline.
+      The verification suite includes metrics such as **TPU Utilization,
+      TensorCore Activity, Memory Usage, and Latency**, and is designed to
+      automatically scale as new metric strategies are added to the validation
+      library.
+
+      ### Prerequisites
+      This test requires an existing GKE cluster.
+      A pre-built Docker image containing the necessary jax, libtpu, and
+      tpu-info packages must also be available in a repository accessible
+      by the GKE cluster.
+
+      ### Procedures
+      The DAG begins by creating temporary GKE TPU node pools for the test.
+      Once the node pools are running, it schedules a Kubernetes JobSet and
+      waits for the pods to become active. It then executes the tpu-info
+      command within these pods to capture the raw text output. This output is
+      parsed into structured tables, performs a point-by-point comparison
+      between the two data sources. A task is marked as successful only if the
+      values fall within a predefined **tolerance percentage**. the DAG cleans
+      up all created resources, including the JobSet and the temporary node
+      pools.
+    """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+
+    @task
+    def generate_second_node_pool_name(
+        node_pool_info: node_pool.Info,
+    ) -> str:
+      """Generates a second node pool name."""
+      return f"{node_pool_info.node_pool_name}-2"
+
+    workload_script = jobset.Workload.JAX_TPU_BENCHMARK
+
+    with TaskGroup(group_id=f"v{config.tpu_version.value}"):
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name="tpu_info_metrics_verification",
+      )
+
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="tpu_info_metrics_verification",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
+      cluster_info_2 = node_pool.copy_node_pool_info_with_override(
+          info=cluster_info,
+          node_pool_name=generate_second_node_pool_name(cluster_info),
+      )
+
+      with TaskGroup(group_id="create_node_pool") as create_node_pool:
+        create_first_node_pool = node_pool.create.override(
+            task_id="node_pool_1",
+        )(
+            node_pool=cluster_info,
+        )
+
+        create_second_node_pool = node_pool.create.override(
+            task_id="node_pool_2",
+        )(
+            node_pool=cluster_info_2,
+        )
+
+        _ = [create_first_node_pool, create_second_node_pool]
+
+      apply_time = jobset.run_workload(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
+      )
+
+      pod_names = jobset.list_pod_names.override(
+          task_id="list_pod_names",
+          retries=5,
+          retry_delay=datetime.timedelta(seconds=10),
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      )
+
+      wait_for_job_start = jobset.wait_for_jobset_started.override(
+          task_id="wait_for_job_start"
+      )(cluster_info, pod_name_list=pod_names, job_apply_time=apply_time)
+
+      verification_results = {}
+      all_verification_groups = []
+
+      for strategy in ALL_METRIC_STRATEGIES:
+        group_id = f"verify_{strategy.dag_id_suffix}"
+
+        with TaskGroup(group_id=group_id) as verification_group:
+          tpu_info_metric_outputs = (
+              get_tpu_info_metric_from_pod.override(
+                  task_id="get_tpu_info_metric_table"
+              )
+              .partial(
+                  node_pool=cluster_info,
+                  jobset_config=jobset_config,
+                  metric_name=strategy.tpu_info_metric_name,
+              )
+              .expand(pod_name=pod_names)
+          )
+
+          tpu_info_metric_output = (
+              tpu_info.parse_tpu_info_output.override(
+                  task_id="get_each_metric_table"
+              )
+              .partial()
+              .expand(output=tpu_info_metric_outputs)
+          )
+
+          verify_metric = (
+              run_metric_verification.override(task_id="run_verification")
+              .partial(
+                  node_pool=cluster_info,
+                  job_apply_time=apply_time,
+                  metric_strategy=strategy,
+              )
+              .expand(comparison_data=pod_names.zip(tpu_info_metric_output))
+          )
+
+        all_verification_groups.append(verification_group)
+
+        verification_results[strategy.dag_id_suffix] = verify_metric
+
+      summary = summarize_results.override(
+          task_id="summarize_results", trigger_rule=TriggerRule.ALL_DONE
+      )(
+          verification_results_dict=verification_results,
+          active_pods=pod_names,
+      )
+
+      clean_up_workload = jobset.end_workload.override(
+          task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      ).as_teardown(
+          setups=apply_time
+      )
+
+      with TaskGroup(group_id="cleanup_node_pool") as cleanup_node_pool:
+        cleanup_first_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool_1",
+            trigger_rule=TriggerRule.ALL_DONE,
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        cleanup_second_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool_2",
+            trigger_rule=TriggerRule.ALL_DONE,
+        )(node_pool=cluster_info_2).as_teardown(
+            setups=create_node_pool,
+        )
+
+        chain(cleanup_first_node_pool, cleanup_second_node_pool)
+
+      chain(
+          jobset_config,
+          cluster_info,
+          cluster_info_2,
+          create_node_pool,
+          apply_time,
+          pod_names,
+          wait_for_job_start,
+          all_verification_groups,
+          summary,
+          clean_up_workload,
+          cleanup_node_pool,
+      )

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -33,6 +33,7 @@ import kubernetes
 
 from dags.tpu_observability.utils import subprocess_util as subprocess
 from dags.tpu_observability.utils.gcp_util import query_time_series
+from dags.tpu_observability.utils.gcp_util import list_time_series
 from dags.tpu_observability.utils.node_pool_util import Info as node_pool_info
 from dags.tpu_observability.utils.node_pool_util import NODE_POOL_SELECTOR_KEY
 from dags.tpu_observability.utils.time_util import TimeUtil
@@ -437,7 +438,7 @@ def _generate_jobset_name(dag_id_prefix: str) -> str:
   timestamp = now_utc.strftime("%Y%m%d%H%M%S")
   dag_id_prefix = dag_id_prefix.replace("_", "-").lower()
 
-  return f"{dag_id_prefix}-workload-{timestamp}"
+  return f"{dag_id_prefix}-{timestamp}"
 
 
 @task
@@ -676,7 +677,7 @@ def wait_for_jobset_started(
       f'resource.labels.cluster_name = "{node_pool.cluster_name}"',
       f'resource.labels.pod_name = "{pod_name}"',
   ]
-  time_series_data = query_time_series(
+  time_series_data = list_time_series(
       project_id=node_pool.project_id,
       filter_str=" AND ".join(filter_string),
       start_time=start_time,
@@ -737,7 +738,7 @@ def wait_for_jobset_ttr_to_be_found(
       else TimeUtil.from_datetime(now - datetime.timedelta(minutes=60))
   )
 
-  time_series = query_time_series(
+  time_series = list_time_series(
       project_id=node_pool.project_id,
       filter_str=(
           'metric.type="kubernetes.io/jobset/times_to_recover" '

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -27,7 +27,7 @@ from airflow.exceptions import AirflowFailException
 from google.cloud import monitoring_v3
 
 from dags.tpu_observability.utils.time_util import TimeUtil
-from dags.tpu_observability.utils.gcp_util import query_time_series
+from dags.tpu_observability.utils.gcp_util import list_time_series
 from dags.tpu_observability.utils import subprocess_util as subprocess
 from xlml.apis import gcs
 from xlml.utils import composer
@@ -236,7 +236,20 @@ def create(
   if ignore_failure:
     command += "2>&1 || true "
 
-  subprocess.run_exec(command)
+  try:
+    subprocess.run_exec(command)
+  except Exception as e:
+    debug_cmd = (
+        "gcloud container operations list "
+        f"--project={node_pool.project_id} "
+        f"--region={node_pool.location} "
+        f"--format=json(name,status)"
+    )
+    debug_res = subprocess.run_exec(debug_cmd)
+
+    raise AirflowFailException(
+        f"Primary task failed. Current operations:\n{debug_res}"
+    ) from e
 
 
 @task
@@ -411,7 +424,7 @@ def _query_status_metric(node_pool: Info) -> Status:
   # data points from all series into a single flat list ('records'). It then
   # finds the record with the maximum timestamp from this list to ensure the
   # true latest status is identified.
-  time_series_data = query_time_series(
+  time_series_data = list_time_series(
       project_id=node_pool.project_id,
       filter_str=" AND ".join(filter_string),
       start_time=start_time,
@@ -526,7 +539,7 @@ def wait_for_availability(
       f'resource.labels.node_pool_name="{node_pool.node_pool_name}"',
   ]
 
-  page_result = query_time_series(
+  page_result = list_time_series(
       project_id=node_pool.project_id,
       filter_str=" AND ".join(filter_string),
       start_time=start_time,
@@ -608,7 +621,7 @@ def wait_for_ttr(
       f'resource.labels.node_pool_name = "{node_pool.node_pool_name}"',
   ]
 
-  page_result = query_time_series(
+  page_result = list_time_series(
       project_id=node_pool.project_id,
       filter_str=" AND ".join(filter_string),
       start_time=start_time,

--- a/dags/tpu_observability/utils/time_util.py
+++ b/dags/tpu_observability/utils/time_util.py
@@ -48,6 +48,22 @@ class TimeUtil:
     iso_str = self.to_datetime().isoformat()
     return iso_str.replace("+00:00", "Z")
 
+  def to_mql_string(self) -> str:
+    dt = self.to_datetime()
+    return dt.strftime("d'%Y/%m/%d-%H:%M:%S'")
+
+  def __add__(self, other: datetime.timedelta) -> "TimeUtil":
+    """Allows usage like: TimeUtil(...) + timedelta(minutes=10)."""
+    if isinstance(other, datetime.timedelta):
+      return TimeUtil(self.time + int(other.total_seconds()))
+    return NotImplemented
+
+  def __sub__(self, other: datetime.timedelta) -> "TimeUtil":
+    """Allows usage like: TimeUtil(...) - timedelta(minutes=10)."""
+    if isinstance(other, datetime.timedelta):
+      return TimeUtil(self.time - int(other.total_seconds()))
+    return NotImplemented
+
 
 if __name__ == "__main__":
   time = "2025-09-19T04:08:35.951+00:00"


### PR DESCRIPTION
# Description
This DAG automates the cross-validation of TPU performance data. It ensures that the metrics reported directly from the hardware are consistent with the data ingested into the cloud monitoring pipeline. The verification suite includes metrics such as **TPU Utilization, TensorCore Activity, Memory Usage, and Latency**, and is designed to automatically scale as new metric strategies are added to the validation library.


# Tests
  - Dag Name : tpu_info_metrics_verification
  - Airflow test results: https://dd58fc12d82f4386ac0a198ede64dcae-dot-us-east1.composer.googleusercontent.com/dags/tpu_info_metrics_verification/grid?dag_run_id=manual__2026-02-13T07%3A20%3A27.616639%2B00%3A00

## Airflow/Composer
- GCP Composer name: `daniel-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`
 
# Required file in GCS bucket [ml-auto-solutions-dag-configs/tpu_observability](gs://ml-auto-solutions-dag-configs/tpu_observability/)
- dag_config.yaml
- jobset_config.yaml

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.