### PR TITLE
fix: Load wrong node location from yaml

### DIFF
--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -34,6 +34,7 @@ from dags.tpu_observability.configs.common import (
 )
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.node_pool_util import NodeOperationSpec
+from xlml.apis import gcs
 
 DAG_ID = "gke_node_pool_status"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
@@ -88,7 +89,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       problematic_node_pool_info = copy.deepcopy(node_pool_info)
-      problematic_node_pool_info.location = f"{node_pool_info.location}-c"
+      yaml_config = gcs.load_yaml_from_gcs(GCS_CONFIG_PATH)
+      wrong_node_loc = (
+          yaml_config.get("dag", {})
+          .get(DAG_ID, {})
+          .get("wrong_node_location", "asia-east1-c")
+      )
+      problematic_node_pool_info.node_location = wrong_node_loc
       problematic_node_pool_info.node_pool_name = (
           f"{node_pool_info.node_pool_name}-x"
       )


### PR DESCRIPTION
The previous implementation of `problematic_node_pool_info` used a hardcoded suffix (`-c`) to corrupt the `location` string for error-path verification. 

With the recent cluster migration to `us-east4`, this logic broke due to two reasons:
1. **Wrong Field Targeted:** The field requiring override is `node_location`, not the main `location`.
2. **Invalid Zone for v6e:** Forcing a non-existent zone prefix or pointing to a zone without v6e support (e.g., `us-east4-c`) caused GKE to throw an `GCE_NOT_FOUND` error, preventing the task from executing its core validation path and properly reaching the intended backend `ERROR` state.

# Description

Please include a summary of relevant context/issue and your changes.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.