### PR TITLE
feat: Add Llama3.1-70b and Gemma4-26b E2E training pipeline

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -53,6 +53,7 @@ with models.DAG(
         ),
     },
 ) as dag:
+  # pylint: disable=line-too-long
   test_models = {
       "gemma3-4b": {
           "checkpoint_conversion": {
@@ -79,18 +80,55 @@ with models.DAG(
               },
           },
       },
+      "gemma4-26b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/sft/{run_name}/checkpoints/5/model_params",
+                  "to_hf_flags": "false false",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/rl/{run_name}/checkpoints/actor/5/model_params",
+                  "to_hf_flags": "false false",
+              },
+          },
+      },
+      "llama3_1_70b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/sft/{run_name}/checkpoints/5/model_params",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/rl/{run_name}/checkpoints/actor/5/model_params",
+              },
+          },
+      },
   }
+  # pylint: enable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
       run_name = "post-{{ ts_nodash }}"
 
-      convert_to_maxtext_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-          f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",
-      )
+      convert_to_maxtext_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
       convert_to_maxtext_task = gke_config.get_gke_config(
           time_out_in_min=60,
-          test_name=f"convert-to-maxtext",
+          test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
@@ -134,8 +172,13 @@ with models.DAG(
           model_path = mode_test_config["maxtext_ckpt_path"].format(
               run_name=run_name
           )
-          convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-              f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path} {to_hf_flags}",
+          convert_to_huggingface_cmd = (
+              f"export HF_TOKEN={HF_TOKEN}",
+              'export HF_HOME="/dev/shm/hf_cache"',
+              'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+          ) + (
+              f"{test_config['checkpoint_conversion']['to_huggingface']} "
+              f"{run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(
               time_out_in_min=60,

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -43,6 +43,7 @@ with models.DAG(
         ),
     },
 ) as dag:
+  # pylint: disable=line-too-long
   test_models = {
       "gemma3-4b": {
           "checkpoint_conversion": {
@@ -54,15 +55,38 @@ with models.DAG(
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/train/{run_name}/checkpoints/4/items",
           },
       },
+      "gemma4-26b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/train/{run_name}/checkpoints/4/items",
+          },
+      },
+      "llama3_1-70b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/train/{run_name}/checkpoints/4/items",
+          },
+      },
   }
+  # pylint: enable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
       run_name = "pre-{{ ts_nodash }}"
 
-      convert_to_maxtext_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-          f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",
-      )
+      convert_to_maxtext_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
       convert_to_maxtext_task = gke_config.get_gke_config(
           time_out_in_min=60,
           test_name="convert-to-maxtext",
@@ -87,8 +111,13 @@ with models.DAG(
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
       )
-      convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-          f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path}",
+      convert_to_huggingface_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (
+          f"{test_config['checkpoint_conversion']['to_huggingface']} "
+          f"{run_name} {model_path}",
       )
       convert_to_huggingface_task = gke_config.get_gke_config(
           time_out_in_min=60,


### PR DESCRIPTION
# Description
According to this ticket: [b/528418808](https://b.corp.google.com/issues/528418808) and [b/528440611](https://b.corp.google.com/issues/528440611)
This PR introduces the end-to-end (E2E) pre-training validation pipeline for the **Llama3.1-70b** and **Gemma4-26b**model in MaxText.

# Tests

Do the manual tests with xpk.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.