### PR TITLE
Fix log validation for orbax training DAGs

### DIFF
--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -150,9 +150,8 @@ with models.DAG(
         )
 
         log_filters = [
-            "jsonPayload.message:\"'event_type': 'emergency_restore'\"",
-            "jsonPayload.message:\"'is_restoring_slice': True\"",
-            "jsonPayload.message:\"'directory': 'gs://\"",
+            "textPayload:\"'event_type': 'restore'\"",
+            "textPayload:\"'directory': 'gs://\"",
         ]
         validate_restored_source = validation_util.validate_log_exist.override(
             task_id="validate_emc_restored_from_gcs"

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -146,9 +146,8 @@ with models.DAG(
         )
 
         log_filters = [
-            "jsonPayload.message:\"'event_type': 'emergency_restore'\"",
-            "jsonPayload.message:\"'is_restoring_slice': True\"",
-            "jsonPayload.message:\"'directory': '/local/\"",
+            "textPayload:\"'event_type': 'restore'\"",
+            "textPayload:\"'directory': '/local/\"",
         ]
         validate_restored_source = validation_util.validate_log_exist.override(
             task_id="validate_emc_restored_from_local"

--- a/dags/orbax/maxtext_emc_resume_gcs.py
+++ b/dags/orbax/maxtext_emc_resume_gcs.py
@@ -213,9 +213,8 @@ with models.DAG(
         )
 
         log_filters = [
-            "jsonPayload.message:\"'event_type': 'emergency_restore'\"",
-            "jsonPayload.message:\"'is_restoring_slice': True\"",
-            "jsonPayload.message:\"'directory': 'gs://\"",
+            "textPayload:\"'event_type': 'restore'\"",
+            "textPayload:\"'directory': 'gs://\"",
         ]
         validate_restore_source = validation_util.validate_log_exist.override(
             task_id="validate_emc_restored_from_gcs"

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -149,8 +149,8 @@ with models.DAG(
         )
 
         log_filters = [
-            "jsonPayload.message:\"'event_type': 'restore'\"",
-            "jsonPayload.message:\"'directory': '/local\"",
+            "textPayload:\"'event_type': 'restore'\"",
+            "textPayload:\"'directory': '/local\"",
         ]
         validate_restored_source = validation_util.validate_log_exist.override(
             task_id="validate_restore_copy_from_peer"


### PR DESCRIPTION
# Description
Fixing the Orbax DAG validation failures by updating the query logs to use testPayload instead of jsonPayload.message.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.