### PR TITLE
Add DAG `jobset_ttr_node_reboot` for TPU node recovery validation

### DIFF
--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -64,6 +64,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "jobset_uptime_validation": dt.timedelta(minutes=90),
         "jobset_ttr_drain_restart": DefaultTimeout,
         "tpu_info_metrics_verification": DefaultTimeout,
+        "jobset_ttr_node_reboot": dt.timedelta(minutes=90),
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {
         "validate_interruption_count_gce_bare_metal_preemption": DefaultTimeout,

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -150,7 +150,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      startup = jobset.create_jobset_startup_group(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -189,7 +189,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           kill_tasks,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -12,37 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A DAG to test JobSet time-to-recover metric using a node pool disk resize."""
+"""A DAG to test JobSet Time-To-Recover (TTR) metric by triggering a node reboot."""
 
 import datetime
+from datetime import timedelta
 
 from airflow import models
 from airflow.models.baseoperator import chain
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.utils.task_group import TaskGroup
 
 from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
-from dags.tpu_observability.utils.jobset_util import JobSet, Workload
+from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.configs.common import (
     MachineConfigMap,
     GCS_CONFIG_PATH,
     GCS_JOBSET_CONFIG_PATH,
 )
-from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+from dags.common.scheduling_helper.scheduling_helper import (
+    SchedulingHelper,
+    get_dag_timeout,
+)
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 
 
-DAG_ID = "jobset_ttr_node_pool_resize"
+DAG_ID = "jobset_ttr_node_reboot"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
-_DISK_SIZE_INCREMENT = 100
+
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id=DAG_ID,
-    start_date=datetime.datetime(2026, 1, 27),
+    start_date=datetime.datetime(2026, 1, 21),
     schedule=SCHEDULE if composer_env.is_prod_env() else None,
     dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
@@ -51,34 +55,35 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         "jobset",
         "time-to-recover",
         "tpu-observability",
-        "node-pool-resize",
+        "node_reboot",
         "TPU",
         "v6e-16",
     ],
     description=(
-        "This DAG tests the JobSet time-to-recover metric by triggering a "
-        "node pool disk resize, then polls the metric to check "
-        "if it is updated."
+        "Tests JobSet TTR metric by rebooting a random TPU node to trigger "
+        "recovery, then polls the metric for updates."
     ),
     doc_md="""
-      # JobSet Time-To-Recover (TTR) Test Using Node Pool Disk Resize
+      # JobSet Time-To-Recover (TTR) Test Using Random Node Reboot
 
       ### Description
-      This DAG verifies that JobSet can recover when the underlying node pool
-      undergoes a disruptive update (Disk Resize). It launches a JobSet,
-      increases the disk size of the node pool, and confirms that the
-      JobSet controller restarts the workload successfully.
+      This DAG verifies that a TPU JobSet can recover from a hardware-level failure.
+      It launches a JobSet, executes a `reboot` command on a random node via a
+      privileged container (using nsenter), and uses a sensor to confirm that
+      the TTR (Time-To-Recover) metric is recorded.
 
       ### Prerequisites
       This test requires an existing cluster to run.
+      GKE Cluster with TPU v6e support.
+      The JobSet must be configured with
+      privileged: True to allow node-level interaction.
 
       ### Procedures
-      First the node-pool is created, a jobset yaml is then launched on the
-      cluster and given a short period of time to initialize. After this a
-      node pool disk resize is triggered to interrupt the jobset. A sensor is
-      finally run which will poll Cloud Monitoring to detect that the jobset
-      time-to-recover (TTR) metric has been updated, resulting in a success,
-      or timeout, and fail.
+      First the node-pool is created, a jobset yaml is then launched on the cluster.
+      After initialization, a random node reboot is triggered by executing
+      `nsenter` through a privileged pod. This simulates a hardware failure
+      by taking one of the TPU nodes offline. A sensor finally polls Cloud
+      Monitoring to confirm the jobset TTR metric is updated.
       """,
 ) as dag:
   for machine in MachineConfigMap:
@@ -86,17 +91,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
-    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-        group_id=f"v{config.tpu_version.value}"
+    with TaskGroupWithTimeout(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}",
+        timeout=timedelta(minutes=90),
     ):
-      selector = jobset.generate_node_pool_selector(
-          "jobset-ttr-node-pool-resize"
-      )
+      selector = jobset.generate_node_pool_selector("jobset-ttr-node-reboot")
 
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
           node_pool_selector=selector,
+          privileged=True,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
@@ -120,11 +125,16 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      node_pool_resize = node_pool.update.override(task_id="node_pool_resize")(
+      target_pod = jobset.draw_random_pod(
           node_pool=cluster_info,
-          spec=node_pool.NodePoolUpdateSpec.DiskSize(
-              delta=_DISK_SIZE_INCREMENT
-          ),
+          jobset_config=jobset_config,
+      )
+
+      reboot_node = jobset.operate_pod.override(task_id="reboot_node")(
+          node_pool=cluster_info,
+          operation=jobset.PodOperationSpec.Reboot(),
+          pod_name=target_pod,
+          namespace="default",
       )
 
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
@@ -136,10 +146,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-      ).as_teardown(
+      )(node_pool=cluster_info, jobset_config=jobset_config).as_teardown(
           setups=startup.jobset_start_time
       )
 
@@ -155,7 +162,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           cluster_info,
           create_node_pool,
           *startup.tasks,
-          node_pool_resize,
+          target_pod,
+          reboot_node,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -110,7 +110,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      startup = jobset.create_jobset_startup_group(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -147,7 +147,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           delete_random_pod,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -111,7 +111,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      startup = jobset.create_jobset_startup_group(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -148,7 +148,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           rollback_node_pool,
           wait_for_metric_upload,
           cleanup_workload,

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -122,7 +122,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
       )
 
-      startup = jobset.create_jobset_startup_group(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -170,7 +170,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_config,
           cluster_info,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           wait_for_jobset_uptime_data,
           clean_up_workload,
           jobset_clear_time,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -401,7 +401,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info_2,
         )
 
-      startup = jobset.create_jobset_startup_group(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -508,7 +508,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           cluster_info,
           cluster_info_2,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           outputs_of_tpu_info,
           output_of_tpu_info,
           verification_group,

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -327,7 +327,7 @@ with models.DAG(
 
         _ = [create_first_node_pool, create_second_node_pool]
 
-      startup = jobset.create_jobset_startup_group(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -417,7 +417,7 @@ with models.DAG(
           cluster_info,
           cluster_info_2,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           all_verification_groups,
           summary,
           clean_up_workload,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -156,7 +156,7 @@ with models.DAG(
         node_pool=cluster_info,
     )
 
-    startup = jobset.create_jobset_startup_group(
+    startup = jobset.create_jobset_startup_tasks(
         node_pool=cluster_info,
         jobset_config=jobset_config,
         workload_type=Workload.JAX_TPU_BENCHMARK,
@@ -188,7 +188,7 @@ with models.DAG(
         jobset_config,
         cluster_info,
         create_node_pool,
-        startup.task_group,
+        *startup.tasks,
         sdk_validation,
         cleanup_workload,
         cleanup_node_pool,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -29,10 +29,12 @@ from typing import Final
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
 from airflow.sensors.base import PokeReturnValue
+from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
 from airflow.utils.task_group import TaskGroup
 from google.cloud.monitoring_v3 import types
 from airflow.models.baseoperator import chain
+from websocket import WebSocketConnectionClosedException
 import kubernetes
 
 from dags.tpu_observability.utils import subprocess_util as subprocess
@@ -168,12 +170,15 @@ _TEMPLATE = string.Template(
                 parallelism: $parallelism
                 template:
                   spec:
+                    hostPID: $host_pid
                     nodeSelector:
                       cloud.google.com/gke-tpu-accelerator: $tpu_accelerator_type
                       cloud.google.com/gke-tpu-topology: $tpu_topology
                       {NODE_POOL_SELECTOR_KEY}: $node_pool_selector
                     containers:
                     - name: $container_name
+                      securityContext:
+                        privileged: $privileged
                       image: $image
                       command: $command
                       args:
@@ -189,6 +194,46 @@ _TEMPLATE = string.Template(
     )
 )
 # pylint: enable=line-too-long
+
+
+class PodOperation(enum.Enum):
+  """Enum for different types of pod operations."""
+
+  REBOOT = enum.auto()
+
+
+@dataclasses.dataclass
+class PodOperationSpec:
+  """Defines the specification for a pod operation, including type.
+
+  This setup mirrors NodeOperationSpec but focuses entirely on container-level
+  infrastructure tasks (e.g., triggering host reboots via an active privileged pod).
+  """
+
+  target: PodOperation
+  command_template: str = ""
+  extra_flags: str = ""
+
+  @staticmethod
+  def Reboot() -> "PodOperationSpec":
+    """
+    Defines a node reboot operation executed via a Kubernetes Pod.
+
+    This method generates a command template utilizing 'kubectl exec' to access
+    a privileged Pod with hostPID capabilities, using 'nsenter' to trigger a
+    reboot on the host OS.
+
+    Returns:
+      NodeOperationSpec: Configured for K8S_CLI approach with the
+                         reboot command template.
+    """
+    reboot_cmd = "nsenter -t 1 -m -u -n -i reboot -f"
+    return PodOperationSpec(
+        target=PodOperation.REBOOT,
+        command_template="kubectl exec {pod_name} -n {namespace} -- "
+        + reboot_cmd,
+        extra_flags="",
+    )
 
 
 @dataclasses.dataclass
@@ -216,6 +261,11 @@ class JobSet:
     container_name: The name of the container in the pod.
     image: The container image to use.
     tpu_cores_per_pod: The number of TPU cores requested per pod.
+    privileged: A test-specific flag to enable privileged mode and hostPID.
+      This unconventional setup is required for E2E validation tasks, such as
+      node-level fault injection (e.g., node reboots), where the pod must
+      interact with the host OS via nsenter. Should remain False for all
+      standard workloads. Defaults to False.
   """
 
   jobset_name: str
@@ -232,6 +282,7 @@ class JobSet:
   image: str
   tpu_cores_per_pod: int
   node_pool_selector: str
+  privileged: bool = False
 
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.
@@ -247,30 +298,30 @@ class JobSet:
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""
+    params["privileged"] = "true" if self.privileged else "false"
+    params["host_pid"] = "true" if self.privileged else "false"
 
     return _TEMPLATE.substitute(params)
 
 
 @dataclasses.dataclass
 class JobSetStartupOutput:
-  """
-  Output encapsulated from the JobSet startup TaskGroup.
+  """Output encapsulated from the JobSet startup sequence.
 
-  This dataclass bundles the TaskGroup and its essential XCom outputs,
-  allowing downstream tasks to easily access the startup metadata without
-  relying on manual tuple unpacking.
+  This dataclass bundles the core list of startup tasks along with their
+  essential XCom outputs. It allows downstream tasks to easily access
+  the startup metadata without relying on error-prone manual tuple unpacking.
 
   Attributes:
-    task_group: The Airflow TaskGroup containing the startup logic (apply,
-      wait for pods, and wait for workload start).
-    running_pods: An XComArg representing a snapshot of pod names that
-      reached the 'Running' state. Note that this list is a point-in-time
-      reference and may change as pods are dynamically managed by Kubernetes.
-    jobset_start_time: An XComArg containing the UTC timestamp when the
-      JobSet was applied. Used as a baseline for monitoring queries.
+    tasks: A list of Airflow operators representing the sequenced startup steps
+      (e.g., applying manifests, waiting for pods, and tracking workload start).
+    running_pods: An XComArg representing a point-in-time snapshot of pod names
+      that successfully reached the 'Running' state.
+    jobset_start_time: An XComArg containing the UTC timestamp when the JobSet
+      was applied, used as a baseline for observability and monitoring queries.
   """
 
-  task_group: TaskGroup
+  tasks: list[BaseOperator]
   running_pods: XComArg
   jobset_start_time: XComArg
 
@@ -685,6 +736,72 @@ def delete_one_random_pod(
     logging.info("Successfully initiated deletion for pod: %s", target_pod)
 
 
+@task
+def draw_random_pod(
+    node_pool: node_pool_info,
+    jobset_config: JobSet,
+) -> str:
+  """Randomly selects one running pod from the specified JobSet pool."""
+  running_pods = get_running_pods(
+      node_pool=node_pool,
+      jobset_name=jobset_config.jobset_name,
+      namespace=jobset_config.namespace,
+  )
+  if not running_pods:
+    logging.error(
+        "No running pods found in namespace: %s", jobset_config.namespace
+    )
+    raise AirflowFailException(
+        f"No running pods found in namespace: {jobset_config.namespace}"
+    )
+
+  pods_list = list(running_pods)
+  random.shuffle(pods_list)
+  target_pod = pods_list[0]
+
+  logging.info(
+      "Randomly selected pod '%s' from JobSet for operation.", target_pod
+  )
+  return target_pod
+
+
+@task
+def operate_pod(
+    node_pool: node_pool_info,
+    pod_name: str,
+    operation: PodOperationSpec,
+    namespace: str = "default",
+) -> str:
+  """Performs an operation through a specific pod based on the provided specification."""
+  base_command = operation.command_template.format(
+      pod_name=pod_name,
+      namespace=namespace,
+  )
+
+  logging.info("Select pod '%s' to %s", pod_name, operation.target.name)
+
+  with tempfile.NamedTemporaryFile() as temp_config_file:
+    env = os.environ.copy()
+    env["KUBECONFIG"] = temp_config_file.name
+
+    commands = [
+        Command.get_credentials_command(node_pool),
+        (f"{base_command} {operation.extra_flags}").strip(),
+    ]
+
+    try:
+      subprocess.run_exec(" && ".join(commands), env=env)
+    except WebSocketConnectionClosedException:
+      if operation.target == PodOperation.REBOOT:
+        logging.info(
+            "Node reboot initiated: WebSocket connection closed as expected."
+        )
+        return pod_name
+      raise
+
+  return pod_name
+
+
 @task.sensor(poke_interval=30, timeout=900, mode="poke")
 def wait_for_jobset_started(
     node_pool: node_pool_info,
@@ -824,18 +941,16 @@ def wait_for_all_pods_running(
   return PokeReturnValue(is_done=False)
 
 
-def create_jobset_startup_group(
+def create_jobset_startup_tasks(
     node_pool: node_pool_info,
     jobset_config: JobSet,
     workload_type: str = Workload.JAX_TPU_BENCHMARK,
 ) -> JobSetStartupOutput:
-  """
-  Provides a standardized TaskGroup for JobSet startup and preparation.
+  """Provides a standardized sequence of tasks for JobSet startup and preparation.
 
-  This helper encapsulates the three essential steps for a stable JobSet:
+  This helper encapsulates and chains the three essential steps for a stable JobSet:
   1. run_workload: Applies the JobSet YAML to the cluster.
-  2. wait_for_all_pods_running: Polls until all worker pods
-     are in 'Running' state.
+  2. wait_for_all_pods_running: Polls until all worker pods are in 'Running' state.
   3. wait_for_job_start: Ensures the JAX/workload initialization is complete.
 
   Args:
@@ -844,33 +959,32 @@ def create_jobset_startup_group(
     workload_type: The predefined workload script to execute.
 
   Returns:
-    JobSetStartupOutput: An object containing the TaskGroup and its
-      associated XCom output arguments.
+    JobSetStartupOutput: An object containing the ordered list of startup tasks
+      and their associated XCom output arguments.
   """
-  with TaskGroup(group_id="jobset_startup_and_prepare") as tg:
-    apply_time = run_workload.override(task_id="run_workload")(
-        node_pool=node_pool,
-        jobset_config=jobset_config,
-        workload_type=workload_type,
-    )
+  apply_time = run_workload.override(task_id="run_workload")(
+      node_pool=node_pool,
+      jobset_config=jobset_config,
+      workload_type=workload_type,
+  )
 
-    running_pods = wait_for_all_pods_running.override(
-        task_id="ensure_all_pods_running"
-    )(
-        node_pool=node_pool,
-        jobset_config=jobset_config,
-    )
+  running_pods = wait_for_all_pods_running.override(
+      task_id="ensure_all_pods_running"
+  )(
+      node_pool=node_pool,
+      jobset_config=jobset_config,
+  )
 
-    wait_start = wait_for_jobset_started.override(task_id="wait_for_job_start")(
-        node_pool=node_pool,
-        pod_name_list=running_pods,
-        job_apply_time=apply_time,
-    )
+  wait_start = wait_for_jobset_started.override(task_id="wait_for_job_start")(
+      node_pool=node_pool,
+      pod_name_list=running_pods,
+      job_apply_time=apply_time,
+  )
 
-    chain(apply_time, running_pods, wait_start)
+  chain(apply_time, running_pods, wait_start)
 
   return JobSetStartupOutput(
-      task_group=tg,
+      tasks=[apply_time, running_pods, wait_start],
       running_pods=running_pods,
       jobset_start_time=apply_time,
   )


### PR DESCRIPTION
 # Description

The primary goal of this PR is to implement the `jobset_ttr_node_reboot` DAG, designed to validate the self-healing capability of TPU JobSets under hardware-level disruption. This DAG automates fault injection by rebooting a random TPU node via SSH and validates that the JAX workload automatically recovers and reports performance metrics.

# Technical Implementation

- **Dynamic Provisioning:** Builds node pool info from GCS configurations and provisions TPU resources based on MachineConfigMap (e.g., v6e-16).
- **JobSet Deployment:** Deploys a JAX TPU benchmark workload using the JobSet operator.
- **Fault Injection:** `@task` `random_node_reboot` simulates a hardware failure by issuing a `sudo reboot` command to a randomly selected node via SSH.
- **Detection Phase:** Monitors the JobSet's reaction. It expects the JobSet to detect the missing pod and trigger a full-slice restart (Killing event) to maintain JAX synchronization.
- **Performance Metric:** Measures the Time To Recovery (TTR). 

# Airflow/Composer

- GCP Composer name: emma-test (under GCP project: cienet-cmcs)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5
- Test results: https://a049b7befc7c4d978535dca36b91a080-dot-us-central1.composer.googleusercontent.com/dags/jobset_ttr_node_reboot/grid
# Required Variables 

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to jobset-ttr-node-reboot-v6e)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.