### PR TITLE
Fix orbax log changed and causing validation fail

### DIFF
--- a/dags/orbax/util/validation_util.py
+++ b/dags/orbax/util/validation_util.py
@@ -52,15 +52,7 @@ def validate_checkpoint_at_steps_are_saved(
     None: This function does not return a value.
   """
 
-  directory_pattern = (
-      rf"{re.escape(ram_disk)}/(\d+)"
-      if ram_disk != "gcs"
-      else r"gs://[^/]+/[^/]+/[^/]+/checkpoints/(\d+)"
-  )
-  log_pattern = (
-      rf"Finished async_save \(blocking \+ background\)\. "
-      rf"Time taken: \d+\.\d+s\. directory={directory_pattern}"
-  )
+  log_pattern = "'step': (\d+)"
 
   complied_pattern = re.compile(log_pattern)
   entries = list_log_entries(
@@ -68,7 +60,11 @@ def validate_checkpoint_at_steps_are_saved(
       location=location,
       cluster_name=cluster_name,
       pod_pattern=pod_pattern,
-      text_filter=f'(textPayload=~"{log_pattern}" OR jsonPayload.message=~"{log_pattern}")',
+      text_filter=(
+          "\"'event_type': 'save'\" AND "
+          f'(textPayload=~"{log_pattern}" OR '
+          f'jsonPayload.message=~"{log_pattern}")'
+      ),
       start_time=start_time,
       end_time=end_time,
   )


### PR DESCRIPTION
# Description
We used to get the save step number from the log `Finished async_save (blocking + background)...` and it got removed from the latest orbax.
Change the filter to `'event_type': 'save'` and get the save step number from the log.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=orbax

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.