### PR TITLE
Fix: Add 2 more missing trailing commas to run_model_cmds tuple

### DIFF
--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -161,7 +161,7 @@ with models.DAG(
           test_name=test_name,
           run_model_cmds=(
               f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/"
-              f"{test_scripts_details_list[0]['script_name']}.sh"
+              f"{test_scripts_details_list[0]['script_name']}.sh",
           ),
           docker_image=docker_image_config,
           test_owner=test_owner.SHUNING_J,
@@ -172,7 +172,7 @@ with models.DAG(
           test_name=test_name,
           run_model_cmds=(
               f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/"
-              f"{test_scripts_details_list[1]['script_name']}.sh"
+              f"{test_scripts_details_list[1]['script_name']}.sh",
           ),
           docker_image=docker_image_config,
           test_owner=test_owner.SHUNING_J,


### PR DESCRIPTION
### Description

Converts the `run_model_cmds` to a tuple in 2 more locations which seem to have been removed in #1316.

### Why was this necessary?
Without the trailing comma, the run_model_cmds parameter was evaluated as a single raw string
rather than a Python tuple. Consequently, the GKE launcher treated it as an iterable and
attempted to execute the Bash commands character-by-character, causing the cluster job to fail
immediately during execution.

#1313 fixed this issue for the unchained tests.

Bug: b/535225894

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.