### PR TITLE
Add Gemma 3 multimodal SFT test to multipod post-training DAG

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -63,6 +63,10 @@ with models.DAG(
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_sft.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/sft/{run_name}/checkpoints/5/model_params",
               },
+              "multimodal_sft": {
+                  "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/multimodal_sft/{run_name}/checkpoints/5/model_params",
+              },
               "rl": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/rl/{run_name}/checkpoints/actor/5/model_params",


### PR DESCRIPTION
# Description

This PR adds the `test_gemma3_multimodal_sft.sh` test script under the `multimodal_sft` key in the post-training configuration for `gemma3-4b`. This ensures that multimodal supervised fine-tuning (SFT) is executed alongside regular SFT and RL post-training validations.

# Tests

We run the e2e script without issue.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.