### PR TITLE
Add MaxText E2E tests DAG triggered by Github Actions workflow

### DIFF
--- a/dags/common/scheduling_helper/dag_integrity_whitelist.yaml
+++ b/dags/common/scheduling_helper/dag_integrity_whitelist.yaml
@@ -51,6 +51,9 @@ whitelisted_dags:
 - maxtext_configs_aot_gpu
 - maxtext_configs_aot_hybridsim
 - maxtext_convergence
+- maxtext_e2e_tests
+- maxtext_e2e_tpu_post_training
+- maxtext_e2e_tpu_pre_training
 - maxtext_emc_and_mtc_orbax_save_local
 - maxtext_emc_orbax_res_gcs
 - maxtext_emc_orbax_res_local

--- a/dags/multipod/maxtext_e2e_tests.py
+++ b/dags/multipod/maxtext_e2e_tests.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Parent DAG that triggers MaxText E2E TPU pre-training and post-training child
+DAGs in parallel, waits for both to complete, then fires a GitHub
+repository_dispatch callback with the aggregated result.
+"""
+import datetime
+import requests
+from airflow import models
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.utils.trigger_rule import TriggerRule
+
+with models.DAG(
+    dag_id="maxtext_e2e_tests",
+    schedule=None,
+    tags=[
+        "maxtext",
+        "e2e",
+        "pre-training",
+        "post-training",
+    ],
+    start_date=datetime.datetime(2026, 6, 10),
+    catchup=False,
+    params={
+        "build_mode": Param(
+            type="string",
+            description="Build mode: stable or nightly",
+        ),
+        "maxtext_sha": Param(
+            type="string",
+            description="Commit SHA being tested",
+        ),
+        "github_run_id": Param(
+            type="string",
+            description="GitHub Actions run ID of the original build workflow",
+        ),
+        "github_repo": Param(
+            type="string",
+            description="GitHub repository in owner/repo format",
+        ),
+        "github_callback_token": Param(
+            type="string",
+            description="GitHub PAT used to fire the repository_dispatch callback",
+        ),
+    },
+) as dag:
+  trigger_pre_training = TriggerDagRunOperator(
+      task_id="trigger_tpu_pre_training",
+      trigger_dag_id="maxtext_e2e_tpu_pre_training",
+      conf={
+          "docker_image": "gcr.io/tpu-prod-env-multipod/maxtext_jax_{{ params.build_mode }}:{{ params.github_run_id }}"
+      },
+      wait_for_completion=True,
+      poke_interval=600,  # check every 10 minutes for child DAG completion
+  )
+
+  trigger_post_training = TriggerDagRunOperator(
+      task_id="trigger_tpu_post_training",
+      trigger_dag_id="maxtext_e2e_tpu_post_training",
+      conf={
+          "docker_image": "gcr.io/tpu-prod-env-multipod/maxtext_post_training_{{ params.build_mode }}:{{ params.github_run_id }}"
+      },
+      wait_for_completion=True,
+      poke_interval=600,  # check every 10 minutes for child DAG completion
+  )
+
+  def fire_github_callback(**context):
+    params = context["params"]
+    dag_run = context["dag_run"]
+
+    response = requests.post(
+        f"https://api.github.com/repos/{params['github_repo']}/dispatches",
+        headers={
+            "Authorization": f"Bearer {params['github_callback_token']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        json={
+            "event_type": "airflow-dag-complete",
+            "client_payload": {
+                "state": "success",
+                "dag_id": dag_run.dag_id,
+                "dag_run_id": dag_run.run_id,
+                "sha": params["maxtext_sha"],
+                "github_run_id": params["github_run_id"],
+            },
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+
+  github_callback = PythonOperator(
+      task_id="fire_github_callback",
+      python_callable=fire_github_callback,
+      trigger_rule=TriggerRule.ALL_SUCCESS,  # Only fire if all upstream tasks succeeded
+  )
+
+  [trigger_pre_training, trigger_post_training] >> github_callback

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A DAG to run MaxText E2E TPU Post-Training tests.
+"""
+import datetime
+import hashlib
+
+from click import command
+from airflow import models
+from airflow.models.param import Param
+from airflow.utils.task_group import TaskGroup
+from dags.common import test_owner
+from dags.common.vm_resource import XpkClusters
+from dags.multipod.configs import gke_config
+
+# HF token retrieved from Airflow Variables for secure credential management
+HF_TOKEN = models.Variable.get("HF_TOKEN", None)
+
+
+def get_workload_name(model, mode, length=6):
+  hex_code = f"{mode}-{hashlib.sha256(model.encode()).hexdigest()}"
+  return hex_code[:length]
+
+
+with models.DAG(
+    dag_id="maxtext_e2e_tpu_post_training",
+    schedule=None,
+    tags=[
+        "maxtext",
+        "post-training",
+        "TPU",
+    ],
+    start_date=datetime.datetime(2026, 6, 10),
+    catchup=False,
+    params={
+        "docker_image": Param(
+            type="string",
+            description="Docker image URI for the candidate to test",
+        ),
+    },
+) as dag:
+  test_models = {
+      "gemma3-4b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/sft/{run_name}/checkpoints/5/model_params",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/rl/{run_name}/checkpoints/actor/5/model_params",
+              },
+          },
+      },
+  }
+
+  for model, test_config in test_models.items():
+    with TaskGroup(group_id=model) as model_group:
+      run_name = "post-{{ ts_nodash }}"
+
+      convert_to_maxtext_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+          f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",
+      )
+      convert_to_maxtext_task = gke_config.get_gke_config(
+          time_out_in_min=60,
+          test_name=f"convert-to-maxtext",
+          run_model_cmds=convert_to_maxtext_cmd,
+          docker_image="{{ params.docker_image }}",
+          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          test_owner=test_owner.SURBHI_J,
+      ).run(skip_post_process=True)
+
+      for mode, mode_test_config in test_config["post_training"].items():
+        with TaskGroup(group_id=f"{mode}-{model}") as model_group:
+          environment_variables = [
+              f"export HF_TOKEN={HF_TOKEN}",
+              "export TPU_MIN_LOG_LEVEL=0",
+              "export TF_CPP_MIN_LOG_LEVEL=0",
+              "export TPU_STDERR_LOG_LEVEL=0",
+              "export JAX_PLATFORMS=proxy,cpu",
+              "export JAX_BACKEND_TARGET=grpc://127.0.0.1:29000",
+              "export ENABLE_PATHWAYS_PERSISTENCE='1'",
+          ]
+
+          with TaskGroup(group_id=f"train-{mode}-{model}") as model_group:
+            command = mode_test_config["command"]
+            training_cmd = (
+                " && ".join(
+                    environment_variables + [f"{command} {run_name} true"]
+                ),
+            )
+            training_task = gke_config.get_gke_config(
+                time_out_in_min=60,
+                num_slices=1,
+                cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+                test_name=get_workload_name(model, mode),
+                run_model_cmds=training_cmd,
+                docker_image="{{ params.docker_image }}",
+                test_owner=test_owner.SURBHI_J,
+            ).run_model(
+                use_pathways=True,
+            )
+
+          model_path = mode_test_config["maxtext_ckpt_path"].format(
+              run_name=run_name
+          )
+          convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+              f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path} false true",
+          )
+          convert_to_huggingface_task = gke_config.get_gke_config(
+              time_out_in_min=60,
+              test_name="convert-to-huggingface",
+              run_model_cmds=convert_to_huggingface_cmd,
+              docker_image="{{ params.docker_image }}",
+              cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+              test_owner=test_owner.SURBHI_J,
+          ).run(skip_post_process=True)
+
+          (
+              convert_to_maxtext_task
+              >> training_task
+              >> convert_to_huggingface_task
+          )

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A DAG to run MaxText E2E TPU Pre-Training tests.
+"""
+import datetime
+from airflow import models
+from airflow.models.param import Param
+from airflow.utils.task_group import TaskGroup
+from dags.common import test_owner
+from dags.common.vm_resource import XpkClusters
+from dags.multipod.configs import gke_config
+
+HF_TOKEN = models.Variable.get("HF_TOKEN", None)
+
+with models.DAG(
+    dag_id="maxtext_e2e_tpu_pre_training",
+    schedule=None,
+    tags=[
+        "maxtext",
+        "pre-training",
+        "TPU",
+    ],
+    start_date=datetime.datetime(2026, 6, 10),
+    catchup=False,
+    params={
+        "docker_image": Param(
+            type="string",
+            description="Docker image URI for the candidate to test",
+        ),
+    },
+) as dag:
+  test_models = {
+      "gemma3-4b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/train/{run_name}/checkpoints/4/items",
+          },
+      },
+  }
+
+  for model, test_config in test_models.items():
+    with TaskGroup(group_id=model) as model_group:
+      run_name = "pre-{{ ts_nodash }}"
+
+      convert_to_maxtext_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+          f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",
+      )
+      convert_to_maxtext_task = gke_config.get_gke_config(
+          time_out_in_min=60,
+          test_name="convert-to-maxtext",
+          run_model_cmds=convert_to_maxtext_cmd,
+          docker_image="{{ params.docker_image }}",
+          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          test_owner=test_owner.SURBHI_J,
+      ).run(skip_post_process=True)
+
+      training_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+          f"{test_config['training']['command']} {run_name}",
+      )
+      training_task = gke_config.get_gke_config(
+          time_out_in_min=60,
+          test_name="training",
+          run_model_cmds=training_cmd,
+          docker_image="{{ params.docker_image }}",
+          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          test_owner=test_owner.SURBHI_J,
+      ).run(skip_post_process=True)
+
+      model_path = test_config["training"]["maxtext_ckpt_path"].format(
+          run_name=run_name
+      )
+      convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+          f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path}",
+      )
+      convert_to_huggingface_task = gke_config.get_gke_config(
+          time_out_in_min=60,
+          test_name="convert-to-huggingface",
+          run_model_cmds=convert_to_huggingface_cmd,
+          docker_image="{{ params.docker_image }}",
+          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          test_owner=test_owner.SURBHI_J,
+      ).run(skip_post_process=True)
+
+      convert_to_maxtext_task >> training_task >> convert_to_huggingface_task


### PR DESCRIPTION

# Description

This PR implements the Airflow DAGs required for the automated E2E testing of the MaxText PyPI release workflow, as part of the [go/maxtext-release-e2e-proposal](http://goto.google.com/maxtext-release-e2e-proposal). 

The following DAGs are added to the `ml-auto-solutions` repository:

1.  **`maxtext_e2e_tests`**: Acts as the orchestration layer between GitHub Actions and the specific E2E test DAGs. It fans out to child DAGs, waits for completion, and fires a `repository_dispatch` callback to GitHub with the aggregated result.
2.  **`maxtext_e2e_tpu_pre_training`**: Validates the pre-training candidate Docker image. Tasks include bidirectional checkpoint conversion (HF to MaxText and back) and a pre-training run on TPU.
3.  **`maxtext_e2e_tpu_post_training`**: Validates the post-training candidate Docker image. Tasks include bidirectional checkpoint conversion, SFT, and RL on TPU.

These DAGs enable the automated validation of candidate Docker images, helping to prevent regressions in critical features like checkpoint compatibility and training stability.

# Tests

The DAGs were verified by triggering them manually via the Airflow REST API and monitoring the execution in the Airflow UI.

- **Manual Triggering**: Verified that `maxtext_e2e_tests` correctly triggers `maxtext_e2e_tpu_pre_training` and `maxtext_e2e_tpu_post_training` in parallel.
- **Task Success**: Verified that the individual tasks (checkpoint conversion, pre-training/SFT/RL) execute successfully with the candidate images.

https://screenshot.googleplex.com/6XpE8H83G8fVpQt


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.