### PR TITLE
Add new DAG that tests node-pool self-healing capability of TPU JobSets

### DIFF
--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -62,6 +62,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "tpu_sdk_monitoring_validation": DefaultTimeout,
         "jobset_ttr_kill_process": dt.timedelta(minutes=90),
         "jobset_uptime_validation": dt.timedelta(minutes=90),
+        "jobset_ttr_drain_restart": DefaultTimeout,
         "tpu_info_metrics_verification": DefaultTimeout,
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -1,0 +1,218 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to test jobset time-to-recover metric after a node-pool drained."""
+
+import datetime
+
+from airflow import models
+from airflow.models.baseoperator import chain
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
+
+
+from airflow.decorators import task
+
+from dags import composer_env
+from dags.tpu_observability.utils import jobset_util as jobset
+from dags.tpu_observability.utils import subprocess_util as subprocess
+from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.utils.node_pool_util import Info
+from dags.tpu_observability.utils.node_pool_util import NodeOperationSpec
+from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+
+
+DAG_ID = "jobset_ttr_drain_restart"
+DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
+SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+
+@task
+def check_nodes_number(
+    pool: Info,
+    drained_node_number: int,
+) -> bool:
+  """Checks whether the current node number match the expected number after
+  node draining.
+
+  Args:
+    pool: An instance of the Info class that encapsulates the
+    configuration and metadata of a GKE node pool.
+    drained_node_number: The number of nodes expected to be drained.
+
+  Returns:
+    A boolean indicating whether the current node number matches the
+      expected number after draining.
+
+  """
+  original_number = pool.num_nodes
+  command = (
+      "kubectl get nodes -l"
+      f"cloud.google.com/gke-nodepool={pool.node_pool_name}"
+      " --field-selector spec.unschedulable!=true --no-headers | wc -l"
+  )
+  stdout = subprocess.run_exec(command)
+  current_number = int(stdout.strip())
+  return current_number == original_number - drained_node_number
+
+
+# Keyword arguments are generated dynamically at runtime (pylint does not
+# know this signature).
+with models.DAG(  # pylint: disable=unexpected-keyword-arg
+    dag_id="jobset_ttr_drain_restart",
+    start_date=datetime.datetime(2025, 8, 10),
+    schedule=SCHEDULE if composer_env.is_prod_env() else None,
+    dagrun_timeout=DAGRUN_TIMEOUT,
+    catchup=False,
+    tags=[
+        "cloud-ml-auto-solutions",
+        "jobset",
+        "time-to-recover",
+        "tpu-observability",
+        "TPU",
+        "v6e-16",
+    ],
+    description=(
+        "This DAG tests using a node drain to interrupt a jobset, then "
+        "verifies if the jobset restarts and polls the time-to-recover-"
+        "metric to check if it is updated."
+    ),
+    doc_md="""
+      # JobSet Time-To-Recover (TTR) Test Using Node Drain
+
+      ### Description
+      This DAG automates the process of creating a node-pool and launching a JobSet.
+      It then performs a node drain on a node where the JobSet is running to
+      trigger an interruption. The DAG monitors if the JobSet successfully
+      restarts and verifies if the JobSet TTR (Time-To-Recover) metric is
+      properly updated. Finally, the DAG cleans up the JobSet and node-pool.
+
+      ### Prerequisites
+      This test requires an existing GKE cluster to run.
+
+      ### Procedures
+      1. Setup: A dedicated node-pool is created to host the JobSet.
+      2. Launch: A JobSet YAML is deployed and given time to reach a 'Running' state.
+      3. Interruption (Drain): The DAG identifies a node hosting a JobSet Pod and
+         executes a `kubectl drain` command to evict the Pod and trigger a restart.
+      4. Verification: A sensor runs to detect if the JobSet has recovered and if the
+         time-to-recover metric has been updated in the monitoring system.
+         Success is determined by the metric update; otherwise, it will timeout and fail.
+      5. Cleanup: The JobSet is deleted and the node-pool is torn down.
+      """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+    # Keyword arguments are generated dynamically at runtime (pylint does not
+    # know this signature).
+    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}"
+    ):
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name="jobset_ttr_drain_restart",
+      )
+
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="jobset_ttr_drain_restart",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
+      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+          node_pool=cluster_info,
+      )
+
+      start_workload = jobset.run_workload.override(task_id="start_workload")(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
+      )
+
+      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
+          task_id="ensure_all_pods_running"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      )
+
+      select_node = node_pool.draw_random_node.override(task_id="select_node")(
+          node_pool=cluster_info
+      )
+
+      drained_node = node_pool.operate_node.override(task_id="drained_node")(
+          node_pool=cluster_info,
+          operation=NodeOperationSpec.Drain(),
+          node_name=select_node,
+      )
+
+      check_nodes_number = check_nodes_number.override(
+          task_id="check_nodes_number"
+      )(
+          pool=cluster_info,
+          drained_node_number=1,
+      )
+
+      uncordon_node = node_pool.operate_node.override(task_id="uncordon_node")(
+          node_pool=cluster_info,
+          operation=NodeOperationSpec.Uncordon(),
+          node_name=select_node,
+      )
+
+      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+          task_id="wait_for_metric_upload"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      )
+
+      cleanup_workload = jobset.end_workload.override(
+          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      ).as_teardown(
+          setups=start_workload
+      )
+
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=cluster_info).as_teardown(
+          setups=create_node_pool,
+      )
+
+      chain(
+          jobset_config,
+          cluster_info,
+          create_node_pool,
+          start_workload,
+          ensure_all_pods_running,
+          select_node,
+          drained_node,
+          check_nodes_number,
+          uncordon_node,
+          wait_for_metric_upload,
+          cleanup_workload,
+          cleanup_node_pool,
+      )

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -26,6 +26,7 @@ from dags import composer_env
 from dags.common import test_owner
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.utils.node_pool_util import NodeOperationSpec
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
 
@@ -121,10 +122,20 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info, status=node_pool.Status.RUNNING
       )
 
-      task_id = "delete_node"
-      delete_node = node_pool.delete_one_random_node.override(task_id=task_id)(
+      task_id = "select_random_node"
+      select_random_node = node_pool.draw_random_node.override(task_id=task_id)(
           node_pool=node_pool_info
       )
+
+      task_id = "delete_node"
+      delete_node = node_pool.operate_node.override(task_id=task_id)(
+          node_pool=node_pool_info,
+          operation=NodeOperationSpec.Delete(),
+          node_name=select_random_node,
+      )
+
+      # TODO: add a check that the node count decreases after deletion.
+      # kubectl is not available here since this DAG has no workload or jobset.
 
       task_id = "wait_for_repair"
       wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
@@ -185,6 +196,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           create_node_pool,
           wait_for_provisioning,
           wait_for_running,
+          select_random_node,
           delete_node,
           wait_for_repair,
           wait_for_recovered,

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -19,8 +19,10 @@ import datetime
 import enum
 import json
 import logging
+import os
 import random
 import re
+import tempfile
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
@@ -347,42 +349,167 @@ def list_nodes(node_pool: Info) -> list[str]:
   return node_names
 
 
-@task
-def delete_one_random_node(node_pool: Info) -> None:
-  """Delete one random node from the specified GKE node pool.
-
-  This function first lists all nodes under the given node pool,
-  then randomly selects one node and deletes it.
+def get_credentials_command(node_pool: Info) -> str:
+  """
+  Returns the command to authenticate `gcloud` with the specified GKE cluster.
 
   Args:
-      node_pool: An instance of the Info class that encapsulates
-        the configuration and metadata of a GKE node pool.
+    node_pool: Configuration object with cluster details.
+
+  Returns:
+    A string containing the command to authenticate `gcloud` with the
+      specified GKE cluster.
+  """
+  for attr_name in ["cluster_name", "region", "project_id"]:
+    if not getattr(node_pool, attr_name):
+      raise ValueError(f"{attr_name} must be set in the Info object.")
+
+  return " ".join([
+      "gcloud container clusters",
+      f"get-credentials {node_pool.cluster_name}",
+      f"--region={node_pool.region}",
+      f"--project={node_pool.project_id}",
+  ])
+
+
+@task
+def draw_random_node(node_pool: Info) -> str:
+  """Selects random nodes from the specified GKE node pool.
+
+  Args:
+    node_pool: An instance of the Info class that encapsulates the
+      configuration and metadata of a GKE node pool.
+    count: The number of nodes to select.
+
+  Returns:
+    A list of names of randomly selected nodes from the node pool.
 
   Raises:
-      ValueError: If no nodes are found in the specified node pool.
+    AirflowFailException: If no nodes are found in the node pool.
   """
-
   nodes_list = list_nodes(node_pool)
+
   if not nodes_list:
     raise AirflowFailException(
-        f"No nodes found in node pool '{node_pool.node_pool_name}'. "
-        "Cannot proceed with node deletion."
+        f"No nodes found in node pool '{node_pool.node_pool_name}'."
     )
 
-  node_to_delete = random.choice(nodes_list)
+  random.shuffle(nodes_list)
+  target_node = nodes_list[0]
   logging.info(
-      "Randomly selected node for deletion: %s",
-      node_to_delete,
+      "Randomly selected nodes '%s' from node pool '%s'.",
+      target_node,
+      node_pool.node_pool_name,
   )
 
-  command = (
-      f"gcloud compute instances delete {node_to_delete} "
-      f"--project={node_pool.project_id} "
-      f"--zone={node_pool.node_locations} "
-      "--quiet"
+  return target_node
+
+
+class NodeOperation(enum.Enum):
+  """Enum for different types of node operations."""
+
+  DELETE = enum.auto()
+  DRAIN = enum.auto()
+  UNCORDON = enum.auto()
+
+
+class NodeOperationApproach(enum.Enum):
+  """Enum for different approaches to perform node operations."""
+
+  K8S_CLI = enum.auto()
+  GCP_CLI = enum.auto()
+
+
+@dataclasses.dataclass
+class NodeOperationSpec:
+  """
+  Defines the specification for a node operation, including type
+  and approach.
+  """
+
+  target: NodeOperation
+  approach: NodeOperationApproach
+  command_template: str = ""
+  extra_flags: str = ""
+
+  @staticmethod
+  def Delete() -> "NodeOperationSpec":
+    return NodeOperationSpec(
+        target=NodeOperation.DELETE,
+        approach=NodeOperationApproach.GCP_CLI,
+        command_template=(
+            "gcloud compute instances delete {node_name} "
+            "--project={project_id} "
+            "--zone={node_locations} --quiet"
+        ),
+        extra_flags="",
+    )
+
+  @staticmethod
+  def Drain() -> "NodeOperationSpec":
+    return NodeOperationSpec(
+        target=NodeOperation.DRAIN,
+        approach=NodeOperationApproach.K8S_CLI,
+        command_template="kubectl drain {node_name}",
+        extra_flags="--ignore-daemonsets --delete-emptydir-data",
+    )
+
+  @staticmethod
+  def Uncordon() -> "NodeOperationSpec":
+    return NodeOperationSpec(
+        target=NodeOperation.UNCORDON,
+        approach=NodeOperationApproach.K8S_CLI,
+        command_template="kubectl uncordon {node_name}",
+        extra_flags="",
+    )
+
+
+@task
+def operate_node(
+    node_pool: Info,
+    node_name: str,
+    operation: NodeOperationSpec,
+) -> str:
+  """Performs a node operation based on the provided specification.
+
+  Args:
+    node_pool: An instance of the Info class with GKE metadata.
+    node_name: The name of the node to operate on.
+    operation: A NodeOperationInterface defining the action to perform.
+
+  Returns:
+    The name of the node that was operated on.
+
+  Raises:
+    ValueError: If the target is unsupported.
+  """
+
+  base_command = operation.command_template.format(
+      node_name=node_name,
+      project_id=node_pool.project_id,
+      node_locations=node_pool.node_locations,
   )
 
-  subprocess.run_exec(command)
+  logging.info("Select node '%s' to %s", node_name, operation.target.name)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    kube_dir = tmpdir + "/kubeconfig"
+    env = os.environ.copy()
+    env["KUBECONFIG"] = kube_dir
+
+    commands = [(f"{base_command} {operation.extra_flags}").strip()]
+    match operation.approach:
+      case NodeOperationApproach.K8S_CLI:
+        commands.insert(0, get_credentials_command(node_pool))
+      case NodeOperationApproach.GCP_CLI:
+        pass
+      case _:
+        raise ValueError(
+            f"Unsupported operation approach: {operation.approach}"
+        )
+
+    subprocess.run_exec(" && ".join(commands), env=env)
+  return node_name
 
 
 def _query_status_metric(node_pool: Info) -> Status:


### PR DESCRIPTION
 # Description

The primary goal of this PR is to implement the `jobset_ttr_drain_restart`, design to validate the self-healing capability of TPU JobSets. This DAG automates fault injection and recovery validation to ensure JAX workloads automatically recover after a random node is drained.

In normal case, a cluster has more than 1 node pool and when a node is drained the cluster would use a node from other node pools to replace it. However, in this case, considering resource limit, I drain(cordon) a node and undrain(uncordon) it a few seconds later. By using this method, we can simulate the same scenario without occupying too many source. 
 
# Technical Implementation

- **Dynamic Provisioning:** Builds node pool info from GCS configurations and provisions TPU resources based on MachineConfigMap (e.g., v6e-16).
- **JobSet Deployment:** Deploys a JAX TPU benchmark workload using the JobSet operator.
- **Fault Injection:** `@task` drain_one_random_node simulates a failure by draining a running TPU node so that a pod becomes pending.
- **Detection Phase:** Monitors the JobSet's reaction. It expects the JobSet to detect the drained node and trigger a full-slice restart to maintain JAX synchronization.
- **Performance Metric:** Measures the Time To Recovery (TTR). In initial runs, the workload successfully recovered in ~103s (the period between node undrained and recovery completion)

# Airflow/Composer

- GCP Composer name: tony-test (under GCP project: cienet-cmcs)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5
- Test results: https:https://b827a8074a3e45609878ed3189e81f27-dot-us-central1.composer.googleusercontent.com/dags/jobset_ttr_drain_restart/grid

# Required Variables 

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to jobset-ttr-pod-delete-v6e)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.