### PR TITLE
Add Gemma 3 LoRA test to multipod post-training DAG

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -67,6 +67,10 @@ with models.DAG(
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/multimodal_sft/{run_name}/checkpoints/5/model_params",
               },
+              "lora": {
+                  "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/lora/{run_name}/checkpoints/5/model_params",
+              },
               "rl": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/rl/{run_name}/checkpoints/actor/5/model_params",


### PR DESCRIPTION
# Description

This PR adds the `lora` test configuration for `gemma3-4b` in the `maxtext_e2e_tpu_post_training` DAG. It runs the end-to-end test script `tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh` to validate the Gemma 3 LoRA post-training pipeline.

# Tests

Ran the end-to-end test script directly on TPU VM:
```bash
bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.
