### PR TITLE
fix: Adjust DAGs schedule

### DIFF
--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -24,7 +24,7 @@ from dags.multipod.configs import gke_config
 from xlml.apis import metric_config
 
 # Run once a day at 6 am UTC (10 pm PST)
-SCHEDULED_TIME = "15 15 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 9 * * 2 4 6" if composer_env.is_prod_env() else None
 
 with models.DAG(
     dag_id="maxtext_convergence",

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -26,7 +26,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 4 am UTC (8 pm PST)
-SCHEDULED_TIME = "0 11 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 7 * * *" if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 
 

--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -23,7 +23,7 @@ from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)
-SCHEDULED_TIME = '0 7 * * *' if composer_env.is_prod_env() else None
+SCHEDULED_TIME = '0 10 * * *' if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get('HF_TOKEN', None)
 
 with models.DAG(

--- a/dags/multipod/maxtext_trillium_configs_perf.py
+++ b/dags/multipod/maxtext_trillium_configs_perf.py
@@ -27,7 +27,9 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config, mlcompass, task
 
 # Run once a day at 3 am UTC (7 pm PST / 8 pm PDT)
-CONIFGS_SCHEDULED_TIME = "0 9 * * *" if composer_env.is_prod_env() else None
+CONIFGS_SCHEDULED_TIME = (
+    "30 9 * * 1 3 5" if composer_env.is_prod_env() else None
+)
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),

--- a/dags/multipod/maxtext_v5p_configs_perf.py
+++ b/dags/multipod/maxtext_v5p_configs_perf.py
@@ -27,7 +27,7 @@ from dags.multipod.configs.common import SetupMode
 from xlml.apis import metric_config, task
 
 # Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
-SCHEDULED_TIME = "0 1 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGES = [
     (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE),
     (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -26,7 +26,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 1 am UTC (5 pm PST)
-SCHEDULED_TIME = "0 5 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 
 


### PR DESCRIPTION
# Description

Some DAGs are using the same cluster, and their schedule time are too close to each other, adjust the schedule could reduce the resource conflict and stabilizes the cluster/DAG.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.