### PR TITLE
feat: Apply `TaskGroupWithTimeout` for TPU Observability DAGs - part 1

### DIFF
--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -21,6 +21,11 @@ from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
+
+
+from airflow.decorators import task
 
 from dags import composer_env
 from dags.common.scheduling_helper.scheduling_helper import (
@@ -41,6 +46,10 @@ from dags.tpu_observability.utils.node_pool_util import Info, NodeOperationSpec
 DAG_ID = "jobset_ttr_drain_restart"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 
 @task
@@ -140,75 +149,102 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        )
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
 
-      select_node = node_pool.draw_random_node.override(task_id="select_node")(
-          node_pool=cluster_info
-      )
+        select_node = node_pool.draw_random_node.override(
+            task_id="select_node"
+        )(node_pool=cluster_info)
 
-      drained_node = node_pool.operate_node.override(task_id="drained_node")(
-          node_pool=cluster_info,
-          operation=NodeOperationSpec.Drain(),
-          node_name=select_node,
-      )
+        drained_node = node_pool.operate_node.override(task_id="drained_node")(
+            node_pool=cluster_info,
+            operation=NodeOperationSpec.Drain(),
+            node_name=select_node,
+        )
 
-      check_nodes_number = check_nodes_number.override(
-          task_id="check_nodes_number"
-      )(
-          pool=cluster_info,
-          drained_node_number=1,
-      )
+        check_nodes_number_task = check_nodes_number.override(
+            task_id="check_nodes_number"
+        )(
+            pool=cluster_info,
+            drained_node_number=1,
+        )
 
-      uncordon_node = node_pool.operate_node.override(task_id="uncordon_node")(
-          node_pool=cluster_info,
-          operation=NodeOperationSpec.Uncordon(),
-          node_name=select_node,
-      )
+        uncordon_node = node_pool.operate_node.override(
+            task_id="uncordon_node"
+        )(
+            node_pool=cluster_info,
+            operation=NodeOperationSpec.Uncordon(),
+            node_name=select_node,
+        )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_metric_upload"
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-      )
+        wait_for_metric_upload = (
+            jobset.wait_for_jobset_ttr_to_be_found.override(
+                task_id="wait_for_metric_upload"
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+            )
+        )
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
-      )
+        chain(
+            *startup.tasks,
+            select_node,
+            drained_node,
+            check_nodes_number_task,
+            uncordon_node,
+            wait_for_metric_upload,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        ).as_teardown(
+            setups=startup.jobset_start_time
+        )
+
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        chain(
+            cleanup_workload,
+            cleanup_node_pool,
+        )
 
       chain(
           selector,
           jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          select_node,
-          drained_node,
-          check_nodes_number,
-          uncordon_node,
-          wait_for_metric_upload,
-          cleanup_workload,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -34,11 +34,17 @@ from dags.tpu_observability.configs.common import (
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
+
 
 DAG_ID = "jobset_ttr_node_pool_resize"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 _DISK_SIZE_INCREMENT = 100
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -108,76 +114,101 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        )
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
 
-      node_pool_resize_start_time = node_pool.update.override(
-          task_id="node_pool_resize"
-      )(
-          node_pool=cluster_info,
-          spec=node_pool.NodePoolUpdateSpec.DiskSize(
-              delta=_DISK_SIZE_INCREMENT
-          ),
-      )
+        node_pool_resize_start_time = node_pool.update.override(
+            task_id="node_pool_resize"
+        )(
+            node_pool=cluster_info,
+            spec=node_pool.NodePoolUpdateSpec.DiskSize(
+                delta=_DISK_SIZE_INCREMENT
+            ),
+        )
 
-      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
-          task_id="wait_for_recovery"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+        wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+            task_id="wait_for_recovery"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      verify_duration = jobset.verify_recovery_duration.override(
-          task_id="verify_recovery_duration"
-      )(
-          start_time=node_pool_resize_start_time,
-          end_time=wait_for_recovery,
-      )
+        verify_duration = jobset.verify_recovery_duration.override(
+            task_id="verify_recovery_duration"
+        )(
+            start_time=node_pool_resize_start_time,
+            end_time=wait_for_recovery,
+        )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found",
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          start_time=node_pool_resize_start_time,
-      )
+        wait_for_metric_upload = (
+            jobset.wait_for_jobset_ttr_to_be_found.override(
+                task_id="wait_for_jobset_ttr_to_be_found",
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+                start_time=node_pool_resize_start_time,
+            )
+        )
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
-      )
+        chain(
+            *startup.tasks,
+            node_pool_resize_start_time,
+            wait_for_recovery,
+            verify_duration,
+            wait_for_metric_upload,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        ).as_teardown(
+            setups=startup.jobset_start_time
+        )
+
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        chain(
+            cleanup_workload,
+            cleanup_node_pool,
+        )
 
       chain(
           selector,
           jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          node_pool_resize_start_time,
-          wait_for_recovery,
-          verify_duration,
-          wait_for_metric_upload,
-          cleanup_workload,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -34,10 +34,22 @@ from dags.tpu_observability.configs.common import (
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
+
 
 DAG_ID = "jobset_ttr_pod_delete"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -105,75 +117,100 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        )
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
 
-      deletion_start_time = jobset.delete_one_random_pod.override(
-          task_id="delete_random_pod"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+        deletion_start_time = jobset.delete_one_random_pod.override(
+            task_id="delete_random_pod"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
-          task_id="wait_for_recovery"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+        wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+            task_id="wait_for_recovery"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      verify_duration = jobset.verify_recovery_duration.override(
-          task_id="verify_recovery_duration"
-      )(
-          start_time=deletion_start_time,
-          end_time=wait_for_recovery,
-      )
+        verify_duration = jobset.verify_recovery_duration.override(
+            task_id="verify_recovery_duration"
+        )(
+            start_time=deletion_start_time,
+            end_time=wait_for_recovery,
+        )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found",
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          start_time=deletion_start_time,
-      )
+        wait_for_metric_upload = (
+            jobset.wait_for_jobset_ttr_to_be_found.override(
+                task_id="wait_for_jobset_ttr_to_be_found",
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+                start_time=deletion_start_time,
+            )
+        )
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
-      )
+        chain(
+            *startup.tasks,
+            deletion_start_time,
+            wait_for_recovery,
+            verify_duration,
+            wait_for_metric_upload,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        ).as_teardown(
+            setups=startup.jobset_start_time
+        )
+
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        chain(
+            cleanup_workload,
+            cleanup_node_pool,
+        )
 
       chain(
           selector,
           jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          deletion_start_time,
-          wait_for_recovery,
-          verify_duration,
-          wait_for_metric_upload,
-          cleanup_workload,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -34,10 +34,22 @@ from dags.tpu_observability.configs.common import (
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
+
 
 DAG_ID = "jobset_rollback_ttr"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -106,71 +118,96 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        )
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
 
-      rollback_node_pool = node_pool.rollback.override(
-          task_id="rollback_node_pool"
-      )(node_pool=cluster_info)
+        rollback_node_pool = node_pool.rollback.override(
+            task_id="rollback_node_pool"
+        )(node_pool=cluster_info)
 
-      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
-          task_id="wait_for_recovery"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+        wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+            task_id="wait_for_recovery"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      verify_duration = jobset.verify_recovery_duration.override(
-          task_id="verify_recovery_duration"
-      )(
-          start_time=rollback_node_pool,
-          end_time=wait_for_recovery,
-      )
+        verify_duration = jobset.verify_recovery_duration.override(
+            task_id="verify_recovery_duration"
+        )(
+            start_time=rollback_node_pool,
+            end_time=wait_for_recovery,
+        )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found",
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          start_time=rollback_node_pool,
-      )
+        wait_for_metric_upload = (
+            jobset.wait_for_jobset_ttr_to_be_found.override(
+                task_id="wait_for_jobset_ttr_to_be_found",
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+                start_time=rollback_node_pool,
+            )
+        )
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
-      )
+        chain(
+            *startup.tasks,
+            rollback_node_pool,
+            wait_for_recovery,
+            verify_duration,
+            wait_for_metric_upload,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        ).as_teardown(
+            setups=startup.jobset_start_time
+        )
+
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        chain(
+            cleanup_workload,
+            cleanup_node_pool,
+        )
 
       chain(
           selector,
           jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          rollback_node_pool,
-          wait_for_recovery,
-          verify_duration,
-          wait_for_metric_upload,
-          cleanup_workload,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -36,10 +36,17 @@ from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.utils.time_util import TimeUtil
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
+
 
 DAG_ID = "jobset_uptime_validation"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 
 @task
@@ -117,67 +124,88 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        )
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
 
-      wait_for_jobset_uptime_data = jobset.wait_for_jobset_uptime_data.override(
-          task_id="wait_for_jobset_uptime_data"
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          jobset_apply_time=startup.jobset_start_time,
-      )
+        wait_for_jobset_uptime_data = (
+            jobset.wait_for_jobset_uptime_data.override(
+                task_id="wait_for_jobset_uptime_data"
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+                jobset_apply_time=startup.jobset_start_time,
+            )
+        )
 
-      clean_up_workload = jobset.end_workload.override(
-          task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
-      )
+        clean_up_workload = jobset.end_workload.override(
+            task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        ).as_teardown(
+            setups=startup.jobset_start_time
+        )
 
-      jobset_clear_time = get_current_time.override(
-          task_id="get_current_time"
-      )()
+        jobset_clear_time = get_current_time.override(
+            task_id="get_current_time"
+        )()
 
-      ensure_no_jobset_uptime_data = (
-          jobset.ensure_no_jobset_uptime_data.override(
-              task_id="ensure_no_jobset_uptime_data"
-          )
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          jobset_clear_time=jobset_clear_time,
-          # Wait 5 minutes to confirm no data has been detected.
-          wait_time_seconds=300,
-      )
+        ensure_no_jobset_uptime_data = (
+            jobset.ensure_no_jobset_uptime_data.override(
+                task_id="ensure_no_jobset_uptime_data"
+            )
+        )(
+            node_pool=cluster_info,
+            jobset_name=jobset_name,
+            jobset_clear_time=jobset_clear_time,
+            # Wait 5 minutes to confirm no data has been detected.
+            wait_time_seconds=300,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+        chain(
+            *startup.tasks,
+            wait_for_jobset_uptime_data,
+            clean_up_workload,
+            jobset_clear_time,
+            ensure_no_jobset_uptime_data,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
 
       chain(
           selector,
           jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          wait_for_jobset_uptime_data,
-          clean_up_workload,
-          jobset_clear_time,
-          ensure_no_jobset_uptime_data,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -30,6 +30,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     MachineConfigMap,
@@ -39,6 +40,10 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 DAG_ID = "multi_host_nodepool_rollback"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -100,38 +105,58 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create.override(owner=test_owner.QUINN_M)(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool",
+            owner=test_owner.QUINN_M,
+        )(node_pool=node_pool_info)
 
-      wait_node_pool_available = node_pool.wait_for_availability(
-          node_pool=node_pool_info, availability=True
-      )
+        wait_node_pool_available = node_pool.wait_for_availability.override(
+            task_id="wait_node_pool_available"
+        )(node_pool=node_pool_info, availability=True)
 
-      rollback_node_pool = node_pool.rollback(node_pool=node_pool_info)
+        chain(create_node_pool, wait_node_pool_available)
 
-      wait_node_pool_unavailable = node_pool.wait_for_availability(
-          node_pool=node_pool_info, availability=False
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        rollback_node_pool = node_pool.rollback.override(
+            task_id="rollback_node_pool"
+        )(node_pool=node_pool_info)
 
-      # A successful rollback means the availability will return to True.
-      # The end of the rollback marks the start the availability, so
-      # the client side should see the state change, and update the metric.
-      wait_node_pool_recovered = node_pool.wait_for_availability(
-          node_pool=node_pool_info, availability=True
-      )
+        wait_node_pool_unavailable = node_pool.wait_for_availability.override(
+            task_id="wait_node_pool_unavailable"
+        )(node_pool=node_pool_info, availability=False)
 
-      cleanup_node_pool = node_pool.delete.override(
-          trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        # A successful rollback means the availability will return to True.
+        # The end of the rollback marks the start the availability, so
+        # the client side should see the state change, and update the metric.
+        wait_node_pool_recovered = node_pool.wait_for_availability.override(
+            task_id="wait_node_pool_recovered"
+        )(node_pool=node_pool_info, availability=True)
+
+        chain(
+            rollback_node_pool,
+            wait_node_pool_unavailable,
+            wait_node_pool_recovered,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool",
+            trigger_rule=TriggerRule.ALL_DONE,
+        )(node_pool=node_pool_info)
 
       chain(
-          create_node_pool,
-          wait_node_pool_available,
-          rollback_node_pool,
-          wait_node_pool_unavailable,
-          wait_node_pool_recovered,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -28,6 +28,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     MachineConfigMap,
@@ -39,6 +40,10 @@ from xlml.apis import gcs
 DAG_ID = "gke_node_pool_status"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -100,107 +105,119 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           f"{node_pool_info.node_pool_name}-x"
       )
 
-      task_id = "create_node_pool"
-      create_node_pool = node_pool.create.override(
-          task_id=task_id,
-          owner=test_owner.YUNA_T,
-      )(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        task_id = "create_node_pool"
+        create_node_pool = node_pool.create.override(
+            task_id=task_id,
+            owner=test_owner.YUNA_T,
+        )(
+            node_pool=node_pool_info,
+        )
 
-      task_id = "wait_for_provisioning"
-      wait_for_provisioning = node_pool.wait_for_status.override(
-          task_id=task_id
-      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+        # Intentionally create a node pool with problematic configurations
+        # to validate that it enters the ERROR state.
+        task_id = "create_problematic_node_pool_info"
+        create_problematic_node_pool_info = node_pool.create.override(
+            task_id=task_id,
+            owner=test_owner.YUNA_T,
+        )(
+            node_pool=problematic_node_pool_info,
+            # The failure is intentionally ignored because we want to validate
+            # that the status of the node pool (which fails to be created) is
+            # "ERROR".
+            ignore_failure=True,
+        )
 
-      task_id = "wait_for_running"
-      wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+        task_id = "wait_for_provisioning"
+        wait_for_provisioning = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-      task_id = "select_random_node"
-      select_random_node = node_pool.draw_random_node.override(task_id=task_id)(
-          node_pool=node_pool_info
-      )
+        task_id = "wait_for_running"
+        wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.RUNNING
+        )
 
-      task_id = "delete_node"
-      delete_node = node_pool.operate_node.override(task_id=task_id)(
-          node_pool=node_pool_info,
-          operation=NodeOperationSpec.Delete(),
-          node_name=select_random_node,
-      )
+        chain(create_node_pool, wait_for_provisioning, wait_for_running)
 
-      # TODO: add a check that the node count decreases after deletion.
-      # kubectl is not available here since this DAG has no workload or jobset.
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        task_id = "select_random_node"
+        select_random_node = node_pool.draw_random_node.override(
+            task_id=task_id
+        )(node_pool=node_pool_info)
 
-      task_id = "wait_for_repair"
-      wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RECONCILING
-      )
+        task_id = "delete_node"
+        delete_node = node_pool.operate_node.override(task_id=task_id)(
+            node_pool=node_pool_info,
+            operation=NodeOperationSpec.Delete(),
+            node_name=select_random_node,
+        )
 
-      task_id = "wait_for_recovered"
-      wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+        task_id = "wait_for_repair"
+        wait_for_repair = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.RECONCILING
+        )
 
-      task_id = "delete_node_pool"
-      delete_node_pool = node_pool.delete.override(task_id=task_id)(
-          node_pool=node_pool_info
-      )
+        task_id = "wait_for_recovered"
+        wait_for_recovered = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      task_id = "wait_for_stopping"
-      wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.STOPPING
-      )
+        task_id = "delete_node_pool"
+        delete_node_pool = node_pool.delete.override(task_id=task_id)(
+            node_pool=node_pool_info
+        )
 
-      task_id = "cleanup_node_pool"
-      cleanup_node_pool = node_pool.delete.override(
-          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        task_id = "wait_for_stopping"
+        wait_for_stopping = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.STOPPING
+        )
 
-      # Intentionally create a node pool with problematic configurations
-      # to validate that it enters the ERROR state.
-      task_id = "create_problematic_node_pool_info"
-      create_problematic_node_pool_info = node_pool.create.override(
-          task_id=task_id,
-          owner=test_owner.YUNA_T,
-      )(
-          node_pool=problematic_node_pool_info,
-          # The failure is intentionally ignored because we want to validate
-          # that the status of the node pool (which fails to be created) is
-          # "ERROR".
-          ignore_failure=True,
-      )
+        task_id = "wait_for_error"
+        validate_problematic_node_pool_enter_error_state = (
+            node_pool.wait_for_status.override(task_id=task_id)(
+                node_pool=problematic_node_pool_info,
+                status=node_pool.Status.ERROR,
+            )
+        )
 
-      task_id = "wait_for_error"
-      wait_for_error = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=problematic_node_pool_info, status=node_pool.Status.ERROR
-      )
+        chain(
+            select_random_node,
+            delete_node,
+            wait_for_repair,
+            wait_for_recovered,
+            delete_node_pool,
+            wait_for_stopping,
+        )
 
-      task_id = "cleanup_wrong_node_pool"
-      cleanup_wrong_node_pool = node_pool.delete.override(
-          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=problematic_node_pool_info).as_teardown(
-          setups=create_problematic_node_pool_info,
-      )
+        chain(
+            create_problematic_node_pool_info,
+            validate_problematic_node_pool_enter_error_state,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        task_id = "cleanup_node_pool"
+        cleanup_node_pool = node_pool.delete.override(
+            task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
+
+        task_id = "cleanup_wrong_node_pool"
+        cleanup_wrong_node_pool = node_pool.delete.override(
+            task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=problematic_node_pool_info)
 
       chain(
-          create_node_pool,
-          wait_for_provisioning,
-          wait_for_running,
-          select_random_node,
-          delete_node,
-          wait_for_repair,
-          wait_for_recovered,
-          delete_node_pool,
-          wait_for_stopping,
-          cleanup_node_pool,
-      )
-
-      chain(
-          create_problematic_node_pool_info,
-          wait_for_error,
-          cleanup_wrong_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -27,6 +27,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     MachineConfigMap,
@@ -37,6 +38,10 @@ DAG_ID = "node_pool_ttr_disk_size"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 _DISK_SIZE_INCREMENT = 50
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 with models.DAG(
     dag_id=DAG_ID,
@@ -89,45 +94,58 @@ with models.DAG(
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=node_pool_info
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(node_pool=node_pool_info)
 
-      wait_for_provisioning = node_pool.wait_for_status.override(
-          task_id="wait_for_provisioning"
-      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+        wait_for_provisioning = node_pool.wait_for_status.override(
+            task_id="wait_for_provisioning"
+        )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-      wait_for_running = node_pool.wait_for_status.override(
-          task_id="wait_for_running"
-      )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
+        wait_for_running = node_pool.wait_for_status.override(
+            task_id="wait_for_running"
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      update_start_time = node_pool.update.override(task_id="update_node_pool")(
-          node_pool=node_pool_info,
-          spec=node_pool.NodePoolUpdateSpec.DiskSize(
-              delta=_DISK_SIZE_INCREMENT
-          ),
-      )
+        chain(create_node_pool, wait_for_provisioning, wait_for_running)
 
-      wait_for_recovered = node_pool.wait_for_status.override(
-          task_id="wait_for_recovered"
-      )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        update_start_time = node_pool.update.override(
+            task_id="update_node_pool"
+        )(
+            node_pool=node_pool_info,
+            spec=node_pool.NodePoolUpdateSpec.DiskSize(
+                delta=_DISK_SIZE_INCREMENT
+            ),
+        )
 
-      wait_for_ttr = node_pool.wait_for_ttr(
-          node_pool=node_pool_info, operation_start_time=update_start_time
-      )
+        wait_for_recovered = node_pool.wait_for_status.override(
+            task_id="wait_for_recovered"
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        wait_for_ttr = node_pool.wait_for_ttr(
+            node_pool=node_pool_info, operation_start_time=update_start_time
+        )
+
+        chain(update_start_time, wait_for_recovered, wait_for_ttr)
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
 
       chain(
-          create_node_pool,
-          wait_for_provisioning,
-          wait_for_running,
-          update_start_time,
-          wait_for_recovered,
-          wait_for_ttr,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -27,6 +27,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     MachineConfigMap,
@@ -36,6 +37,10 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 DAG_ID = "node_pool_ttr_update_label"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 with models.DAG(
     dag_id=DAG_ID,
@@ -87,50 +92,62 @@ with models.DAG(
           tpu_topology=config.tpu_topology,
       )
 
-      task_id = "create_node_pool"
-      create_node_pool = node_pool.create.override(task_id=task_id)(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        task_id = "create_node_pool"
+        create_node_pool = node_pool.create.override(task_id=task_id)(
+            node_pool=node_pool_info,
+        )
 
-      task_id = "wait_for_provisioning"
-      wait_for_provisioning = node_pool.wait_for_status.override(
-          task_id=task_id
-      )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
+        task_id = "wait_for_provisioning"
+        wait_for_provisioning = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.PROVISIONING)
 
-      task_id = "wait_for_running"
-      wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+        task_id = "wait_for_running"
+        wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+            node_pool=node_pool_info, status=node_pool.Status.RUNNING
+        )
 
-      task_id = "update_node_pool_label"
-      update_node_pool_label = node_pool.update.override(task_id=task_id)(
-          node_pool=node_pool_info,
-          spec=node_pool.NodePoolUpdateSpec.Label(delta=labels_to_update),
-      )
+        chain(create_node_pool, wait_for_provisioning, wait_for_running)
 
-      task_id = "wait_for_recovered"
-      wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
-          node_pool=node_pool_info, status=node_pool.Status.RUNNING
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        task_id = "update_node_pool_label"
+        update_node_pool_label = node_pool.update.override(task_id=task_id)(
+            node_pool=node_pool_info,
+            spec=node_pool.NodePoolUpdateSpec.Label(delta=labels_to_update),
+        )
 
-      task_id = "wait_for_ttr"
-      wait_for_ttr = node_pool.wait_for_ttr.override(task_id=task_id)(
-          node_pool=node_pool_info, operation_start_time=update_node_pool_label
-      )
+        task_id = "wait_for_recovered"
+        wait_for_recovered = node_pool.wait_for_status.override(
+            task_id=task_id
+        )(node_pool=node_pool_info, status=node_pool.Status.RUNNING)
 
-      task_id = "cleanup_node_pool"
-      cleanup_node_pool = node_pool.delete.override(
-          task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=create_node_pool,
-      )
+        task_id = "wait_for_ttr"
+        wait_for_ttr = node_pool.wait_for_ttr.override(task_id=task_id)(
+            node_pool=node_pool_info,
+            operation_start_time=update_node_pool_label,
+        )
+
+        chain(update_node_pool_label, wait_for_recovered, wait_for_ttr)
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        task_id = "cleanup_node_pool"
+        cleanup_node_pool = node_pool.delete.override(
+            task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
 
       chain(
-          create_node_pool,
-          wait_for_provisioning,
-          wait_for_running,
-          update_node_pool_label,
-          wait_for_recovered,
-          wait_for_ttr,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -29,6 +29,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     MachineConfigMap,
@@ -38,6 +39,10 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 DAG_ID = "gke_node_pool_label_update"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -88,43 +93,59 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      create_node_pool = node_pool.create.override(
-          task_id="create_node_pool",
-          owner=test_owner.YUNA_T,
-      )(
-          node_pool=node_pool_info,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool",
+            owner=test_owner.YUNA_T,
+        )(
+            node_pool=node_pool_info,
+        )
 
-      wait_for_availability = node_pool.wait_for_availability.override(
-          task_id="wait_for_initial_availability"
-      )(node_pool=node_pool_info, availability=True)
+        wait_for_availability = node_pool.wait_for_availability.override(
+            task_id="wait_for_initial_availability"
+        )(node_pool=node_pool_info, availability=True)
 
-      update_node_pool_label = node_pool.update.override(
-          task_id="update_node_pool_label"
-      )(
-          node_pool=node_pool_info,
-          spec=node_pool.NodePoolUpdateSpec.Label(delta=labels_to_update),
-      )
+        chain(create_node_pool, wait_for_availability)
 
-      wait_for_unavailable = node_pool.wait_for_availability.override(
-          task_id="wait_for_unavailability_after_update"
-      )(node_pool=node_pool_info, availability=False)
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        update_node_pool_label = node_pool.update.override(
+            task_id="update_node_pool_label"
+        )(
+            node_pool=node_pool_info,
+            spec=node_pool.NodePoolUpdateSpec.Label(delta=labels_to_update),
+        )
 
-      wait_node_pool_recovered = node_pool.wait_for_availability.override(
-          task_id="wait_for_recovery"
-      )(node_pool=node_pool_info, availability=True)
+        wait_for_unavailable = node_pool.wait_for_availability.override(
+            task_id="wait_for_unavailability_after_update"
+        )(node_pool=node_pool_info, availability=False)
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=node_pool_info).as_teardown(
-          setups=[create_node_pool],
-      )
+        wait_node_pool_recovered = node_pool.wait_for_availability.override(
+            task_id="wait_for_recovery"
+        )(node_pool=node_pool_info, availability=True)
+
+        chain(
+            update_node_pool_label,
+            wait_for_unavailable,
+            wait_node_pool_recovered,
+        )
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          is_teardown=True,
+      ) as post_test:
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=node_pool_info)
 
       chain(
-          create_node_pool,
-          wait_for_availability,
-          update_node_pool_label,
-          wait_for_unavailable,
-          wait_node_pool_recovered,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -553,7 +553,7 @@ def _query_status_metric(node_pool: Info) -> Status:
   return Status.from_str(latest_status)
 
 
-@task.sensor(poke_interval=60, timeout=600, mode="poke")
+@task.sensor(poke_interval=60, timeout=600, mode="poke", retries=0)
 def wait_for_status(
     node_pool: Info,
     status: Status,
@@ -608,7 +608,7 @@ def rollback(node_pool: Info) -> None:
   return TimeUtil.from_datetime(current_time_utc)
 
 
-@task.sensor(poke_interval=30, timeout=1200, mode="poke")
+@task.sensor(poke_interval=30, timeout=1200, mode="poke", retries=0)
 def wait_for_availability(
     node_pool: Info,
     availability: bool,
@@ -684,7 +684,7 @@ def wait_for_availability(
   return availability == state
 
 
-@task.sensor(poke_interval=30, timeout=3600, mode="poke")
+@task.sensor(poke_interval=30, timeout=3600, mode="poke", retries=0)
 def wait_for_ttr(
     node_pool: Info,
     operation_start_time: TimeUtil,


### PR DESCRIPTION
Integrates `TaskGroupWithTimeout` directly into all TPU Observability DAGs that do not depend on Kubernetes JobSets. This provides strict, shared deadline timeout enforcement across distinct stages of GKE node pool validation.

Specifically:
1. Configures stage-specific timeouts for all modified DAGs:
   - `PRE_TEST_TIMEOUT`: 10 minutes (for GKE provisioning and availability setup)
   - `POST_TEST_TIMEOUT`: 10 minutes (for GKE teardown and cleanup)
   - `TEST_TIMEOUT`: Evaluates dynamically as `DAGRUN_TIMEOUT - 20 mins`

2. Restructures the following 5 DAGs into three separate `TaskGroupWithTimeout` blocks:
   - `dags/tpu_observability/node_pool_status.py`
   - `dags/tpu_observability/node_pool_ttr_disk_size.py`
   - `dags/tpu_observability/node_pool_ttr_update_label.py`
   - `dags/tpu_observability/multi_host_nodepool_rollback_dag.py`
   - `dags/tpu_observability/update_node_pool_label.py`

3. Refactors GKE node pool operations into:
   - `pre_test`: Handles node pool creation and waiting for provisioning/running.
   - `test`: Executes the core test mutation and verification flow.
   - `post_test`: Manages cleanup/teardown of GKE node pools (using `is_teardown=True` to guarantee execution even if upstream stages timeout or fail).

* refactor(tpu-observability): wrap TPU observability DAGs with TaskGroupWithTimeout

Refactors five TPU observability DAGs to use TaskGroupWithTimeout for proper timeout management during pre-test setup, test execution, and post-test teardown. This aligns their implementation pattern with node_pool_status.py.

Specifically, this change:
- Imports TaskGroupWithTimeout in each DAG.
- Defines PRE_TEST_TIMEOUT, TEST_TIMEOUT, and POST_TEST_TIMEOUT at the module level.
- Groups tasks into pre_test, test, and post_test TaskGroupWithTimeout blocks.
- Chains tasks sequentially within each group and updates the overall DAG chain.

Modified DAGs:
- dags/tpu_observability/jobset_ttr_drain_restart.py
- dags/tpu_observability/jobset_ttr_node_pool_resize.py
- dags/tpu_observability/jobset_ttr_pod_delete.py
- dags/tpu_observability/jobset_ttr_rollback.py
- dags/tpu_observability/jobset_uptime_validation.py

# Description

Please include a summary of relevant context/issue and your changes.

# Tests

Please describe the tests that you ran on Cloud VM to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.