### PR TITLE
feat: add Gemma 4 26B E2E pre-training pipeline

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -53,6 +53,16 @@ with models.DAG(
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/train/{run_name}/checkpoints/4/items",
           },
       },
+      "gemma4-26b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/train/{run_name}/checkpoints/4/items",
+          },
+      },
   }
 
   for model, test_config in test_models.items():


### PR DESCRIPTION
# Description

This PR introduces the end-to-end (E2E) pre-training validation pipeline for the **Gemma 4 26B** model in MaxText.

# Tests

Need to wait for [PR](https://github.com/AI-Hypercomputer/maxtext/pull/4278) to be merged then do the testsing.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.