### PR TITLE
fix: Adjustments for some DAGs

### DIFF
--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -102,7 +102,7 @@ with models.DAG(
         test_name=f"{test_name_prefix}-stable-{model}",
         run_model_cmds=model_cmds,
         docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
-        cluster=XpkClusters.TPU_V5P_8_CLUSTER,
+        cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
         test_owner=test_config["owner"],
     ).run_with_quarantine(quarantine_task_group)
     nightly_tpu = gke_config.get_gke_config(

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -26,7 +26,7 @@ from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 1 am UTC (5 pm PST)
-SCHEDULED_TIME = "0 2 * * *" if composer_env.is_prod_env() else None
+SCHEDULED_TIME = "30 1 * * *" if composer_env.is_prod_env() else None
 HF_TOKEN = models.Variable.get("HF_TOKEN", None)
 
 


### PR DESCRIPTION
# Description

**Changes:**
-  `maxtext_end_to_end`: cluster change to: auto-v5p-8-bodaborg
-  `maxtext_moe_tpu_e2e`: schedule time change from `0 2 * * *`  to `30 1 * * *`

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.