### PR TITLE
add DeepSeek-V4 end to end tests to xlml dag

### DIFF
--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -69,13 +69,14 @@ SHARON_Y = "Shuang-cnt"
 # MLCompass
 ORTI_B = "ortibazar"
 
-# Sparsity & Diffusion DevX
+# JAX Models and Performance
 RAN_R = "RissyRan"
 PARAM_B = "parambole"
 KUNJAN_P = "coolkp"
 MICHELLE_Y = "michelle-yooh"
 SHUNING_J = "shuningjin"
 ROHAN_B = "Rohan-Bierneni"
+SNEHAL_V = "snehalv2002"
 
 # Inference
 XIANG_S = "sixiang-google"

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -65,6 +65,12 @@ with models.DAG(
 
   # Unchained tests
   test_models_tpu = {
+      "deepseek4-284b": {
+          "script_name": "tpu/deepseek/v4-284b/2_test_deepseek",
+          "cluster": XpkClusters.TPU_V5P_128_CLUSTER,
+          "time_out_in_min": 180,
+          "owner": test_owner.SNEHAL_V,
+      },
       "deepseek32-671b": {
           "script_name": "tpu/deepseek/v3.2-671b/2_test_deepseek",
           "cluster": XpkClusters.TPU_V5P_128_CLUSTER,


### PR DESCRIPTION
# Description

Adding logit matching and decoding tests for deepseek4-284b to xlml.

# Tests

Verified `maxtext/tests/end_to_end/tpu/deepseek/v4-284b/2_test_deepseek.sh` before adding to XLML dag. Logs: https://cloudlogging.app.goo.gl/ox3QKj9JmgH2dSEx7

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.