### PR TITLE
Fix train_rl and rl.yml paths

### DIFF
--- a/dags/post_training/maxtext_rl.py
+++ b/dags/post_training/maxtext_rl.py
@@ -79,7 +79,7 @@ with models.DAG(
           f"{test_config_util.DEFAULT_BUCKET}/llama3.1-70b-Instruct/"
           "scanned-pathways/0/items/"
       ),
-      rl_config_path="src/MaxText/configs/rl.yml",
+      rl_config_path="src/maxtext/configs/post_train/rl.yml",
       loss_algos=[
           test_config_util.LossAlgo.GRPO,
           test_config_util.LossAlgo.GSPO,

--- a/dags/post_training/util/test_config_util.py
+++ b/dags/post_training/util/test_config_util.py
@@ -88,7 +88,7 @@ class RLTestConfig:
   tokenizer_path: str
   load_parameters_path: str
   loss_algos: list[LossAlgo]
-  rl_config_path: str = "src/MaxText/configs/rl.yml"
+  rl_config_path: str = "src/maxtext/configs/post_train/rl.yml"
 
   def __init__(
       self,
@@ -100,7 +100,7 @@ class RLTestConfig:
       tokenizer_path: str,
       load_parameters_path: str,
       loss_algos: list[LossAlgo],
-      rl_config_path: str = "src/MaxText/configs/rl.yml",
+      rl_config_path: str = "src/maxtext/configs/post_train/rl.yml",
   ):
     """Initializes the RL test configurations.
 
@@ -158,7 +158,7 @@ class RLTestConfig:
       ])
 
     rl_command = (
-        "python -m src.MaxText.rl.train_rl "
+        "python -m src.maxtext.rl.train_rl "
         f"{self.rl_config_path} " + " ".join(command_params)
     )
 


### PR DESCRIPTION
# Description
Update paths for train_rl.py and rl.yml to fix maxtext_rl DAG.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/dags/maxtext_rl/grid?tab=logs&task_id=gspo-nightly-1xv5p-128.run_training.run_model.wait_for_workload_completion&dag_run_id=manual__2026-02-26T02%3A25%3A19.936588%2B00%3A00

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.