### PR TITLE
remove mixtral-8x22b test

### DIFF
--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -57,13 +57,7 @@ with models.DAG(
   }
 
   # Unchained tests
-  # TODO(ranran): add back ckpt conversation after b/384580048
   test_models_tpu = {
-      "mixtral-8x22b": {
-          "script_name": "tpu/mixtral/8x22b/2_test_mixtral",
-          "cluster": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
-          "time_out_in_min": 90,
-      },
       "deepseek3-671b": {
           "script_name": "tpu/deepseek/v3-671b/2_test_deepseek",
           "cluster": XpkClusters.TPU_V5P_128_CLUSTER,


### PR DESCRIPTION
# Description

remove the Mixtral 8x22B tests from XL ML. Since the architecture is identical to the 8x7B model, these tests are redundant and don't provide additional coverage.

fix: b/437388457, b/484395675

# Tests

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.