### PR TITLE
Fix: Add missing trailing comma to run_model_cmds tuple `maxtext_moe_tpu_e2e.py`

### DIFF
--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -100,7 +100,7 @@ with models.DAG(
           run_model_cmds=(
               f"export HF_TOKEN={HF_TOKEN}; "
               "export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
-              f"bash tests/end_to_end/{test_scripts_details['script_name']}.sh"
+              f"bash tests/end_to_end/{test_scripts_details['script_name']}.sh",
           ),
           docker_image=image_config,
           test_owner=test_owner.SHUNING_J,


### PR DESCRIPTION
# Description

Adds a missing trailing comma to the  run_model_cmds  argument passed to  get_gke_config(...)
  within  maxtext_moe_tpu_e2e.py .

# Why was this necessary?
  Without the trailing comma, the  run_model_cmds  parameter was evaluated as a single raw string
  rather than a Python tuple. Consequently, the GKE launcher treated it as an iterable and
  attempted to execute the Bash commands character-by-character, causing the cluster job to fail
  immediately during execution.

# Tests

Ran `bash scripts/local-airflow.sh dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py` locally to verify DAG compilation is correct.
Failing Production Run: https://screenshot.googleplex.com/9hhbDYJxeMzFvyR
Test Local Run: https://screenshot.googleplex.com/9R5nXqWc4WbksZw

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.