### PR TITLE
fix: Adjust `maxtext_sft_notebook` schedule

### DIFF
--- a/dags/post_training/maxtext_sft_notebook.py
+++ b/dags/post_training/maxtext_sft_notebook.py
@@ -15,7 +15,7 @@ from dags.common import test_owner
 from dags.post_training.util import notebook_util
 
 
-SCHEDULE = "0 23 * * *" if composer_env.is_prod_env() else None
+SCHEDULE = "0 19 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_sft_notebook"
 
 with models.DAG(


### PR DESCRIPTION
# Description
Adjust `maxtext_sft_notebook` schedule for dashboard data.

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.