### PR TITLE
fix: Update uptime metrics query and fix node pool exception

### DIFF
--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -822,7 +822,7 @@ def query_uptime_metrics(
       f'resource.labels.entity_name = "{jobset_name}"',
   ]
 
-  return query_time_series(
+  return list_time_series(
       project_id=node_pool.project_id,
       filter_str=" AND ".join(filter_string),
       start_time=start_time,

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -243,7 +243,8 @@ def create(
         "gcloud container operations list "
         f"--project={node_pool.project_id} "
         f"--region={node_pool.location} "
-        f"--format=json(name,status)"
+        f"--filter='status=RUNNING AND targetLink:{node_pool.node_pool_name}' "
+        f"--format='json(name,status)'"
     )
     debug_res = subprocess.run_exec(debug_cmd)
 


### PR DESCRIPTION
- In `query_uptime_metrics`, replace `query_time_series` with `list_time_series` to align with the recent `gcloud_util.py` refactoring.
- Fix a syntax error in the exception handling within `node_pool_util`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.