### PR TITLE
fix: Separate config construction from Airflow task execution

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -43,6 +43,12 @@ jobs:
     - name: Install Python dependencies
       run: pip install -r .github/requirements.txt
 
+    - name: Authenticate with gcloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCS_SECRET }}
+        create_credentials_file: true
+
     - name: Run DAGs
       run: |
         scripts/dag-check.sh

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -21,7 +21,6 @@ from airflow.models.baseoperator import chain
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
-
 from airflow.decorators import task
 
 from dags import composer_env
@@ -76,7 +75,7 @@ def check_nodes_number(
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
-    dag_id="jobset_ttr_drain_restart",
+    dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 10),
     schedule=SCHEDULE if composer_env.is_prod_env() else None,
     dagrun_timeout=DAGRUN_TIMEOUT,
@@ -125,36 +124,31 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name="jobset_ttr_drain_restart",
+          dag_name=DAG_ID,
+          node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="jobset_ttr_drain_restart",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
       )
 
-      start_workload = jobset.run_workload.override(task_id="start_workload")(
+      startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
-
-      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
-          task_id="ensure_all_pods_running"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
       )
 
       select_node = node_pool.draw_random_node.override(task_id="select_node")(
@@ -193,7 +187,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=start_workload
+          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
@@ -203,11 +197,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
-          jobset_config,
-          cluster_info,
+          selector,
           create_node_pool,
-          start_workload,
-          ensure_all_pods_running,
+          *startup.tasks,
           select_node,
           drained_node,
           check_nodes_number,

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -135,9 +135,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -186,8 +184,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
           create_node_pool,
           *startup.tasks,
           kill_tasks,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -99,9 +99,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -151,8 +149,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
           create_node_pool,
           *startup.tasks,
           node_pool_resize,

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -104,9 +104,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           privileged=True,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -158,8 +156,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
           create_node_pool,
           *startup.tasks,
           target_pod,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -95,9 +95,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -144,8 +142,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
           create_node_pool,
           *startup.tasks,
           delete_random_pod,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -96,9 +96,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -145,8 +143,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
           create_node_pool,
           *startup.tasks,
           rollback_node_pool,

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -107,9 +107,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -167,8 +165,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
           create_node_pool,
           *startup.tasks,
           wait_for_jobset_uptime_data,

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -87,9 +87,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -125,7 +123,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
-          node_pool_info,
           create_node_pool,
           wait_node_pool_available,
           rollback_node_pool,

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -15,9 +15,9 @@
 """A DAG to validate the status of a GKE node pool through its lifecycle."""
 
 import datetime
+import copy
 
 from airflow import models
-from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
@@ -69,28 +69,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    @task
-    def generate_problematic_node_pool_name(
-        node_pool_info: node_pool.Info,
-    ) -> str:
-      """Generates a problematic node pool name."""
-      return f"{node_pool_info.node_pool_name}-x"
-
-    @task
-    def generate_problematic_node_location(
-        node_pool_info: node_pool.Info,
-    ) -> str:
-      """Generates a problematic node location."""
-      return f"{node_pool_info.location}-c"
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -98,10 +82,10 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      problematic_node_pool_info = node_pool.copy_node_pool_info_with_override(
-          info=node_pool_info,
-          node_pool_name=generate_problematic_node_pool_name(node_pool_info),
-          node_locations=generate_problematic_node_location(node_pool_info),
+      problematic_node_pool_info = copy.deepcopy(node_pool_info)
+      problematic_node_pool_info.location = f"{node_pool_info.location}-c"
+      problematic_node_pool_info.node_pool_name = (
+          f"{node_pool_info.node_pool_name}-x"
       )
 
       task_id = "create_node_pool"
@@ -191,8 +175,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
-          node_pool_info,
-          problematic_node_pool_info,
           create_node_pool,
           wait_for_provisioning,
           wait_for_running,

--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -118,7 +118,6 @@ with models.DAG(
       )
 
       chain(
-          node_pool_info,
           create_node_pool,
           wait_for_provisioning,
           wait_for_running,

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -73,9 +73,7 @@ with models.DAG(
     LABELS_TO_UPDATE = {"test_key": "test_val"}
 
     with TaskGroup(group_id=f"v{config.tpu_version.value}"):
-      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -122,7 +120,6 @@ with models.DAG(
       )
 
       chain(
-          node_pool_info,
           create_node_pool,
           wait_for_provisioning,
           wait_for_running,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -23,6 +23,7 @@ import os
 import re
 import subprocess
 import tempfile
+import copy
 
 from airflow import models
 from airflow.decorators import task
@@ -342,13 +343,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    @task
-    def generate_second_node_pool_name(
-        node_pool_info: node_pool.Info,
-    ) -> str:
-      """Generates a second node pool name."""
-      return f"{node_pool_info.node_pool_name}-2"
-
     selector = jobset.generate_node_pool_selector(
         "tpu-info-format-validation-dag"
     )
@@ -364,9 +358,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -375,12 +367,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info_2 = node_pool.copy_node_pool_info_with_override.override(
-          task_id="copy_node_pool_info_with_override"
-      )(
-          info=cluster_info,
-          node_pool_name=generate_second_node_pool_name(cluster_info),
-      )
+      cluster_info_2 = copy.deepcopy(cluster_info)
+      cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"
 
       # Keyword arguments are generated dynamically at runtime (pylint does not
       # know this signature).
@@ -504,9 +492,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
-          cluster_info_2,
           create_node_pool,
           *startup.tasks,
           outputs_of_tpu_info,

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -17,11 +17,11 @@ This script uses a factory pattern to dynamically generate an Airflow DAG for
 each metric verification strategy.
 """
 
-from dataclasses import replace
 import datetime
 import logging
 import os
 import tempfile
+import copy
 
 from airflow import models
 from airflow.decorators import task
@@ -278,13 +278,6 @@ with models.DAG(
   for machine in MachineConfigMap:
     config = machine.value
 
-    @task
-    def generate_second_node_pool_name(
-        node_pool_info: node_pool.Info,
-    ) -> str:
-      """Generates a second node pool name."""
-      return f"{node_pool_info.node_pool_name}-2"
-
     with TaskGroup(group_id=f"v{config.tpu_version.value}"):
       selector = jobset.generate_node_pool_selector(
           "tpu_info_metrics_verification"
@@ -296,9 +289,7 @@ with models.DAG(
           node_pool_selector=selector,
       )
 
-      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -307,10 +298,8 @@ with models.DAG(
           node_pool_selector=selector,
       )
 
-      cluster_info_2 = node_pool.copy_node_pool_info_with_override(
-          info=cluster_info,
-          node_pool_name=generate_second_node_pool_name(cluster_info),
-      )
+      cluster_info_2 = copy.deepcopy(cluster_info)
+      cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"
 
       with TaskGroup(group_id="create_node_pool") as create_node_pool:
         create_first_node_pool = node_pool.create.override(
@@ -413,9 +402,6 @@ with models.DAG(
 
       chain(
           selector,
-          jobset_config,
-          cluster_info,
-          cluster_info_2,
           create_node_pool,
           *startup.tasks,
           all_verification_groups,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -141,9 +141,7 @@ with models.DAG(
         node_pool_selector=selector,
     )
 
-    cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-        task_id="build_node_pool_info_from_gcs_yaml"
-    )(
+    cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
         gcs_path=GCS_CONFIG_PATH,
         dag_name=DAG_ID,
         is_prod=composer_env.is_prod_env(),
@@ -185,8 +183,6 @@ with models.DAG(
 
     chain(
         selector,
-        jobset_config,
-        cluster_info,
         create_node_pool,
         *startup.tasks,
         sdk_validation,

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -75,9 +75,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-          task_id="build_node_pool_info_from_gcs_yaml"
-      )(
+      node_pool_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
@@ -118,7 +116,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       chain(
-          node_pool_info,
           create_node_pool,
           wait_for_availability,
           update_node_pool_label,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -31,9 +31,8 @@ from airflow.exceptions import AirflowFailException
 from airflow.sensors.base import PokeReturnValue
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
-from airflow.utils.task_group import TaskGroup
-from google.cloud.monitoring_v3 import types
 from airflow.models.baseoperator import chain
+from google.cloud.monitoring_v3 import types
 from websocket import WebSocketConnectionClosedException
 import kubernetes
 
@@ -412,8 +411,18 @@ class Command:
     return Command.k8s_get_pods(jobset_name, namespace, output)
 
 
+class ReplicatedJobStatus(enum.Enum):
+  """Defines status of a replicated job."""
+
+  READY = "ready"
+  SUSPENDED = "suspended"
+  ACTIVE = "active"
+  FAILED = "failed"
+  SUCCEEDED = "succeeded"
+
+
 def get_replica_num(
-    replica_type: str, job_name: str, node_pool: node_pool_info
+    job_status: ReplicatedJobStatus, job_name: str, node_pool: node_pool_info
 ) -> int:
   """
   Get the number of a certain type of replicas from a running jobset.
@@ -422,12 +431,12 @@ def get_replica_num(
   the number of replicas in a certain status.
 
   Args:
-    replica_type: The type of replica being searched for.
+    job_status: The status of the replicated job being searched for.
     job_name: The name of the job replica which is run from the jobset.
     node_pool: The Info object containing the cluster information needed for
     the kubernetes API to connect to it.
   Returns:
-    The number of replicas of the specific type in the jobset.
+    The number of replicas of the specific status in the jobset.
   """
   api_client = gke.get_authenticated_client(
       node_pool.project_id,
@@ -447,7 +456,7 @@ def get_replica_num(
   try:
     replica_job_status = jobsets["items"][0]["status"]["replicatedJobsStatus"]
     name = replica_job_status[0]["name"]
-    replicas = replica_job_status[0][replica_type]
+    replicas = replica_job_status[0][job_status.value]
     logging.info("Found %s replicas", replicas)
 
   except (KeyError, IndexError, TypeError) as e:
@@ -520,7 +529,6 @@ def _generate_jobset_name(dag_id_prefix: str) -> str:
   return f"{dag_id_prefix}-{timestamp}"
 
 
-@task
 def build_jobset_from_gcs_yaml(
     gcs_path: str,
     dag_name: str,

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -86,13 +86,12 @@ class Info:
   node_pool_selector: str = None
 
 
-@task
 def build_node_pool_info_from_gcs_yaml(
     gcs_path: str, dag_name: str, is_prod: bool = True, **overrides
 ) -> Info:
   """Builds a node_pool.Info instance by merging configurations.
 
-  This task merges values from the 'common' section of the provided dag_config,
+  This function merges values from the 'common' section of the provided dag_config,
   a DAG-specific section (given by dag_name), and any provided overrides.
   Only fields that exist in the node_pool.Info dataclass are included.
 
@@ -145,35 +144,6 @@ def build_node_pool_info_from_gcs_yaml(
       merged[k] = v
 
   return Info(**merged)
-
-
-@task
-def copy_node_pool_info_with_override(info: Info, **overrides) -> Info:
-  """Copies a node_pool.Info instance and applies overrides.
-
-  Args:
-      info: The base node_pool.Info instance to copy.
-      **overrides: Key-value pairs to override fields in the copied Info.
-
-  Returns:
-      A new node_pool.Info instance with overrides applied.
-  """
-  known = {f.name for f in dataclasses.fields(Info)}
-
-  unknown = [k for k in overrides if k not in known]
-  if unknown:
-    logging.warning(f"Ignoring unknown fields in overrides: {unknown}")
-
-  cfg = {k: v for k, v in overrides.items() if k in known and v is not None}
-  if not cfg:
-    return info  # Nothing to change.
-
-  # return dataclasses.replace(info, **cfg)
-  replaced_info = dataclasses.replace(info, **cfg)
-  logging.info(
-      f"Created a new node_pool.Info instance with overrides: {replaced_info}"
-  )
-  return replaced_info
 
 
 def _node_pool_exists(node_pool: Info) -> bool:


### PR DESCRIPTION
# Description

Move jobsets and node pool configuration out from dag, so that during CI/CD process, GitHub action machine can access GCP bucket data. 

# Changes
- Add a "Authenticate with gcloud" in dag-check.sh, and corresponding secret key in repository setting.
- remove the override of configuration step in all existing tpu-obs dags and unnecessary @task marks.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.