### PR TITLE
fix: Standardize node pool and jobset TTR validation flows in TPU-Obs…

### DIFF
--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -150,31 +150,16 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      apply_time = jobset.run_workload.override(task_id="run_workload")(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      running_pods = jobset.wait_for_all_pods_running.override(
-          task_id="ensure_all_pods_running"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-      )
-
-      wait_for_job_start = jobset.wait_for_jobset_started.override(
-          task_id="wait_for_job_start"
-      )(
-          cluster_info,
-          pod_name_list=running_pods,
-          job_apply_time=apply_time,
-      )
-
       kill_tasks = (
           kill_tpu_pod_workload.override(task_id="kill_tpu_pod_workload")
           .partial(info=cluster_info)
-          .expand(pod_name=running_pods)
+          .expand(pod_name=startup.running_pods)
       )
 
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
@@ -190,7 +175,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=apply_time
+          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
@@ -204,9 +189,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          apply_time,
-          running_pods,
-          wait_for_job_start,
+          startup.task_group,
           kill_tasks,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -114,17 +114,10 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      start_workload = jobset.run_workload.override(task_id="start_workload")(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
-
-      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
-          task_id="ensure_all_pods_running"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
       )
 
       node_pool_resize = node_pool.update.override(task_id="node_pool_resize")(
@@ -147,7 +140,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=start_workload
+          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
@@ -161,8 +154,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          start_workload,
-          ensure_all_pods_running,
+          startup.task_group,
           node_pool_resize,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -110,17 +110,10 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      start_workload = jobset.run_workload.override(task_id="start_workload")(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
-
-      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
-          task_id="ensure_all_pods_running"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
       )
 
       delete_random_pod = jobset.delete_one_random_pod.override(
@@ -140,7 +133,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
       )(node_pool=cluster_info, jobset_config=jobset_config).as_teardown(
-          setups=start_workload
+          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
@@ -154,8 +147,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          start_workload,
-          ensure_all_pods_running,
+          startup.task_group,
           delete_random_pod,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -111,17 +111,10 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      start_workload = jobset.run_workload.override(task_id="start_workload")(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
-
-      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
-          task_id="ensure_all_pods_running"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
       )
 
       rollback_node_pool = node_pool.rollback.override(
@@ -141,7 +134,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=start_workload
+          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
@@ -155,8 +148,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          start_workload,
-          ensure_all_pods_running,
+          startup.task_group,
           rollback_node_pool,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -122,27 +122,18 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      apply_time = jobset.run_workload.override(task_id="run_workload")(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
-
-      pod_names = jobset.list_pod_names.override(task_id="list_pod_names")(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-      )
-
-      wait_for_job_start = jobset.wait_for_jobset_started.override(
-          task_id="wait_for_job_start"
-      )(cluster_info, pod_name_list=pod_names, job_apply_time=apply_time)
 
       wait_for_jobset_uptime_data = jobset.wait_for_jobset_uptime_data.override(
           task_id="wait_for_jobset_uptime_data"
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
-          jobset_apply_time=apply_time,
+          jobset_apply_time=startup.jobset_start_time,
       )
 
       clean_up_workload = jobset.end_workload.override(
@@ -151,7 +142,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=apply_time
+          setups=startup.jobset_start_time
       )
 
       jobset_clear_time = get_current_time.override(
@@ -175,11 +166,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
+          selector,
+          jobset_config,
           cluster_info,
           create_node_pool,
-          apply_time,
-          pod_names,
-          wait_for_job_start,
+          startup.task_group,
           wait_for_jobset_uptime_data,
           clean_up_workload,
           jobset_clear_time,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -297,7 +297,10 @@ def validate_latency_table(tpu_info_output: list[tpu_info.Table]):
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 15),
-    default_args={"retries": 0},
+    default_args={
+        "retries": 0,
+        "owner": test_owner.YUNA_T,
+    },
     schedule=SCHEDULE if composer_env.is_prod_env() else None,
     dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
@@ -398,33 +401,16 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info_2,
         )
 
-      apply_time = jobset.run_workload.override(
-          owner=test_owner.YUNA_T, task_id="run_workload"
-      )(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      running_pods = jobset.wait_for_all_pods_running.override(
-          task_id="ensure_all_pods_running"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-      )
-
-      wait_for_job_start = jobset.wait_for_jobset_started.override(
-          task_id="wait_for_job_start"
-      )(
-          cluster_info,
-          pod_name_list=running_pods,
-          job_apply_time=apply_time,
-      )
-
       outputs_of_tpu_info = (
           get_tpu_info_from_pod.override(task_id="get_tpu_info")
           .partial(info=cluster_info)
-          .expand(pod_name=running_pods)
+          .expand(pod_name=startup.running_pods)
       )
 
       output_of_tpu_info = (
@@ -478,7 +464,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=apply_time
+          setups=startup.jobset_start_time
       )
 
       # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -522,9 +508,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           cluster_info,
           cluster_info_2,
           create_node_pool,
-          apply_time,
-          running_pods,
-          wait_for_job_start,
+          startup.task_group,
           outputs_of_tpu_info,
           output_of_tpu_info,
           verification_group,

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -327,24 +327,11 @@ with models.DAG(
 
         _ = [create_first_node_pool, create_second_node_pool]
 
-      apply_time = jobset.run_workload(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
-
-      pod_names = jobset.list_pod_names.override(
-          task_id="list_pod_names",
-          retries=5,
-          retry_delay=datetime.timedelta(seconds=10),
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-      )
-
-      wait_for_job_start = jobset.wait_for_jobset_started.override(
-          task_id="wait_for_job_start"
-      )(cluster_info, pod_name_list=pod_names, job_apply_time=apply_time)
 
       verification_results = {}
       all_verification_groups = []
@@ -362,7 +349,7 @@ with models.DAG(
                   jobset_config=jobset_config,
                   metric_name=strategy.tpu_info_metric_name,
               )
-              .expand(pod_name=pod_names)
+              .expand(pod_name=startup.running_pods)
           )
 
           tpu_info_metric_output = (
@@ -377,10 +364,14 @@ with models.DAG(
               run_metric_verification.override(task_id="run_verification")
               .partial(
                   node_pool=cluster_info,
-                  job_apply_time=apply_time,
+                  job_apply_time=startup.jobset_start_time,
                   metric_strategy=strategy,
               )
-              .expand(comparison_data=pod_names.zip(tpu_info_metric_output))
+              .expand(
+                  comparison_data=startup.running_pods.zip(
+                      tpu_info_metric_output
+                  )
+              )
           )
 
         all_verification_groups.append(verification_group)
@@ -391,7 +382,7 @@ with models.DAG(
           task_id="summarize_results", trigger_rule=TriggerRule.ALL_DONE
       )(
           verification_results_dict=verification_results,
-          active_pods=pod_names,
+          active_pods=startup.running_pods,
       )
 
       clean_up_workload = jobset.end_workload.override(
@@ -400,7 +391,7 @@ with models.DAG(
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=apply_time
+          setups=startup.jobset_start_time
       )
 
       with TaskGroup(group_id="cleanup_node_pool") as cleanup_node_pool:
@@ -426,9 +417,7 @@ with models.DAG(
           cluster_info,
           cluster_info_2,
           create_node_pool,
-          apply_time,
-          pod_names,
-          wait_for_job_start,
+          startup.task_group,
           all_verification_groups,
           summary,
           clean_up_workload,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -156,31 +156,16 @@ with models.DAG(
         node_pool=cluster_info,
     )
 
-    apply_time = jobset.run_workload.override(task_id="run_workload")(
+    startup = jobset.create_jobset_startup_group(
         node_pool=cluster_info,
         jobset_config=jobset_config,
         workload_type=Workload.JAX_TPU_BENCHMARK,
     )
 
-    running_pods = jobset.wait_for_all_pods_running.override(
-        task_id="ensure_all_pods_running"
-    )(
-        node_pool=cluster_info,
-        jobset_config=jobset_config,
-    )
-
-    wait_for_jobset_started = jobset.wait_for_jobset_started.override(
-        task_id="wait_for_jobset_started"
-    )(
-        cluster_info,
-        pod_name_list=running_pods,
-        job_apply_time=apply_time,
-    )
-
     sdk_validation = (
         validate_monitoring_sdk.override(task_id="sdk_validation")
         .partial(info=cluster_info)
-        .expand(pod_name=running_pods)
+        .expand(pod_name=startup.running_pods)
     )
 
     cleanup_workload = jobset.end_workload.override(
@@ -189,7 +174,7 @@ with models.DAG(
         node_pool=cluster_info,
         jobset_config=jobset_config,
     ).as_teardown(
-        setups=apply_time
+        setups=startup.jobset_start_time
     )
 
     cleanup_node_pool = node_pool.delete.override(
@@ -203,9 +188,7 @@ with models.DAG(
         jobset_config,
         cluster_info,
         create_node_pool,
-        apply_time,
-        running_pods,
-        wait_for_jobset_started,
+        startup.task_group,
         sdk_validation,
         cleanup_workload,
         cleanup_node_pool,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -29,7 +29,10 @@ from typing import Final
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
 from airflow.sensors.base import PokeReturnValue
+from airflow.models.xcom_arg import XComArg
+from airflow.utils.task_group import TaskGroup
 from google.cloud.monitoring_v3 import types
+from airflow.models.baseoperator import chain
 import kubernetes
 
 from dags.tpu_observability.utils import subprocess_util as subprocess
@@ -246,6 +249,30 @@ class JobSet:
     params["node_pool_selector"] = self.node_pool_selector or ""
 
     return _TEMPLATE.substitute(params)
+
+
+@dataclasses.dataclass
+class JobSetStartupOutput:
+  """
+  Output encapsulated from the JobSet startup TaskGroup.
+
+  This dataclass bundles the TaskGroup and its essential XCom outputs,
+  allowing downstream tasks to easily access the startup metadata without
+  relying on manual tuple unpacking.
+
+  Attributes:
+    task_group: The Airflow TaskGroup containing the startup logic (apply,
+      wait for pods, and wait for workload start).
+    running_pods: An XComArg representing a snapshot of pod names that
+      reached the 'Running' state. Note that this list is a point-in-time
+      reference and may change as pods are dynamically managed by Kubernetes.
+    jobset_start_time: An XComArg containing the UTC timestamp when the
+      JobSet was applied. Used as a baseline for monitoring queries.
+  """
+
+  task_group: TaskGroup
+  running_pods: XComArg
+  jobset_start_time: XComArg
 
 
 class Command:
@@ -795,6 +822,58 @@ def wait_for_all_pods_running(
     )
     return PokeReturnValue(is_done=True, xcom_value=running_pods)
   return PokeReturnValue(is_done=False)
+
+
+def create_jobset_startup_group(
+    node_pool: node_pool_info,
+    jobset_config: JobSet,
+    workload_type: str = Workload.JAX_TPU_BENCHMARK,
+) -> JobSetStartupOutput:
+  """
+  Provides a standardized TaskGroup for JobSet startup and preparation.
+
+  This helper encapsulates the three essential steps for a stable JobSet:
+  1. run_workload: Applies the JobSet YAML to the cluster.
+  2. wait_for_all_pods_running: Polls until all worker pods
+     are in 'Running' state.
+  3. wait_for_job_start: Ensures the JAX/workload initialization is complete.
+
+  Args:
+    node_pool: Configuration object containing cluster and project details.
+    jobset_config: The JobSet object containing YAML and scaling configurations.
+    workload_type: The predefined workload script to execute.
+
+  Returns:
+    JobSetStartupOutput: An object containing the TaskGroup and its
+      associated XCom output arguments.
+  """
+  with TaskGroup(group_id="jobset_startup_and_prepare") as tg:
+    apply_time = run_workload.override(task_id="run_workload")(
+        node_pool=node_pool,
+        jobset_config=jobset_config,
+        workload_type=workload_type,
+    )
+
+    running_pods = wait_for_all_pods_running.override(
+        task_id="ensure_all_pods_running"
+    )(
+        node_pool=node_pool,
+        jobset_config=jobset_config,
+    )
+
+    wait_start = wait_for_jobset_started.override(task_id="wait_for_job_start")(
+        node_pool=node_pool,
+        pod_name_list=running_pods,
+        job_apply_time=apply_time,
+    )
+
+    chain(apply_time, running_pods, wait_start)
+
+  return JobSetStartupOutput(
+      task_group=tg,
+      running_pods=running_pods,
+      jobset_start_time=apply_time,
+  )
 
 
 def query_uptime_metrics(


### PR DESCRIPTION
 # Description

The primary goal of this PR is to unify the architectural design and implementation logic specifically across all TPU TTR (Time To Recovery) related DAGs.

Previously, different TTR DAGs used inconsistent methods to verify workload status—some called `wait_for_jobset_started`, some used `wait_for_jobset_ttr_to_be_found`, and some used both. This PR refactors these into a **standardized "Procedure of TTR"**, ensuring that all DAGs triggering workloads follow a consistent, unified function to verify that JobSets and have entered the proper state.

# Technical Implementation (TTR Unification)

- Standardized `run_jobset_ttr_validation_flow` and `run_node_pool_ttr_validation_flow` Helper:
  1. Encapsulated the entire TTR lifecycle into a single, unified entry point.
  2. Standardized the sequence to: **Workload Stability Check** → **Failure Injection** → **TTR Metric Verification**.
  3. Simplified DAG development by requiring only the `trigger_task` (fault injection) to be passed into the flow.

# Airflow/Composer

- GCP Composer name: emmalien-test (under GCP project: cienet-cmcs)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5
- Test results: https://35b13c750f364c56b55b9367bb681dee-dot-us-central1.composer.googleusercontent.com/dags/jobset_ttr_kill_process/grid
# Required Variables (Shared across 6 DAGs)

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to jobset_ttr_kill_process-v6e)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.