### PR TITLE
Fix validation log patterns of post-training DAGs

### DIFF
--- a/dags/post_training/maxtext_rl.py
+++ b/dags/post_training/maxtext_rl.py
@@ -165,7 +165,7 @@ with models.DAG(
                     project_id=training_config.cluster.project,
                     location=zone_to_region(training_config.cluster.zone),
                     cluster_name=training_config.cluster.name,
-                    text_filter="Post RL Training",
+                    text_filter='"Post RL Training"',
                     namespace="default",
                     container_name="jax-tpu",
                     pod_pattern=f"{loss_algo.value}.*",

--- a/dags/post_training/maxtext_sft.py
+++ b/dags/post_training/maxtext_sft.py
@@ -75,7 +75,10 @@ def validate_training(
         project_id=config.cluster.project,
         location=zone_to_region(config.cluster.zone),
         cluster_name=config.cluster.name,
-        text_filter=f'"Training: 100%" AND "{steps}/{steps}"',
+        text_filter=(
+            f"(jsonPayload.message: \"'event_type': 'save'\" "
+            f"AND jsonPayload.message: \"'step': {steps}\")"
+        ),
         namespace="default",
         container_name="jax-tpu",
         pod_pattern=f"{config.short_id}.*",


### PR DESCRIPTION
# Description
1. Fix missing quotes in the `maxtext_rl` validation pattern.
2. Update the `maxtext_sft` validation pattern because the original log is disabled in non-notebook environments.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=post-training

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.