### PR TITLE
Tpu obs/user/yuna/taskgroup timeout

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -48,29 +48,30 @@ SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 
 @task
-def kill_tpu_pod_workload(info: node_pool.Info, pod_name: str) -> None:
+def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
   """
-  Kills the python process on a single pod.
+  Kills the python process on a list of pods.
 
   This task retrieves cluster credentials, then attempts to kill the JAX
-  python process inside the specified pod. It ignores errors if the pod
+  python process inside each specified pod. It ignores errors if the pod
   has already been deleted to ensure pipeline continuity.
   """
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
 
-    cmd = " && ".join([
-        jobset.Command.get_credentials_command(info),
-        f"kubectl exec {pod_name} -n default -- pkill -9 -f python",
-    ])
+    for pod_name in pod_names:
+      cmd = " && ".join([
+          jobset.Command.get_credentials_command(info),
+          f"kubectl exec {pod_name} -n default -- pkill -9 -f python",
+      ])
 
-    try:
-      subprocess.run_exec(cmd, env=env)
-    except subprocess.ProcessKilledException:
-      logging.info("Process was terminated with SIGKILL")
-    except Exception as e:
-      raise e
+      try:
+        subprocess.run_exec(cmd, env=env)
+      except subprocess.ProcessKilledException:
+        logging.info(f"Process in pod {pod_name} was terminated with SIGKILL")
+      except Exception as e:
+        raise e
 
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -156,10 +157,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      kill_tasks = (
-          kill_tpu_pod_workload.override(task_id="kill_tpu_pod_workload")
-          .partial(info=cluster_info)
-          .expand(pod_name=startup.running_pods)
+      kill_tasks = kill_tpu_pod_workloads.override(
+          task_id="kill_tpu_pod_workloads"
+      )(
+          info=cluster_info,
+          pod_names=startup.running_pods,
       )
 
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -26,6 +26,7 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
@@ -34,6 +35,10 @@ from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, ge
 DAG_ID = "multi_host_nodepool_rollback"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -97,39 +102,59 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create.override(owner=test_owner.QUINN_M)(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool",
+            owner=test_owner.QUINN_M,
+        )(node_pool=node_pool_info)
 
-      wait_node_pool_available = node_pool.wait_for_availability(
-          node_pool=node_pool_info, availability=True
-      )
+        wait_node_pool_available = node_pool.wait_for_availability.override(
+            task_id="wait_node_pool_available"
+        )(node_pool=node_pool_info, availability=True)
 
-      rollback_node_pool = node_pool.rollback(node_pool=node_pool_info)
+        chain(create_node_pool, wait_node_pool_available)
 
-      wait_node_pool_unavailable = node_pool.wait_for_availability(
-          node_pool=node_pool_info, availability=False
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        rollback_node_pool = node_pool.rollback.override(
+            task_id="rollback_node_pool"
+        )(node_pool=node_pool_info)
 
-      # A successful rollback means the availability will return to True.
-      # The end of the rollback marks the start the availability, so
-      # the client side should see the state change, and update the metric.
-      wait_node_pool_recovered = node_pool.wait_for_availability(
-          node_pool=node_pool_info, availability=True
-      )
+        wait_node_pool_unavailable = node_pool.wait_for_availability.override(
+            task_id="wait_node_pool_unavailable"
+        )(node_pool=node_pool_info, availability=False)
 
-      cleanup_node_pool = node_pool.delete.override(
-          trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        # A successful rollback means the availability will return to True.
+        # The end of the rollback marks the start the availability, so
+        # the client side should see the state change, and update the metric.
+        wait_node_pool_recovered = node_pool.wait_for_availability.override(
+            task_id="wait_node_pool_recovered"
+        )(node_pool=node_pool_info, availability=True)
+
+        chain(
+            rollback_node_pool,
+            wait_node_pool_unavailable,
+            wait_node_pool_recovered,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool",
+            trigger_rule=TriggerRule.ALL_DONE,
+        )(node_pool=node_pool_info)
 
       chain(
           node_pool_info,
-          create_node_pool,
-          wait_node_pool_available,
-          rollback_node_pool,
-          wait_node_pool_unavailable,
-          wait_node_pool_recovered,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -24,6 +24,7 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.node_pool_util import NodeOperationSpec
@@ -33,6 +34,10 @@ from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, ge
 DAG_ID = "gke_node_pool_status"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -104,109 +109,118 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_locations=generate_problematic_node_location(node_pool_info),
       )
 
-      task_id = "create_node_pool"
-      create_node_pool = node_pool.create.override(
-          task_id=task_id,
-          owner=test_owner.YUNA_T,
-      )(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        task_id = "create_node_pool"
+        create_node_pool = node_pool.create.override(
+            task_id=task_id,
+            owner=test_owner.YUNA_T,
+        )(
+            node_pool=node_pool_info,
+        )
 
-      task_id = "wait_for_provisioning"
-      wait_for_provisioning = node_pool.wait_for_status.override(
-          task_id=task_id
-      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+        task_id = "wait_for_provisioning"
+        wait_for_provisioning = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-      task_id = "wait_for_running"
-      wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+        task_id = "wait_for_running"
+        wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.RUNNING
+        )
 
-      task_id = "select_random_node"
-      select_random_node = node_pool.draw_random_node.override(task_id=task_id)(
-          node_pool=node_pool_info
-      )
+        chain(create_node_pool, wait_for_provisioning, wait_for_running)
 
-      task_id = "delete_node"
-      delete_node = node_pool.operate_node.override(task_id=task_id)(
-          node_pool=node_pool_info,
-          operation=NodeOperationSpec.Delete(),
-          node_name=select_random_node,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        task_id = "select_random_node"
+        select_random_node = node_pool.draw_random_node.override(
+            task_id=task_id
+        )(node_pool=node_pool_info)
 
-      # TODO: add a check that the node count decreases after deletion.
-      # kubectl is not available here since this DAG has no workload or jobset.
+        task_id = "delete_node"
+        delete_node = node_pool.operate_node.override(task_id=task_id)(
+            node_pool=node_pool_info,
+            operation=NodeOperationSpec.Delete(),
+            node_name=select_random_node,
+        )
 
-      task_id = "wait_for_repair"
-      wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RECONCILING
-      )
+        task_id = "wait_for_repair"
+        wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.RECONCILING
+        )
 
-      task_id = "wait_for_recovered"
-      wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+        task_id = "wait_for_recovered"
+        wait_for_recovered = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      task_id = "delete_node_pool"
-      delete_node_pool = node_pool.delete.override(task_id=task_id)(
-          node_pool=node_pool_info
-      )
+        task_id = "delete_node_pool"
+        delete_node_pool = node_pool.delete.override(task_id=task_id)(
+            node_pool=node_pool_info
+        )
 
-      task_id = "wait_for_stopping"
-      wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.STOPPING
-      )
+        task_id = "wait_for_stopping"
+        wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.STOPPING
+        )
 
-      task_id = "cleanup_node_pool"
-      cleanup_node_pool = node_pool.delete.override(
-          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        # Intentionally create a node pool with problematic configurations
+        # to validate that it enters the ERROR state.
+        task_id = "create_problematic_node_pool_info"
+        create_problematic_node_pool_info = node_pool.create.override(
+            task_id=task_id,
+            owner=test_owner.YUNA_T,
+        )(
+            node_pool=problematic_node_pool_info,
+            # The failure is intentionally ignored because we want to validate
+            # that the status of the node pool (which fails to be created) is
+            # "ERROR".
+            ignore_failure=True,
+        )
 
-      # Intentionally create a node pool with problematic configurations
-      # to validate that it enters the ERROR state.
-      task_id = "create_problematic_node_pool_info"
-      create_problematic_node_pool_info = node_pool.create.override(
-          task_id=task_id,
-          owner=test_owner.YUNA_T,
-      )(
-          node_pool=problematic_node_pool_info,
-          # The failure is intentionally ignored because we want to validate
-          # that the status of the node pool (which fails to be created) is
-          # "ERROR".
-          ignore_failure=True,
-      )
+        task_id = "wait_for_error"
+        wait_for_error = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=problematic_node_pool_info, status=node_pool.Status.ERROR
+        )
 
-      task_id = "wait_for_error"
-      wait_for_error = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=problematic_node_pool_info, status=node_pool.Status.ERROR
-      )
+        chain(
+            select_random_node,
+            delete_node,
+            wait_for_repair,
+            wait_for_recovered,
+            delete_node_pool,
+            wait_for_stopping,
+        )
 
-      task_id = "cleanup_wrong_node_pool"
-      cleanup_wrong_node_pool = node_pool.delete.override(
-          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=problematic_node_pool_info).as_teardown(
-          setups=create_problematic_node_pool_info,
-      )
+        chain(
+            create_problematic_node_pool_info,
+            wait_for_error,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        task_id = "cleanup_node_pool"
+        cleanup_node_pool = node_pool.delete.override(
+            task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
+
+        task_id = "cleanup_wrong_node_pool"
+        cleanup_wrong_node_pool = node_pool.delete.override(
+            task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=problematic_node_pool_info)
 
       chain(
           node_pool_info,
           problematic_node_pool_info,
-          create_node_pool,
-          wait_for_provisioning,
-          wait_for_running,
-          select_random_node,
-          delete_node,
-          wait_for_repair,
-          wait_for_recovered,
-          delete_node_pool,
-          wait_for_stopping,
-          cleanup_node_pool,
-      )
-
-      chain(
-          create_problematic_node_pool_info,
-          wait_for_error,
-          cleanup_wrong_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -23,6 +23,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
@@ -32,6 +33,10 @@ DAG_ID = "node_pool_ttr_disk_size"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 _DISK_SIZE_INCREMENT = 50
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 with models.DAG(
     dag_id=DAG_ID,
@@ -84,46 +89,59 @@ with models.DAG(
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=node_pool_info
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(node_pool=node_pool_info)
 
-      wait_for_provisioning = node_pool.wait_for_status.override(
-          task_id="wait_for_provisioning"
-      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+        wait_for_provisioning = node_pool.wait_for_status.override(
+            task_id="wait_for_provisioning"
+        )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-      wait_for_running = node_pool.wait_for_status.override(
-          task_id="wait_for_running"
-      )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
+        wait_for_running = node_pool.wait_for_status.override(
+            task_id="wait_for_running"
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      update_start_time = node_pool.update.override(task_id="update_node_pool")(
-          node_pool=node_pool_info,
-          spec=node_pool.NodePoolUpdateSpec.DiskSize(
-              delta=_DISK_SIZE_INCREMENT
-          ),
-      )
+        chain(create_node_pool, wait_for_provisioning, wait_for_running)
 
-      wait_for_recovered = node_pool.wait_for_status.override(
-          task_id="wait_for_recovered"
-      )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        update_start_time = node_pool.update.override(
+            task_id="update_node_pool"
+        )(
+            node_pool=node_pool_info,
+            spec=node_pool.NodePoolUpdateSpec.DiskSize(
+                delta=_DISK_SIZE_INCREMENT
+            ),
+        )
 
-      wait_for_ttr = node_pool.wait_for_ttr(
-          node_pool=node_pool_info, operation_start_time=update_start_time
-      )
+        wait_for_recovered = node_pool.wait_for_status.override(
+            task_id="wait_for_recovered"
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        wait_for_ttr = node_pool.wait_for_ttr(
+            node_pool=node_pool_info, operation_start_time=update_start_time
+        )
+
+        chain(update_start_time, wait_for_recovered, wait_for_ttr)
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
 
       chain(
           node_pool_info,
-          create_node_pool,
-          wait_for_provisioning,
-          wait_for_running,
-          update_start_time,
-          wait_for_recovered,
-          wait_for_ttr,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -22,6 +22,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
@@ -30,6 +31,10 @@ from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, ge
 DAG_ID = "node_pool_ttr_update_label"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 with models.DAG(
     dag_id=DAG_ID,
@@ -83,51 +88,63 @@ with models.DAG(
           tpu_topology=config.tpu_topology,
       )
 
-      task_id = "create_node_pool"
-      create_node_pool = node_pool.create.override(task_id=task_id)(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        task_id = "create_node_pool"
+        create_node_pool = node_pool.create.override(task_id=task_id)(
+            node_pool=node_pool_info,
+        )
 
-      task_id = "wait_for_provisioning"
-      wait_for_provisioning = node_pool.wait_for_status.override(
-          task_id=task_id
-      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+        task_id = "wait_for_provisioning"
+        wait_for_provisioning = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-      task_id = "wait_for_running"
-      wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+        task_id = "wait_for_running"
+        wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.RUNNING
+        )
 
-      task_id = "update_node_pool_label"
-      update_node_pool_label = node_pool.update.override(task_id=task_id)(
-          node_pool=node_pool_info,
-          spec=node_pool.NodePoolUpdateSpec.Label(delta=LABELS_TO_UPDATE),
-      )
+        chain(create_node_pool, wait_for_provisioning, wait_for_running)
 
-      task_id = "wait_for_recovered"
-      wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        task_id = "update_node_pool_label"
+        update_node_pool_label = node_pool.update.override(task_id=task_id)(
+            node_pool=node_pool_info,
+            spec=node_pool.NodePoolUpdateSpec.Label(delta=LABELS_TO_UPDATE),
+        )
 
-      task_id = "wait_for_ttr"
-      wait_for_ttr = node_pool.wait_for_ttr.override(task_id=task_id)(
-          node_pool=node_pool_info, operation_start_time=update_node_pool_label
-      )
+        task_id = "wait_for_recovered"
+        wait_for_recovered = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      task_id = "cleanup_node_pool"
-      cleanup_node_pool = node_pool.delete.override(
-          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        task_id = "wait_for_ttr"
+        wait_for_ttr = node_pool.wait_for_ttr.override(task_id=task_id)(
+            node_pool=node_pool_info,
+            operation_start_time=update_node_pool_label,
+        )
+
+        chain(update_node_pool_label, wait_for_recovered, wait_for_ttr)
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        task_id = "cleanup_node_pool"
+        cleanup_node_pool = node_pool.delete.override(
+            task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
 
       chain(
           node_pool_info,
-          create_node_pool,
-          wait_for_provisioning,
-          wait_for_running,
-          update_node_pool_label,
-          wait_for_recovered,
-          wait_for_ttr,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -25,6 +25,7 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
@@ -33,6 +34,10 @@ from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, ge
 DAG_ID = "gke_node_pool_label_update"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -85,44 +90,60 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create.override(
-          task_id="create_node_pool",
-          owner=test_owner.YUNA_T,
-      )(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool",
+            owner=test_owner.YUNA_T,
+        )(
+            node_pool=node_pool_info,
+        )
 
-      wait_for_availability = node_pool.wait_for_availability.override(
-          task_id="wait_for_initial_availability"
-      )(node_pool=node_pool_info, availability=True)
+        wait_for_availability = node_pool.wait_for_availability.override(
+            task_id="wait_for_initial_availability"
+        )(node_pool=node_pool_info, availability=True)
 
-      update_node_pool_label = node_pool.update.override(
-          task_id="update_node_pool_label"
-      )(
-          node_pool=node_pool_info,
-          spec=node_pool.NodePoolUpdateSpec.Label(delta=LABELS_TO_UPDATE),
-      )
+        chain(create_node_pool, wait_for_availability)
 
-      wait_for_unavailable = node_pool.wait_for_availability.override(
-          task_id="wait_for_unavailability_after_update"
-      )(node_pool=node_pool_info, availability=False)
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        update_node_pool_label = node_pool.update.override(
+            task_id="update_node_pool_label"
+        )(
+            node_pool=node_pool_info,
+            spec=node_pool.NodePoolUpdateSpec.Label(delta=LABELS_TO_UPDATE),
+        )
 
-      wait_node_pool_recovered = node_pool.wait_for_availability.override(
-          task_id="wait_for_recovery"
-      )(node_pool=node_pool_info, availability=True)
+        wait_for_unavailable = node_pool.wait_for_availability.override(
+            task_id="wait_for_unavailability_after_update"
+        )(node_pool=node_pool_info, availability=False)
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=[create_node_pool],
-      )
+        wait_node_pool_recovered = node_pool.wait_for_availability.override(
+            task_id="wait_for_recovery"
+        )(node_pool=node_pool_info, availability=True)
+
+        chain(
+            update_node_pool_label,
+            wait_for_unavailable,
+            wait_node_pool_recovered,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
 
       chain(
           node_pool_info,
-          create_node_pool,
-          wait_for_availability,
-          update_node_pool_label,
-          wait_for_unavailable,
-          wait_node_pool_recovered,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
# Description

This PR integrates TaskGroupWithTimeout directly into all GKE Node Pool validation DAGs that are unrelated to JobSets/workloads. This ensures strict stage-specific timeout enforcement across different phases (Pre-test provisioning: 10 mins, Post-test cleanup: 10 mins, and the remaining budget allocated to the main test case).

## DAGs Refactored with TaskGroupWithTimeout
The following 5 GKE Node Pool status and label validation DAGs have been successfully refactored into separate pre_test, test, and post_test blocks under TaskGroupWithTimeout:

- dags/tpu_observability/node_pool_status.py
- dags/tpu_observability/node_pool_ttr_disk_size.py
- dags/tpu_observability/node_pool_ttr_update_label.py
- dags/tpu_observability/multi_host_nodepool_rollback_dag.py
- dags/tpu_observability/update_node_pool_label.py

## Deferred DAGs (Unchanged)
Because TaskGroupWithTimeout does not support nested TaskGroups, GKE DAGs that involve JAX workloads and rely on jobset.create_jobset_startup_group() cannot be refactored yet. The helper function internally instantiates a standard TaskGroup (jobset_startup_and_prepare), which triggers a parsing-time AirflowFailException when nested inside a parent TaskGroupWithTimeout.

As a result, the following JobSet and workload-related DAGs are temporarily left unchanged using original TaskGroups, to be refactored once nested TaskGroups are natively supported:

- dags/tpu_observability/jobset_ttr_drain_restart.py
- dags/tpu_observability/jobset_ttr_node_pool_resize.py
- dags/tpu_observability/jobset_ttr_pod_delete.py
- dags/tpu_observability/jobset_ttr_rollback.py
- dags/tpu_observability/jobset_uptime_validation.py
- dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py (Added)
- dags/tpu_observability/tpu_info_metrics_dag.py (Added)
- dags/tpu_observability/tpu_info_format_validation_dags.py (Added)
- dags/tpu_observability/jobset_ttr_kill_process.py

## Key Changes & Mechanisms
Timeout Budgets:
- PRE_TEST_TIMEOUT: 10 minutes
- POST_TEST_TIMEOUT: 10 minutes
- TEST_TIMEOUT: Evaluated dynamically as DAGRUN_TIMEOUT - 20 minutes
- Guaranteed Cleanup: The post_test block in the refactored DAGs utilizes is_teardown=True under the hood, ensuring that GKE node pool deletions are executed even if upstream test cases timeout or fail, preventing accidental resource leakages.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.