### PR TITLE
fix: Reduce CI noise by wrapping `Variable.get`

### DIFF
--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,2 +1,3 @@
 pylint==3.1.0
 pyink==23.10.0
+semgrep

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -18,8 +18,8 @@ import datetime as dt
 import enum
 from typing import TypeAlias
 
-from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags.common.vm_resource import TpuVersion, Zone
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 
 
 class DayOfWeek(enum.Enum):

--- a/dags/dashboard/airflow_to_bq_export.py
+++ b/dags/dashboard/airflow_to_bq_export.py
@@ -1,9 +1,13 @@
-from airflow import DAG
+"""DAG for exporting Airflow metadata to BigQuery."""
+
 from datetime import datetime
+
+from airflow import DAG
+from airflow.models.baseoperator import chain
 from airflow.models.param import Param
-from airflow.models import Variable
 
 from dags import composer_env
+from dags.common.quarantined_tests import safe_get_from_variable
 from dags.dashboard.configs import export_config
 
 # Scheduled time
@@ -11,19 +15,21 @@ SCHEDULED_TIME = "15 0 * * *" if composer_env.is_prod_env() else None
 
 
 # Load default config values from Airflow Variables
-DEFAULT_GCP_PROJECT_ID = Variable.get(
-    "gcp_target_project_id_default", default_var=""
+DEFAULT_GCP_PROJECT_ID = safe_get_from_variable(
+    "gcp_target_project_id_default", ""
 )
-DEFAULT_BQ_DATASET_ID = Variable.get(
-    "bq_target_dataset_id_default", default_var=""
+DEFAULT_BQ_DATASET_ID = safe_get_from_variable(
+    "bq_target_dataset_id_default", ""
 )
-DEFAULT_GCS_BUCKET = Variable.get("gcs_target_bucket_default", default_var="")
+DEFAULT_GCS_BUCKET = safe_get_from_variable("gcs_target_bucket_default", "")
 
 params = {
     "target_project_id": Param(
         type="string",
         title="Target GCP Project ID",
-        description="The Google Cloud Project ID where the data will be cloned.",
+        description=(
+            "The Google Cloud Project ID where the data will be cloned."
+        ),
         default=DEFAULT_GCP_PROJECT_ID,
     ),
     "target_bigquery_dataset": Param(
@@ -58,11 +64,11 @@ with DAG(
     # Define export task to run export_table Python function
     export_task = export_config.get_export_operator(source_table)
     destination_table = (
-        "{{ params['target_project_id'] }}.{{ params['target_bigquery_dataset'] }}.%s"
-        % source_table.table_name
+        "{{ params['target_project_id'] }}."
+        "{{ params['target_bigquery_dataset'] }}.%s" % source_table.table_name
     )
     load_task = export_config.get_gcs_to_bq_operator(
         source_table, "{{ params['target_gcs_bucket'] }}", destination_table
     )
     # Set task dependency: export -> load
-    export_task >> load_task
+    chain(export_task, load_task)

--- a/dags/dashboard/xlml_to_buganizer.py
+++ b/dags/dashboard/xlml_to_buganizer.py
@@ -1,23 +1,27 @@
+"""
+A DAG that periodically queries GKE cluster health
+and logs anomalies to a Google Sheet.
+"""
 # ================================================================
 # Step 0: Imports & Global Config
 # ================================================================
 import enum
 import json
 import logging
-from typing import List, Any, Dict
 from datetime import datetime, timezone
+from typing import Any, Dict, List
 
 import google
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models.param import Param
-from airflow.models import Variable
 from airflow.operators.python import get_current_context
 from airflow.providers.google.suite.hooks.sheets import GSheetsHook
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery, container_v1
 
 from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
 
 # --- Airflow DAG Schedule ---
 SCHEDULED_TIME = "0 */4 * * *"  # Per 4 hours
@@ -28,7 +32,7 @@ DEFAULT_DATASET_ID = "amy_xlml_poc_prod"
 
 # --- Google Sheets Config ---
 GSPREAD_INSERT_ENABLED = True
-DEFAULT_GSPREAD_SHEET_ID = Variable.get("buganizer_sheet_id", default_var="")
+DEFAULT_GSPREAD_SHEET_ID = safe_get_from_variable("buganizer_sheet_id", "")
 GSPREAD_WORKSHEET_NAME = "unhealthy_clusters"
 
 
@@ -89,7 +93,8 @@ def insert_cluster_status_lists(
     #  Cannot query cluster info without location
     if not location:
       raise NotFound(
-          "The requested resource can not be found on the server without location."
+          "The requested resource can not be found on the server "
+          "without location."
       )
     info = get_cluster_status(credentials, project_name, location, cluster_name)
     cluster_status = info["status"]
@@ -160,7 +165,7 @@ def insert_cluster_status_lists(
             now_utc=now_utc,
         )
     )
-  except Exception as e:
+  except Exception as e:  # pylint: disable=broad-exception-caught
     logging.info(
         f"Error fetching details for {project_name}/{cluster_name}: {e}"
     )
@@ -203,8 +208,9 @@ def insert_gspread_rows(rows: List[List[str]], sheet_id: str):
         f"Inserting {len(rows)} rows into Google Sheet ID: {sheet_id}..."
     )
     if len(sheet_id) == 0:
-      raise Exception(
-          f"Sheet ID is empty. Please insert Sheet ID or set 'buganizer_sheet_id' in Variables"
+      raise Exception(  # pylint: disable=broad-exception-raised
+          "Sheet ID is empty. Please insert Sheet ID or "
+          "set 'buganizer_sheet_id' in Variables"
       )
     hook.append_values(
         spreadsheet_id=sheet_id,
@@ -214,7 +220,7 @@ def insert_gspread_rows(rows: List[List[str]], sheet_id: str):
         value_input_option="RAW",
     )
     logging.info(f"Successfully appended {len(rows)} rows to Google Sheet.")
-  except Exception as e:
+  except Exception as e:  # pylint: disable=broad-exception-caught
     logging.error(f"An error occurred while writing to Google Sheet: {e}")
 
 
@@ -337,26 +343,38 @@ params = {
     "source_bq_project_id": Param(
         type="string",
         title="Source BigQuery GCP Project ID",
-        description="The Source Google Cloud Project ID where the big query belong to",
+        description=(
+            "The Source Google Cloud Project ID "
+            "where the big query belong to"
+        ),
         default=DEFAULT_PROJECT_ID,
     ),
     "source_bq_dataset_id": Param(
         type="string",
         title="Source Big Query Dataset ID",
-        description="The Source BigQuery dataset ID where the data would be queried",
+        description=(
+            "The Source BigQuery dataset ID where the data would be queried"
+        ),
         default=DEFAULT_DATASET_ID,
     ),
     "target_gsheet_id": Param(
         type="string",
         title="Target Google Sheet ID",
-        description="The Target Google Sheet ID where the Buganizer issue information are stored",
+        description=(
+            "The Target Google Sheet ID where the Buganizer "
+            "issue information are stored"
+        ),
         default=DEFAULT_GSPREAD_SHEET_ID,
     ),
 }
 
 with DAG(
     dag_id="xlml_to_buganizer",
-    description="A DAG that periodically queries the status of GKE clusters to monitor their health, and writes the collected data as rows into the target Google Sheet.",
+    description=(
+        "A DAG that periodically queries the status of GKE clusters "
+        "to monitor their health, and writes the collected data as rows "
+        "into the target Google Sheet."
+    ),
     start_date=datetime(2025, 9, 3),
     schedule=SCHEDULED_TIME,
     catchup=False,

--- a/dags/mantaray/run_mantaray_jobs.py
+++ b/dags/mantaray/run_mantaray_jobs.py
@@ -21,12 +21,12 @@ import yaml
 import os
 import dags.common.vm_resource as resource
 from airflow import models
-from airflow.models import Variable
 from airflow.utils.task_group import TaskGroup
 from airflow.decorators import task as task_decorators
 from airflow.decorators import task_group
 from airflow.hooks.subprocess import SubprocessHook
 from dags import composer_env
+from dags.common.quarantined_tests import safe_get_from_variable
 from dags.pytorch_xla.configs import pytorchxla_torchbench_config as config
 from dags.common import test_owner
 from dags.common.vm_resource import AcceleratorType, GpuVersion, TpuVersion, Region, Zone, Project, RuntimeVersion, V6E_GCE_NETWORK, V6E_GCE_SUBNETWORK
@@ -202,7 +202,7 @@ if composer_env.is_prod_env() or composer_env.is_dev_env():
     print("Test run rows:", test_run_rows)
     bigquery_metric.insert(test_run_rows)
 
-  HF_TOKEN_LLaMA3_8B = Variable.get("HF_TOKEN_LLaMA3_8B", None)
+  HF_TOKEN_LLaMA3_8B = safe_get_from_variable("HF_TOKEN_LLaMA3_8B", None)
 
   # commands for vllm nightly benchmarking
   def run_test_code_on_persistent_TPUVM(

--- a/dags/maxtext_pathways/pw_mcjax_elastic.py
+++ b/dags/maxtext_pathways/pw_mcjax_elastic.py
@@ -15,14 +15,14 @@
 """DAG definition for running MaxText Pathways Elastic benchmarks on GKE."""
 
 import datetime
-import time
-from absl import logging
 
+from absl import logging
 from airflow import models
 from airflow.decorators import task
-from airflow.utils.trigger_rule import TriggerRule
+from airflow.models.baseoperator import chain
 from airflow.models.taskmixin import DAGNode
 from airflow.utils.task_group import TaskGroup
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
 from dags.common import test_owner
@@ -292,7 +292,7 @@ def worker_pod_interruption(
       )
 
       if previous_cycle_tail:
-        previous_cycle_tail >> wait_for_step
+        chain(previous_cycle_tail, wait_for_step)
       previous_cycle_tail = wait_for_slices_active
     return group
 
@@ -402,14 +402,14 @@ with models.DAG(
       cluster_name=fetched_params["cluster_name"],
   )
 
-  (
-      fetched_params
-      >> calculated_params
-      >> generated_cmds
-      >> start_recipe
-      >> interruption_task
-      >> wait_for_workload_complete
-      >> clean_up_recipe
+  chain(
+      fetched_params,
+      calculated_params,
+      generated_cmds,
+      start_recipe,
+      interruption_task,
+      wait_for_workload_complete,
+      clean_up_recipe,
   )
 
 replica_params = elastic_params.copy()
@@ -537,12 +537,12 @@ with models.DAG(
       cluster_name=fetched_params["cluster_name"],
   )
 
-  (
-      fetched_params
-      >> calculated_params
-      >> generated_cmds
-      >> start_recipe
-      >> interruption_task
-      >> wait_for_workload_complete
-      >> clean_up_recipe
+  chain(
+      fetched_params,
+      calculated_params,
+      generated_cmds,
+      start_recipe,
+      interruption_task,
+      wait_for_workload_complete,
+      clean_up_recipe,
   )

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -23,11 +23,12 @@ from airflow import models
 from airflow.models.param import Param
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import XpkClusters
 from dags.multipod.configs import gke_config
 
 # HF token retrieved from Airflow Variables for secure credential management
-HF_TOKEN = models.Variable.get("HF_TOKEN", None)
+HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
 def get_workload_name(model, mode, length=6):

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -20,10 +20,11 @@ from airflow import models
 from airflow.models.param import Param
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import XpkClusters
 from dags.multipod.configs import gke_config
 
-HF_TOKEN = models.Variable.get("HF_TOKEN", None)
+HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 with models.DAG(
     dag_id="maxtext_e2e_tpu_pre_training",

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -19,7 +19,7 @@ import datetime
 from airflow import models
 from airflow.utils.task_group import TaskGroup
 from dags import composer_env
-from dags.common.quarantined_tests import QuarantineTests
+from dags.common.quarantined_tests import QuarantineTests, safe_get_from_variable
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import gke_config
@@ -27,7 +27,7 @@ from xlml.utils import name_format
 
 # Run once a day at 4 am UTC (8 pm PST)
 SCHEDULED_TIME = "0 7 * * *" if composer_env.is_prod_env() else None
-HF_TOKEN = models.Variable.get("HF_TOKEN", None)
+HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
 with models.DAG(

--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -18,13 +18,14 @@ import datetime
 from airflow import models
 from dags import composer_env, gcs_bucket
 from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)
 SCHEDULED_TIME = '0 10 * * *' if composer_env.is_prod_env() else None
-HF_TOKEN = models.Variable.get('HF_TOKEN', None)
+HF_TOKEN = safe_get_from_variable('HF_TOKEN', None)
 
 with models.DAG(
     dag_id='maxtext_sft_trainer',

--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_nightly_supported_config.py
@@ -17,10 +17,10 @@
 import time
 import datetime
 from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
 from xlml.apis import gcp_config, metric_config, task, test_config
 from dags import gcs_bucket
 from dags.solutions_team.configs.tensorflow import common
-from airflow.models import Variable
 from dags.common.vm_resource import TpuVersion, Project, RuntimeVersion
 from typing import List
 
@@ -52,7 +52,7 @@ def get_tf_keras_config(
   benchmark_id = f"{keras_test_name}-v{tpu_version.value}-{tpu_cores}"
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  tpu_name = safe_get_from_variable(benchmark_id, None) if is_pod else "local"
   env_variable = (
       common.export_env_variables(tpu_name, is_pod, is_pjrt)
       + " TF_CPP_MIN_LOG_LEVEL=0  TPU_STDERR_LOG_LEVEL=0 TPU_MIN_LOG_LEVEL=0 "
@@ -148,7 +148,7 @@ def get_tf_resnet_config(
   benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  tpu_name = safe_get_from_variable(benchmark_id, None) if is_pod else "local"
   env_variable = common.export_env_variables(tpu_name, is_pod, is_pjrt)
 
   epoch = time.time()
@@ -216,7 +216,7 @@ def get_tf_dlrm_v1_config(
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   test_name = "tf_dlrm_criteo"
   benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  tpu_name = safe_get_from_variable(benchmark_id, None) if is_pod else "local"
   is_v5p = tpu_version == TpuVersion.V5P
   env_variable = (
       common.export_env_variables(tpu_name, is_pod, is_pjrt, is_v5p_sc=is_v5p)
@@ -320,7 +320,7 @@ def get_tf_dlrm_v1_config(
   model_dir = "/tmp"
 
   params_override["trainer"]["pipeline_sparse_and_dense_execution"] = "true"
-  tpu_id = Variable.get(benchmark_id, default_var=None)
+  tpu_id = safe_get_from_variable(benchmark_id, None)
   # TODO (ericlefort): Replace the model_dir with this line when the var is available
   # model_dir = metric_config.SshEnvVars.GCS_OUTPUT.value + f"/dlrm/v5p/{benchmark_id}"
   epoch = time.time()
@@ -388,7 +388,7 @@ def get_tf_dlrm_v2_config(
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   test_name = "tf_dlrm_criteo"
   benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  tpu_name = safe_get_from_variable(benchmark_id, None) if is_pod else "local"
   is_v5p = tpu_version == TpuVersion.V5P
   env_variable = common.export_env_variables(
       tpu_name, is_pod, is_pjrt, is_v5p_sc=is_v5p
@@ -513,7 +513,7 @@ def get_tf_dlrm_v2_config(
   model_dir = "/tmp"
 
   params_override["trainer"]["pipeline_sparse_and_dense_execution"] = "true"
-  tpu_id = Variable.get(benchmark_id, default_var=None)
+  tpu_id = safe_get_from_variable(benchmark_id, None)
   # TODO (ericlefort): Replace the model_dir with this line when the var is available
   # model_dir = metric_config.SshEnvVars.GCS_OUTPUT.value + f"/dlrm/v5p/{benchmark_id}"
   epoch = time.time()

--- a/dags/solutions_team/configs/tensorflow/solutionsteam_tf_release_supported_config.py
+++ b/dags/solutions_team/configs/tensorflow/solutionsteam_tf_release_supported_config.py
@@ -19,10 +19,10 @@ import datetime
 import time
 from datetime import date
 from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
 from xlml.apis import gcp_config, metric_config, task, test_config
 from dags import gcs_bucket
 from dags.solutions_team.configs.tensorflow import common
-from airflow.models import Variable
 from dags.common.vm_resource import TpuVersion, Project, RuntimeVersion
 
 
@@ -103,7 +103,7 @@ def get_tf_resnet_config(
   benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
   # Add default_var to pass DAG check
   # TODO(ranran): replace Variable.get() to XCOM when it applies
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  tpu_name = safe_get_from_variable(benchmark_id, None) if is_pod else "local"
   env_variable = common.export_env_variables(tpu_name, is_pod, is_pjrt)
   run_model_cmds = (
       "sudo chmod -R 777 /tmp/",
@@ -167,7 +167,7 @@ def get_tf_dlrm_config(
   # TODO(ranran): replace Variable.get() to XCOM when it applies
   test_name = "tf_dlrm_criteo"
   benchmark_id = f"{test_name}-v{tpu_version.value}-{tpu_cores}"
-  tpu_name = Variable.get(benchmark_id, default_var=None) if is_pod else "local"
+  tpu_name = safe_get_from_variable(benchmark_id, None) if is_pod else "local"
   is_v5p = tpu_version == TpuVersion.V5P
   env_variable = common.export_env_variables(
       tpu_name, is_pod, is_pjrt, is_v5p_sc=is_v5p
@@ -293,7 +293,7 @@ def get_tf_dlrm_config(
   model_dir = "/tmp"
 
   params_override["trainer"]["pipeline_sparse_and_dense_execution"] = "true"
-  tpu_id = Variable.get(benchmark_id, default_var=None)
+  tpu_id = safe_get_from_variable(benchmark_id, None)
   # TODO (ericlefort): Replace the model_dir with this line when the var is available
   # model_dir = metric_config.SshEnvVars.GCS_OUTPUT.value + f"/dlrm/v5p/{benchmark_id}"
   epoch = time.time()

--- a/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
+++ b/dags/solutions_team/configs/vllm/vllm_benchmark_config.py
@@ -19,8 +19,9 @@ import datetime
 import json
 import os
 from typing import Dict
+
+from dags.common.quarantined_tests import safe_get_from_variable
 from xlml.apis import gcp_config, metric_config, task, test_config
-from airflow.models import Variable
 from dags.common import test_owner
 from dags.multipod.configs import common
 from dags.common.vm_resource import MachineVersion, ImageFamily, ImageProject, GpuVersion, TpuVersion, Project, RuntimeVersion, Zone
@@ -29,7 +30,7 @@ from dags.common.vm_resource import MachineVersion, ImageFamily, ImageProject, G
 PROJECT_NAME = Project.CLOUD_ML_AUTO_SOLUTIONS.value
 RUNTIME_IMAGE = RuntimeVersion.TPU_UBUNTU2204_BASE.value
 GCS_SUBFOLDER_PREFIX = test_owner.Team.SOLUTIONS_TEAM.value
-HF_TOKEN = Variable.get("HF_TOKEN", None)
+HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 VLLM_TPU_DOCKER_IMAGE = "gcr.io/cloud-tpu-v2-images/vllm-tpu-nightly:latest"
 VLLM_TPU_CONTAINER = "vllm-tpu-container"
 

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -16,18 +16,24 @@
 
 
 import datetime
+
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
+
 from dags import composer_env
-from dags.common.quarantined_tests import QuarantineTests
 from dags.common import test_owner
-from dags.common.vm_resource import XpkClusters, DockerImage
+from dags.common.quarantined_tests import (
+    QuarantineTests,
+    safe_get_from_variable,
+)
+from dags.common.vm_resource import DockerImage, XpkClusters
 from dags.multipod.configs import gke_config
 from xlml.utils import name_format
 
 # Run once a day at 1 am UTC (5 pm PST)
 SCHEDULED_TIME = "30 1 * * *" if composer_env.is_prod_env() else None
-HF_TOKEN = models.Variable.get("HF_TOKEN", None)
+HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
 with models.DAG(
@@ -87,14 +93,16 @@ with models.DAG(
 
   unchained_tests = []
   for model, test_scripts_details in test_models_tpu.items():
-    for image in docker_image.keys():
+    for image, image_config in docker_image.items():
       training_tpu = gke_config.get_gke_config(
           time_out_in_min=test_scripts_details["time_out_in_min"],
           test_name=f"{test_name_prefix}_{image}_{model}",
           run_model_cmds=(
-              f"export HF_TOKEN={HF_TOKEN}; export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/{test_scripts_details['script_name']}.sh",
+              f"export HF_TOKEN={HF_TOKEN}; "
+              "export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
+              f"bash tests/end_to_end/{test_scripts_details['script_name']}.sh"
           ),
-          docker_image=docker_image[image],
+          docker_image=image_config,
           test_owner=test_owner.SHUNING_J,
           cluster=test_scripts_details["cluster"],
       ).run_with_quarantine(quarantine_task_group)
@@ -102,7 +110,7 @@ with models.DAG(
 
   # stable_tpu >> nightly_tpu
   for i in range(len(unchained_tests) - 1):
-    unchained_tests[i] >> unchained_tests[i + 1]
+    chain(unchained_tests[i], unchained_tests[i + 1])
 
   # Chained tests
   multicluster_test_models = {
@@ -133,49 +141,51 @@ with models.DAG(
   }
 
   def convert_checkpoint_and_run_training(
-      test_group_id,
-      test_name_prefix,
-      image,
-      docker_image,
-      model,
-      test_scripts_details,
+      test_group_id_val,
+      test_name_prefix_str,
+      image_tag,
+      docker_image_config,
+      model_id,
+      test_scripts_details_list,
   ):
-    with TaskGroup(group_id=test_group_id, prefix_group_id=False) as group:
-      test_name = f"{test_name_prefix}_{image}_{model}"
+    with TaskGroup(group_id=test_group_id_val, prefix_group_id=False):
+      test_name = f"{test_name_prefix_str}_{image_tag}_{model_id}"
       shared_gcs_location = name_format.generate_gcs_folder_location.override(
-          task_id=f"{test_group_id}_generate_gcs_folder_location"
+          task_id=f"{test_group_id_val}_generate_gcs_folder_location"
       )(
           gcs_subfolder,
-          test_group_id,
+          test_group_id_val,
       )
       conversion_cpu = gke_config.get_maxtext_cpu_end_to_end_gke_config(
-          time_out_in_min=test_scripts_details[0]["time_out_in_min"],
+          time_out_in_min=test_scripts_details_list[0]["time_out_in_min"],
           test_name=test_name,
           run_model_cmds=(
-              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/{test_scripts_details[0]['script_name']}.sh",
+              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/"
+              f"{test_scripts_details_list[0]['script_name']}.sh",
           ),
-          docker_image=docker_image,
+          docker_image=docker_image_config,
           test_owner=test_owner.SHUNING_J,
-          cluster=test_scripts_details[0]["cluster"],
+          cluster=test_scripts_details_list[0]["cluster"],
       ).run(gcs_location=shared_gcs_location)
-      training_tpu = gke_config.get_gke_config(
-          time_out_in_min=test_scripts_details[1]["time_out_in_min"],
+      training_tpu_task = gke_config.get_gke_config(
+          time_out_in_min=test_scripts_details_list[1]["time_out_in_min"],
           test_name=test_name,
           run_model_cmds=(
-              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/{test_scripts_details[1]['script_name']}.sh",
+              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/"
+              f"{test_scripts_details_list[1]['script_name']}.sh",
           ),
-          docker_image=docker_image,
+          docker_image=docker_image_config,
           test_owner=test_owner.SHUNING_J,
           cluster=test_scripts_details[1]["cluster"],
       ).run(gcs_location=shared_gcs_location)
-      return conversion_cpu, training_tpu
+      return conversion_cpu, training_tpu_task
 
   tests = []
   for model, test_scripts_details in multicluster_test_models.items():
     gcs_subfolder = (
         f"{test_owner.Team.JAX_MODELS_AND_PERFORMANCE.value}/maxtext"
     )
-    for image in docker_image.keys():
+    for image, image_config in docker_image.items():
       test_group_id = "chained_tests" + "_" + model + "_" + image
       if QuarantineTests.is_quarantined(test_group_id):
         with quarantine_task_group:
@@ -183,7 +193,7 @@ with models.DAG(
               test_group_id,
               test_name_prefix,
               image,
-              docker_image[image],
+              image_config,
               model,
               test_scripts_details,
           )
@@ -192,7 +202,7 @@ with models.DAG(
             test_group_id,
             test_name_prefix,
             image,
-            docker_image[image],
+            image_config,
             model,
             test_scripts_details,
         )
@@ -201,4 +211,4 @@ with models.DAG(
 
     # stable_cpu >> stable_tpu >> nightly_cpu >> nightly_tpu
     for i in range(len(tests) - 1):
-      tests[i] >> tests[i + 1]
+      chain(tests[i], tests[i + 1])

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,6 +19,9 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
+echo "[code-style] Running Semgrep static analysis..."
+semgrep --config scripts/semgrep-rules.yaml --error
+
 for folder in "${FOLDERS_TO_FORMAT[@]}"
 do
   pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff

--- a/scripts/semgrep-rules.yaml
+++ b/scripts/semgrep-rules.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: block-native-variable-get
+    # blacklist
+    pattern-either:
+      - pattern: airflow.models.Variable.get(...)
+    message: "[code-style] native Variable.get() is prohibited. Please use safe_get_from_variable() instead."
+    languages: [python]
+    severity: ERROR
+    # whitelist
+    paths:
+      exclude:
+        - "dags/common/quarantined_tests.py"

--- a/xlml/utils/ssh.py
+++ b/xlml/utils/ssh.py
@@ -17,9 +17,10 @@
 import dataclasses
 
 from airflow.decorators import task
-from airflow.models import Variable
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+
+from dags.common.quarantined_tests import safe_get_from_variable
 
 
 @dataclasses.dataclass
@@ -59,9 +60,9 @@ def generate_ssh_keys() -> SshKeys:
 def obtain_persist_ssh_keys() -> SshKeys:
   """Obtain persistent SSH keys and user from Airflow Variables."""
   try:
-    user = Variable.get("os-login-ssh-user")
-    private_key = Variable.get("os-login-ssh-private-key")
-    public_key = Variable.get("os-login-ssh-public-key")
+    user = safe_get_from_variable("os-login-ssh-user", None)
+    private_key = safe_get_from_variable("os-login-ssh-private-key", None)
+    public_key = safe_get_from_variable("os-login-ssh-public-key", None)
   except KeyError as e:
     raise ValueError(
         f"Required Airflow Variable {e} is not set. "


### PR DESCRIPTION
## Description

### Summary of Context & Issue
During GitHub Actions (CI) pipeline execution, native Airflow methods and cloud-dependent functions cause blocking errors due to the lack of an active database connection or cloud permissions. Specifically:
1. **Airflow Variables DB Connection Failure:** Native `Variable.get()` calls attempt to connect to the metadata database, causing the CI pipeline to throw errors during top-level DAG parsing.

### Changes
1. **Centralized Wrapper Refactoring:** Refactored multiple DAGs and configuration files to replace native `Variable.get()` with the existing `safe_get_from_variable()` wrapper, avoiding unexpected database connection attempts during CI parsing.
2. **CI Block:** Enhanced the `safe_get_from_variable()` function to block execution by raising a RuntimeError when triggered inside GitHub Actions. This implements a strict fail-fast check that prevents misconfigurations and enforces the team policy of using explicit mocks within test suites rather than relying on fallback default values.
3. **Code Clean-up:** Simplified function calls by removing redundant keyword arguments (`default_var=`) where positional arguments are sufficient, improving readability.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.