### PR TITLE
Update tpu_info_metrics_dag schedule and environment logic

### DIFF
--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -237,7 +237,7 @@ with models.DAG(
     dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 15),
     default_args={"retries": 0},
-    schedule=SCHEDULE,
+    schedule=SCHEDULE if composer_env.is_prod_env() else None,
     catchup=False,
     tags=["gke", "tpu-observability", "tpu-info", "TPU", "v6e-16"],
     description=(


### PR DESCRIPTION
# Description

Update tpu_info_metrics_dag schedule and environment logic

- Prevent the DAG from using the production environment during testing.
- Set 'schedule_interval' to None to disable automatic scheduling.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.