### PR TITLE
fix: Rearrange tests in `maxtext_end_to_end`

### DIFF
--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -116,18 +116,6 @@ with models.DAG(
     stable_tpu >> nightly_tpu
 
   multicluster_test_models = {
-      "gemma-7b": [
-          {
-              "script_name": "tpu/gemma/7b/1_test_gemma",
-              "cluster": XpkClusters.CPU_N2_STANDARD_64_CLUSTER,
-              "time_out_in_min": 60,
-          },
-          {
-              "script_name": "tpu/gemma/7b/2_test_gemma",
-              "cluster": XpkClusters.TPU_V5P_8_CLUSTER,
-              "time_out_in_min": 60,
-          },
-      ],
       "llama2-70b": [
           {
               "script_name": "tpu/llama2/70b/1_test_llama2_70b",
@@ -137,6 +125,18 @@ with models.DAG(
           {
               "script_name": "tpu/llama2/70b/2_test_llama2_70b",
               "cluster": XpkClusters.TPU_V5P_128_CLUSTER,
+              "time_out_in_min": 60,
+          },
+      ],
+      "gemma-7b": [
+          {
+              "script_name": "tpu/gemma/7b/1_test_gemma",
+              "cluster": XpkClusters.CPU_N2_STANDARD_64_CLUSTER,
+              "time_out_in_min": 60,
+          },
+          {
+              "script_name": "tpu/gemma/7b/2_test_gemma",
+              "cluster": XpkClusters.TPU_V5P_8_CLUSTER,
               "time_out_in_min": 60,
           },
       ],


### PR DESCRIPTION
# Description

Move `chained_tests_llama2-70b_stable`, `chained_tests_llama2-70b_nightly` before `chained_tests_gemma-7b_stable` and `chained_tests_gemma-7b_nightly` in `maxtext_end_to_end`.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.