### PR TITLE
feat: Add GPT-OSS-20b and Qwen2-VL-2b to MaxText TPU E2E pipelines

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -126,7 +126,38 @@ with models.DAG(
               },
               "rl": {
                   "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh",
-                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/rl/{run_name}/checkpoints/actor/4/items",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/rl/{run_name}/checkpoints/actor/5/model_params",
+              },
+          },
+      },
+      "qwen3-vl-2b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_hf.sh",
+          },
+          "post_training": {
+              "multimodal_sft": {
+                  "command": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-vl-2b/multimodal/sft/{run_name}/checkpoints/4/items",
+                  "to_hf_flags": "true false",
+              },
+          },
+      },
+      "gpt-oss-20b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/sft/{run_name}/checkpoints/5/model_params",
+                  "to_hf_flags": "true",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/rl/{run_name}/checkpoints/actor/5/model_params",
+                  "to_hf_flags": "true",
               },
           },
       },
@@ -147,7 +178,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -197,11 +228,11 @@ with models.DAG(
               f"{run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(
-              time_out_in_min=60,
+              time_out_in_min=90,
               test_name="convert-to-huggingface",
               run_model_cmds=convert_to_huggingface_cmd,
               docker_image="{{ params.docker_image }}",
-              cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+              cluster=XpkClusters.TPU_V5P_128_CLUSTER,
               test_owner=test_owner.SURBHI_J,
           ).run(skip_post_process=True, priority="very-high")
 

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -178,7 +178,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -232,7 +232,7 @@ with models.DAG(
               test_name="convert-to-huggingface",
               run_model_cmds=convert_to_huggingface_cmd,
               docker_image="{{ params.docker_image }}",
-              cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+              cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
               test_owner=test_owner.SURBHI_J,
           ).run(skip_post_process=True, priority="very-high")
 

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -84,6 +84,18 @@ with models.DAG(
               "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/train/{run_name}/checkpoints/4/items",
           },
+          "to_hf_flags": "false true",
+      },
+      "gpt-oss-20b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/train/{run_name}/checkpoints/4/items",
+          },
+          "to_hf_flags": "true",
       },
   }
   # pylint: enable=line-too-long
@@ -102,7 +114,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -121,20 +133,22 @@ with models.DAG(
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
       )
+      to_hf_flags = test_config.get("to_hf_flags", "")
+
       convert_to_huggingface_cmd = (
           f"export HF_TOKEN={HF_TOKEN}",
           'export HF_HOME="/dev/shm/hf_cache"',
           'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
       ) + (
           f"{test_config['checkpoint_conversion']['to_huggingface']} "
-          f"{run_name} {model_path}",
+          f"{run_name} {model_path} {to_hf_flags}",
       )
       convert_to_huggingface_task = gke_config.get_gke_config(
-          time_out_in_min=60,
+          time_out_in_min=90,
           test_name="convert-to-huggingface",
           run_model_cmds=convert_to_huggingface_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -114,7 +114,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -148,7 +148,7 @@ with models.DAG(
           test_name="convert-to-huggingface",
           run_model_cmds=convert_to_huggingface_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 


### PR DESCRIPTION
# Description
According to this ticket: [b/534456996](https://buganizer.corp.google.com/issues/534456996) and [b/538209143](https://b.corp.google.com/issues/538209143)
This PR introduces the end-to-end (E2E) pre-training validation pipeline for the **GPT-OSS-20b** and **Qwen2-VL-2b**model in MaxText.

## Key Additions & Updates:
  
- Added E2E testing pipelines for `gpt-oss-20b` (pre-training, SFT, and RL).
- Added E2E testing pipelines for `qwen3-vl-2b` (multimodal SFT).
- Introduced `to_hf_flags` logic propagation into the E2E pre-training DAG to support distinct HuggingFace conversion requirements (e.g., passing `scan_layer=true`).
- Fixed the reinforcement learning (RL) maxtext checkpoint path for the `qwen3-30b-a3b-base` E2E test.

# Tests

Do the manual tests with xpk.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.