### PR TITLE
fix: Add lifecycle and termination controls to JobSet Template

### DIFF
--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -20,6 +20,7 @@ killing the main process inside a worker Pod.
 import datetime
 import logging
 import os
+import random
 import tempfile
 
 from airflow import models
@@ -42,6 +43,7 @@ from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils import subprocess_util as subprocess
 from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.utils.time_util import TimeUtil
 
 DAG_ID = "jobset_ttr_kill_process"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
@@ -49,7 +51,7 @@ SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 
 @task
-def kill_tpu_pod_workload(info: node_pool.Info, pod_name: str) -> None:
+def kill_tpu_pod_workload(info: node_pool.Info, running_pods: list) -> None:
   """
   Kills the python process on a single pod.
 
@@ -57,14 +59,20 @@ def kill_tpu_pod_workload(info: node_pool.Info, pod_name: str) -> None:
   python process inside the specified pod. It ignores errors if the pod
   has already been deleted to ensure pipeline continuity.
   """
+  target_pod = random.choice(running_pods)
+
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
 
     cmd = " && ".join([
         jobset.Command.get_credentials_command(info),
-        f"kubectl exec {pod_name} -n default -- pkill -9 -f python",
+        f"kubectl exec {target_pod} -n default -- pkill -9 -f python",
     ])
+
+    operation_start_time = TimeUtil.from_datetime(
+        datetime.datetime.now(datetime.timezone.utc)
+    )
 
     try:
       subprocess.run_exec(cmd, env=env)
@@ -72,6 +80,8 @@ def kill_tpu_pod_workload(info: node_pool.Info, pod_name: str) -> None:
       logging.info("Process was terminated with SIGKILL")
     except Exception as e:
       raise e
+
+  return operation_start_time
 
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -157,17 +167,34 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      kill_tasks = (
-          kill_tpu_pod_workload.override(task_id="kill_tpu_pod_workload")
-          .partial(info=cluster_info)
-          .expand(pod_name=startup.running_pods)
+      kill_tasks = kill_tpu_pod_workload.override(
+          task_id="kill_tpu_pod_workload"
+      )(
+          info=cluster_info,
+          running_pods=startup.running_pods,
+      )
+
+      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+          task_id="wait_for_recovery"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      )
+
+      verify_duration = jobset.verify_recovery_duration.override(
+          task_id="verify_recovery_duration"
+      )(
+          start_time=kill_tasks,
+          end_time=wait_for_recovery,
       )
 
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_metric_upload"
+          task_id="wait_for_jobset_ttr_to_be_found",
       )(
           node_pool=cluster_info,
           jobset_name=jobset_name,
+          start_time=kill_tasks,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -192,6 +219,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           create_node_pool,
           *startup.tasks,
           kill_tasks,
+          wait_for_recovery,
+          verify_duration,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -149,7 +149,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_jobset_ttr_to_be_found",
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
           start_time=node_pool_resize_start_time,
       )
 
@@ -175,6 +175,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           create_node_pool,
           *startup.tasks,
           node_pool_resize_start_time,
+          wait_for_recovery,
+          verify_duration,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -121,18 +121,36 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      node_pool_resize = node_pool.update.override(task_id="node_pool_resize")(
+      node_pool_resize_start_time = node_pool.update.override(
+          task_id="node_pool_resize"
+      )(
           node_pool=cluster_info,
           spec=node_pool.NodePoolUpdateSpec.DiskSize(
               delta=_DISK_SIZE_INCREMENT
           ),
       )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found"
+      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+          task_id="wait_for_recovery"
       )(
           node_pool=cluster_info,
+          jobset_config=jobset_config,
           jobset_name=jobset_name,
+      )
+
+      verify_duration = jobset.verify_recovery_duration.override(
+          task_id="verify_recovery_duration"
+      )(
+          start_time=node_pool_resize_start_time,
+          end_time=wait_for_recovery,
+      )
+
+      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+          task_id="wait_for_jobset_ttr_to_be_found",
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          start_time=node_pool_resize_start_time,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -156,7 +174,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_name,
           create_node_pool,
           *startup.tasks,
-          node_pool_resize,
+          node_pool_resize_start_time,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -137,11 +137,27 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           namespace="default",
       )
 
+      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+          task_id="wait_for_recovery"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      )
+
+      verify_duration = jobset.verify_recovery_duration.override(
+          task_id="verify_recovery_duration"
+      )(
+          start_time=reboot_node,
+          end_time=wait_for_recovery,
+      )
+
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found"
+          task_id="wait_for_jobset_ttr_to_be_found",
       )(
           node_pool=cluster_info,
           jobset_name=jobset_name,
+          start_time=reboot_node,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -167,6 +183,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           *startup.tasks,
           target_pod,
           reboot_node,
+          wait_for_recovery,
+          verify_duration,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -118,7 +118,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      delete_random_pod = jobset.delete_one_random_pod.override(
+      deletion_start_time = jobset.delete_one_random_pod.override(
           task_id="delete_random_pod"
       )(
           node_pool=cluster_info,
@@ -126,11 +126,27 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_name=jobset_name,
       )
 
+      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+          task_id="wait_for_recovery"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      )
+
+      verify_duration = jobset.verify_recovery_duration.override(
+          task_id="verify_recovery_duration"
+      )(
+          start_time=deletion_start_time,
+          end_time=wait_for_recovery,
+      )
+
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found"
+          task_id="wait_for_jobset_ttr_to_be_found",
       )(
           node_pool=cluster_info,
           jobset_name=jobset_name,
+          start_time=deletion_start_time,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -154,7 +170,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           jobset_name,
           create_node_pool,
           *startup.tasks,
-          delete_random_pod,
+          deletion_start_time,
+          wait_for_recovery,
+          verify_duration,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -123,11 +123,27 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="rollback_node_pool"
       )(node_pool=cluster_info)
 
+      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+          task_id="wait_for_recovery"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      )
+
+      verify_duration = jobset.verify_recovery_duration.override(
+          task_id="verify_recovery_duration"
+      )(
+          start_time=rollback_node_pool,
+          end_time=wait_for_recovery,
+      )
+
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found"
+          task_id="wait_for_jobset_ttr_to_be_found",
       )(
           node_pool=cluster_info,
           jobset_name=jobset_name,
+          start_time=rollback_node_pool,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -152,6 +168,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           create_node_pool,
           *startup.tasks,
           rollback_node_pool,
+          wait_for_recovery,
+          verify_duration,
           wait_for_metric_upload,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -275,6 +275,11 @@ class JobSet:
       node-level fault injection (e.g., node reboots), where the pod must
       interact with the host OS via nsenter. Should remain False for all
       standard workloads. Defaults to False.
+    dag_id_prefix: The prefix assigned to the DAG ID for identification or
+      routing purposes. Defaults to "".
+    delay_recovery: A flag to enable a delayed recovery mechanism, which injects
+      a pre-stop sleep and modifies the restart policy/strategy to wait before
+      recreating pods. Defaults to False.
   """
 
   namespace: str
@@ -306,7 +311,6 @@ class JobSet:
           class.
         jobset_name: The name of the JobSet.
         node_pool_selector: The node pool selector to use.
-        apply_recovery_delay: Whether to apply a recovery delay.
 
     Returns:
         A string containing the complete JobSet YAML.
@@ -639,7 +643,6 @@ def run_workload(
     workload_type: Workload,
     jobset_name: str,
     node_pool_selector: str = None,
-    apply_recovery_delay: bool = False,
 ) -> TimeUtil:
   """Applies the specified YAML file to the GKE cluster.
 
@@ -649,7 +652,6 @@ def run_workload(
     workload_type: The workload script to execute.
     jobset_name: The name of the JobSet.
     node_pool_selector: The node pool selector to use.
-    apply_recovery_delay: Whether to apply recovery delay.
   Returns:
     The UTC time when the workload was started.
   """
@@ -660,7 +662,6 @@ def run_workload(
         workload_script=workload_type,
         jobset_name=jobset_name,
         node_pool_selector=node_pool_selector,
-        apply_recovery_delay=apply_recovery_delay,
     )
 
     cmd = " && ".join([
@@ -884,6 +885,7 @@ def operate_pod(
         (f"{base_command} {operation.extra_flags}").strip(),
     ]
 
+    current_time_utc = datetime.datetime.now(datetime.timezone.utc)
     try:
       subprocess.run_exec(" && ".join(commands), env=env)
     except WebSocketConnectionClosedException:
@@ -891,10 +893,10 @@ def operate_pod(
         logging.info(
             "Node reboot initiated: WebSocket connection closed as expected."
         )
-        return pod_name
+        return TimeUtil.from_datetime(current_time_utc)
       raise
 
-  return pod_name
+  return TimeUtil.from_datetime(current_time_utc)
 
 
 @task.sensor(poke_interval=30, timeout=900, mode="poke")
@@ -981,7 +983,7 @@ def verify_recovery_duration(start_time: TimeUtil, end_time: TimeUtil):
     )
 
 
-@task.sensor(poke_interval=60, timeout=3600, mode="poke")
+@task.sensor(poke_interval=60, timeout=3600, mode="poke", retries=0)
 def wait_for_jobset_ttr_to_be_found(
     node_pool: node_pool_info,
     jobset_name: str,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -15,6 +15,8 @@
 """Utilities for managing JobSets in GKE clusters for TPU observability."""
 
 import dataclasses
+import datetime
+from datetime import timedelta
 import enum
 import json
 import logging
@@ -23,7 +25,7 @@ import random
 import string
 import tempfile
 import textwrap
-from datetime import timedelta
+import time
 from typing import Final
 
 import kubernetes
@@ -68,6 +70,7 @@ class Workload:
   JAX_TPU_BENCHMARK = json.dumps(
       textwrap.dedent(
           """
+          pip install requests
           pip install jax[k8s] libtpu
           python -c '
           import jax
@@ -158,6 +161,7 @@ _TEMPLATE = string.Template(
         spec:
           failurePolicy:
             maxRestarts: $max_restarts
+            $restartStrategy
           replicatedJobs:
           - name: $replicated_job_name
             replicas: $replicas
@@ -169,6 +173,8 @@ _TEMPLATE = string.Template(
                 template:
                   spec:
                     hostPID: $host_pid
+                    restartPolicy: Never
+                    terminationGracePeriodSeconds: 350
                     nodeSelector:
                       cloud.google.com/gke-tpu-accelerator: $tpu_accelerator_type
                       cloud.google.com/gke-tpu-topology: $tpu_topology
@@ -178,6 +184,10 @@ _TEMPLATE = string.Template(
                       securityContext:
                         privileged: $privileged
                       image: $image
+                      lifecycle:
+                        preStop:
+                          exec:
+                            $container_prestop_command
                       command: $command
                       args:
                         - $args
@@ -281,6 +291,7 @@ class JobSet:
   tpu_cores_per_pod: int
   privileged: bool = False
   dag_id_prefix: str = ""
+  delay_recovery: bool = False
 
   def generate_yaml(
       self,
@@ -295,6 +306,7 @@ class JobSet:
           class.
         jobset_name: The name of the JobSet.
         node_pool_selector: The node pool selector to use.
+        apply_recovery_delay: Whether to apply a recovery delay.
 
     Returns:
         A string containing the complete JobSet YAML.
@@ -306,6 +318,25 @@ class JobSet:
     params["node_pool_selector"] = node_pool_selector or ""
     params["privileged"] = "true" if self.privileged else "false"
     params["host_pid"] = "true" if self.privileged else "false"
+
+    default_vals = {
+        "restartStrategy": "",
+        "restartPolicy": "",
+        "terminationGracePeriodSeconds": "",
+        "container_prestop_command": 'command: ["/bin/sh", "-c", "true"]',
+    }
+
+    if self.delay_recovery:
+      default_vals.update({
+          "restartStrategy": "restartStrategy: BlockingRecreate",
+          "restartPolicy": "restartPolicy: Never",
+          "terminationGracePeriodSeconds": "terminationGracePeriodSeconds: 350",
+          "container_prestop_command": (
+              'command: ["/bin/sh", "-c", "sleep 300"]'
+          ),
+      })
+
+    params.update(default_vals)
 
     return _TEMPLATE.substitute(params)
 
@@ -416,6 +447,33 @@ class Command:
   ) -> str:
     """Alias for getting just the names, maintaining existing API."""
     return Command.k8s_get_pods(jobset_name, namespace, output)
+
+  @staticmethod
+  def k8s_get_jobset_events_command(
+      jobset_name: str,
+      namespace: str,
+  ) -> str:
+    """Generates a kubectl command to fetch filtered events for a specific
+    JobSet.
+
+    This command customizes the output format using custom columns to only
+    include essential event details and suppresses the default table headers for
+    easier parsing.
+
+    The customized output format consists of the following columns:
+      - LAST_SEEN: The timestamp of the last recorded event.
+      - REASON: The programmatic reason for the event (e.g., SuccessfulCreate).
+      - MESSAGE: A human-readable description of the event.
+    """
+
+    columns = "LAST_SEEN:.lastTimestamp,REASON:.reason,MESSAGE:.message"
+    selector = f"involvedObject.kind=JobSet,involvedObject.name={jobset_name}"
+
+    return (
+        f"kubectl get events -n {namespace} "
+        f"--field-selector {selector} "
+        f"-o custom-columns={columns} --no-headers"
+    )
 
 
 class ReplicatedJobStatus(enum.Enum):
@@ -581,9 +639,9 @@ def run_workload(
     workload_type: Workload,
     jobset_name: str,
     node_pool_selector: str = None,
+    apply_recovery_delay: bool = False,
 ) -> TimeUtil:
-  """
-  Applies the specified YAML file to the GKE cluster.
+  """Applies the specified YAML file to the GKE cluster.
 
   Args:
     node_pool: Configuration object with cluster details.
@@ -591,6 +649,7 @@ def run_workload(
     workload_type: The workload script to execute.
     jobset_name: The name of the JobSet.
     node_pool_selector: The node pool selector to use.
+    apply_recovery_delay: Whether to apply recovery delay.
   Returns:
     The UTC time when the workload was started.
   """
@@ -601,6 +660,7 @@ def run_workload(
         workload_script=workload_type,
         jobset_name=jobset_name,
         node_pool_selector=node_pool_selector,
+        apply_recovery_delay=apply_recovery_delay,
     )
 
     cmd = " && ".join([
@@ -762,8 +822,11 @@ def delete_one_random_pod(
         ),
     ])
 
+    current_time_utc = datetime.datetime.now(datetime.timezone.utc)
     subprocess.run_exec(cmd, env=env)
     logging.info("Successfully initiated deletion for pod: %s", target_pod)
+
+    return TimeUtil.from_datetime(current_time_utc)
 
 
 @task
@@ -896,6 +959,26 @@ def wait_for_jobset_started(
   ]
 
   return all(p > threshold_value for p in last_n_data_points)
+
+
+@task
+def verify_recovery_duration(start_time: TimeUtil, end_time: TimeUtil):
+  """
+  Checks if the time elapsed since start_timestamp is > 60 seconds.
+  """
+
+  duration = end_time.time - start_time.time
+
+  logging.info(f"Start Time: {start_time.to_iso_string()}")
+  logging.info(f"End Time: {end_time.to_iso_string()}")
+  logging.info(f"Recovery Duration: {duration} seconds")
+
+  if duration < 60:
+    raise AirflowFailException(
+        f"Recovery too fast ({duration}s < 60s). "
+        "The 'jobset_time_to_recover' metric requires > 60s to be recorded. "
+        "Failing fast to avoid waiting for a missing metric."
+    )
 
 
 @task.sensor(poke_interval=60, timeout=3600, mode="poke")
@@ -1093,3 +1176,31 @@ def ensure_no_jobset_uptime_data(
     logging.info("Stability period passed with no data detected.")
     return True
   return False
+
+
+@task
+def wait_for_jobset_recovered(
+    node_pool: node_pool_info,
+    jobset_config: JobSet,
+    jobset_name: str,
+) -> TimeUtil:
+  """Executes the event command and extracts the LAST_SEEN timestamp.
+
+  Args:
+    node_pool: Configuration object with cluster details.
+    jobset_config: The JobSet object containing configuration details.
+    jobset_name: The name of the JobSet.
+    namespace: The Kubernetes namespace to query. Defaults to "default".
+
+  Returns:
+    The timestamp string (e.g., '2026-03-04T03:48:47Z') or None if no events
+    found.
+  """
+  # TODO(b/522052592): Revert this workaround once wait_for_recovery supports all DAGs.
+  # Currently sleeping 300s to ensure next task verify_duration always passes.
+  logging.info(
+      "Sleeping for 300 seconds as a temporary workaround for recovery"
+      " detection."
+  )
+  time.sleep(300)
+  return TimeUtil.now()

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -207,7 +207,7 @@ def create(
         f"--reservation={node_pool.reservation}"
     )
   else:
-    command += " --spot "
+    command += " --spot"
 
   if node_pool_selector:
     command += f" --node-labels={NODE_POOL_SELECTOR_KEY}={node_pool_selector}"
@@ -602,7 +602,10 @@ def rollback(node_pool: Info) -> None:
       f"--quiet"
   )
 
+  current_time_utc = datetime.datetime.now(datetime.timezone.utc)
   subprocess.run_exec(command)
+
+  return TimeUtil.from_datetime(current_time_utc)
 
 
 @task.sensor(poke_interval=30, timeout=1200, mode="poke")


### PR DESCRIPTION
# Description

This PR enhances the _TEMPLATE in jobset_util.py by introducing three new parameters: restartStrategy, terminationGracePeriodSeconds, and preStop commands.

The primary goal is to provide granular control over the Pod lifecycle, specifically during disruption events. By utilizing preStop hooks and adjusting terminationGracePeriodSeconds, we can manually inject a delay into the container shutdown process.

Note:
- Partial Fix Disclaimer:
    Please note that this PR does not fully resolve all instances of JobSet TTR metric failures. It specifically addresses one identified root cause: the recovery window being too short for Cloud Monitoring to capture.

- Expected Outcome:
    After merging these changes, we expect the stability of the jobset_ttr_pod_delete DAG to improve significantly. While it may still experience occasional "No Data" gaps due to other underlying ingestion issues (currently under investigation in [b/493761694](http://b/487901640)), it will no longer fail consistently every day. This moves us from a "deterministic failure" to an "intermittent issue" status, allowing for more nuanced debugging.

# Tests
  - Dag Name : jobset_ttr_kill_process
  - Airflow test results: https://39b01025d8504fa5afa7226c9e54d883-dot-us-east1.composer.googleusercontent.com/dags/jobset_ttr_kill_process/grid?dag_run_id=manual__2026-06-10T02%3A54%3A11.442370%2B00%3A00

## Airflow/Composer
- GCP Composer name: `yuna-ml-auto` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`
 
# Required file in GCS bucket [ml-auto-solutions-dag-configs/tpu_observability](gs://ml-auto-solutions-dag-configs/tpu_observability/)
- dag_config.yaml
- jobset_config.yaml


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.