### PR TITLE
feat(dags): Migrate MaxText E2E TPU DAGs to mlperf-v5p with dynamic cluster override

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -272,6 +272,14 @@ class XpkClusters:
       project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
       zone=Zone.EUROPE_WEST4_B.value,
   )
+  TPU_V5P_MLPERF_CLUSTER = XpkClusterConfig(
+      name="mlperf-v5p",
+      device_version=TpuVersion.V5P,
+      core_count=8,
+      project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+      zone=Zone.EUROPE_WEST4_B.value,
+      namespace="automation-testing",
+  )
   TPU_V5E_256_CLUSTER = XpkClusterConfig(
       name="v5e-256-bodaborg-europe-west4",
       device_version=TpuVersion.V5E,

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -59,6 +59,7 @@ def get_gke_config(
       num_slices=num_slices,
       cluster_name=cluster.name,
       docker_image=docker_image,
+      namespace=cluster.namespace,
   )
   job_metric_config = user_specified_job_metric_config
   if job_metric_config is None:

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -147,7 +147,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -173,7 +173,9 @@ with models.DAG(
             training_task = gke_config.get_gke_config(
                 time_out_in_min=60,
                 num_slices=1,
-                cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+                cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(
+                    core_count=128
+                ),
                 test_name=get_workload_name(model, mode),
                 run_model_cmds=training_cmd,
                 docker_image="{{ params.docker_image }}",
@@ -201,7 +203,7 @@ with models.DAG(
               test_name="convert-to-huggingface",
               run_model_cmds=convert_to_huggingface_cmd,
               docker_image="{{ params.docker_image }}",
-              cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+              cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
               test_owner=test_owner.SURBHI_J,
           ).run(skip_post_process=True, priority="very-high")
 

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -102,7 +102,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -114,7 +114,7 @@ with models.DAG(
           test_name="training",
           run_model_cmds=training_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(core_count=128),
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -134,7 +134,7 @@ with models.DAG(
           test_name="convert-to-huggingface",
           run_model_cmds=convert_to_huggingface_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -512,6 +512,7 @@ class XpkTask(BaseTask):
           workload_id=workload_id,
           dry_run=False,
           last_node=last_node,
+          namespace=self.task_test_config.namespace,
       )
 
       wait_for_workload_completion = xpk.wait_for_workload_completion.override(
@@ -521,6 +522,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
 
       clean_up_workload = xpk.clean_up_workload(
@@ -529,6 +531,7 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
+          namespace=self.task_test_config.namespace,
       ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
 
       _ = (
@@ -576,6 +579,7 @@ class XpkTask(BaseTask):
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
           max_restart=max_restart,
+          namespace=self.task_test_config.namespace,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
           timeout=self.workload_provision_timeout.total_seconds()
@@ -584,6 +588,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
       wait_for_workload_to_reach_step = (
           xpk.wait_for_workload_reach_step.override(
@@ -594,6 +599,7 @@ class XpkTask(BaseTask):
               region=gke.zone_to_region(self.task_gcp_config.zone),
               cluster_name=self.task_test_config.cluster_name,
               expect_reach_to_step=str(expect_reach_to_step),
+              namespace=self.task_test_config.namespace,
           )
       )
 
@@ -700,7 +706,8 @@ class XpkTask(BaseTask):
         )
         self.task_metric_config.profile.file_location = profile_file_location
         run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
+            use_pathways=use_pathways,
+            xpk_branch=xpk_branch,
         )
         _ = (
             run_name
@@ -710,7 +717,8 @@ class XpkTask(BaseTask):
         )
       else:
         run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
+            use_pathways=use_pathways,
+            xpk_branch=xpk_branch,
         )
         _ = (
             run_name
@@ -773,6 +781,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
 
       clean_up_workload = xpk.clean_up_workload(
@@ -781,6 +790,7 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
+          namespace=self.task_test_config.namespace,
       ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
 
       _ = (
@@ -827,6 +837,7 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
+          namespace=self.task_test_config.namespace,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
           timeout=self.workload_provision_timeout.total_seconds()
@@ -835,6 +846,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
       _ = run_workload >> wait_for_workload_start
       return group

--- a/xlml/apis/test_config.py
+++ b/xlml/apis/test_config.py
@@ -266,6 +266,7 @@ class CpuGkeTest(TestConfig[Cpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
+  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:
@@ -301,6 +302,7 @@ class TpuGkeTest(TestConfig[Tpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
+  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:
@@ -343,6 +345,7 @@ class GpuXpkTest(TestConfig[Gpu]):
     run_model_cmds: List of commands to run the model under test.
     startup_time_out_in_sec: Timeout to start up the pod.
     num_slices: Number of GPU slices.
+    namespace: Kubernetes namespace of the cluster.
   """
 
   test_name: str
@@ -352,6 +355,7 @@ class GpuXpkTest(TestConfig[Gpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
+  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:

--- a/xlml/apis/xpk_cluster_config.py
+++ b/xlml/apis/xpk_cluster_config.py
@@ -15,7 +15,7 @@
 """Config file for XPK cluster."""
 
 import dataclasses
-from typing import Union
+from typing import Optional, Union
 
 
 @dataclasses.dataclass
@@ -28,6 +28,7 @@ class XpkClusterConfig:
     core_count: Core count of the cluster
     project: Project of the cluster
     zone: Zone of the cluster
+    namespace: Kubernetes namespace of the cluster
   """
 
   name: str
@@ -35,3 +36,18 @@ class XpkClusterConfig:
   core_count: int
   project: str
   zone: str
+  namespace: str = 'default'
+
+  def override(
+      self,
+      *,
+      core_count: Optional[int] = None,
+      namespace: Optional[str] = None,
+  ) -> 'XpkClusterConfig':
+    """Returns a copy of this cluster config with specified fields overridden."""
+    changes = {}
+    if core_count is not None:
+      changes['core_count'] = core_count
+    if namespace is not None:
+      changes['namespace'] = namespace
+    return dataclasses.replace(self, **changes)

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -44,7 +44,7 @@ LOGGING_URL_FORMAT = (
     + "resource.labels.project_id%3D%22{project}%22%0A"
     + "resource.labels.location%3D%22{region}%22%0A"
     + "resource.labels.cluster_name%3D%22{cluster}%22%0A"
-    + "resource.labels.namespace_name%3D%22default%22%0A"
+    + "resource.labels.namespace_name%3D%22{namespace}%22%0A"
     + "labels.k8s-pod%2Fjobset_sigs_k8s_io%2F"
     + "jobset-name%3D%22{workload_id}%22%20severity%3E%3DDEFAULT;"
     + "storageScope=project;duration=P7D?e=13803378&"
@@ -115,6 +115,7 @@ def run_workload(
     max_restart: int = 0,
     # to avoid workload preemption by manual tests.
     priority: str = "high",
+    namespace: str = "default",
 ):
   """Run workload through xpk tool."""
 
@@ -154,6 +155,9 @@ def run_workload(
         f" --priority={priority}"
         f" --env {metric_config.SshEnvVars.GCS_OUTPUT.name}={gcs_path}"
     )
+
+    if namespace and namespace != "default":
+      workload_create_cmd += f" --namespace={namespace}"
 
     if ramdisk_directory and not use_pathways:
       workload_create_cmd += f" --ramdisk-directory={ramdisk_directory}"
@@ -209,13 +213,17 @@ def _get_core_api_client(
 
 
 def _list_workload_pods(
-    core_api: k8s_client.CoreV1Api, workload_id: str
+    core_api: k8s_client.CoreV1Api,
+    workload_id: str,
+    namespace: str = "default",
 ) -> k8s_client.V1PodList:
   """List all pods for the given workload."""
-  logging.info(f"Getting pods for workload_id: {workload_id}")
+  logging.info(
+      f"Getting pods for workload_id: {workload_id} in namespace: {namespace}"
+  )
   pods = core_api.list_namespaced_pod(
       label_selector=f"jobset.sigs.k8s.io/jobset-name={workload_id}",
-      namespace="default",
+      namespace=namespace,
   )
   return pods
 
@@ -235,13 +243,17 @@ def _get_batch_api_client(
 
 
 def _get_workload_job(
-    batch_api: k8s_client.BatchV1Api, workload_id: str
+    batch_api: k8s_client.BatchV1Api,
+    workload_id: str,
+    namespace: str = "default",
 ) -> k8s_client.V1Job:
   """Get the job for a given workload."""
-  logging.info(f"Getting job for workload_id: {workload_id}")
+  logging.info(
+      f"Getting job for workload_id: {workload_id} in namespace: {namespace}"
+  )
   jobs = batch_api.list_namespaced_job(
       label_selector=f"jobset.sigs.k8s.io/jobset-name={workload_id}",
-      namespace="default",
+      namespace=namespace,
   )
   if len(jobs.items) == 0:
     logging.info(f"Getting job for workload_id: {workload_id}")
@@ -293,11 +305,15 @@ def _log_workload_pod_statuses(workload_id: str, pods) -> None:
 
 @task.sensor(poke_interval=60, timeout=600, mode="reschedule")
 def wait_for_workload_start(
-    workload_id: str, project_id: str, region: str, cluster_name: str
+    workload_id: str,
+    project_id: str,
+    region: str,
+    cluster_name: str,
+    namespace: str = "default",
 ) -> bool:
   """Check if the workload has started."""
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   _log_workload_pod_statuses(workload_id, pods)
   print(f"Found {len(pods.items)} pods for workload {workload_id}")
@@ -306,11 +322,15 @@ def wait_for_workload_start(
 
 @task.sensor(poke_interval=60, timeout=600, mode="reschedule")
 def wait_for_workload_completion(
-    workload_id: str, project_id: str, region: str, cluster_name: str
+    workload_id: str,
+    project_id: str,
+    region: str,
+    cluster_name: str,
+    namespace: str = "default",
 ) -> bool:
   """Check the workload status."""
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   _log_workload_pod_statuses(workload_id, pods)
 
@@ -320,7 +340,7 @@ def wait_for_workload_completion(
     # Pathways jobs delete all pods on failure so we must also check if the job
     # is complete
     batch_api = _get_batch_api_client(project_id, region, cluster_name)
-    job = _get_workload_job(batch_api, workload_id)
+    job = _get_workload_job(batch_api, workload_id, namespace=namespace)
     if job is None:
       logging.info(
           f"No pods or jobs were found for workload selector: {workload_id}"
@@ -367,6 +387,7 @@ def wait_for_workload_completion(
         project=project_id,
         region=region,
         cluster=cluster_name,
+        namespace=namespace,
         workload_id=workload_id,
     )
     logging.info(f"Link to logs: {url}")
@@ -382,6 +403,7 @@ def clean_up_workload(
     zone: str,
     cluster_name: str,
     xpk_branch: str = MAIN_BRANCH,
+    namespace: str = "default",
 ) -> bool:
   """Delete workload."""
   with tempfile.TemporaryDirectory() as tmpdir:
@@ -391,6 +413,8 @@ def clean_up_workload(
         f" --cluster={cluster_name} --workload={workload_id}"
         f" --project={project_id} --zone={zone}"
     )
+    if namespace and namespace != "default":
+      workload_delete_cmd += f" --namespace={namespace}"
 
     cmds = get_xpk_setup_cmd(tmpdir, xpk_branch)
     cmds.append(workload_delete_cmd)
@@ -411,13 +435,14 @@ def wait_for_workload_reach_step(
     cluster_name: str,
     workload_id: str,
     expect_reach_to_step: str,
+    namespace: str = "default",
 ) -> bool:
   """
   Watch any given training pod, check the given step is already reach before
   deleting a node
   """
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   if not pods.items:
     logging.info("No pods found for workload selector: %s.", workload_id)
@@ -471,10 +496,11 @@ def _find_target_pod_node(
     cluster_name: str,
     workload_id: str,
     last_node: bool = False,
+    namespace: str = "default",
 ) -> str:
   """find the node name for the workload."""
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
   pod_node_pairs = []
   pattern = re.compile(r".*slice-job-(\d+)-(\d+)-\w+")
 
@@ -515,6 +541,7 @@ def delete_node(
     project: str,
     dry_run: bool = False,
     last_node: bool = False,
+    namespace: str = "default",
 ) -> None:
   """Delete node."""
   delete_info = _find_target_pod_node(
@@ -523,6 +550,7 @@ def delete_node(
       cluster_name,
       workload_id,
       last_node,
+      namespace=namespace,
   )
   node_name = delete_info["node"]
   # Delete the specified compute instance.
@@ -554,13 +582,16 @@ def delete_node(
 # TODO(cienet): naming/description, interrupt <-> SIGILL?
 @task
 def interrupt_worker_pod(
-    workload_id: str, cluster_name: str, region: str, project_id: str
+    workload_id: str,
+    cluster_name: str,
+    region: str,
+    project_id: str,
+    namespace: str = "default",
 ):
   """
   Authenticates with the GKE cluster and sends SIGILL to worker pod 0-1.
   """
 
-  namespace = "default"
   target_worker_index = "0-1"
 
   # TODO(cienet): use Kubernetes API instead of kubectl CLI + raw command
@@ -601,13 +632,14 @@ def check_last_logs(
     cluster_name: str,
     workload_id: str,
     expect_log_contains: str,
+    namespace: str = "default",
 ) -> bool:
   """
   Checks if the last 45 seconds of a running pod's logs
   contain a specific substring.
   """
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   if not pods.items:
     logging.info("No pods found for workload selector: %s.", workload_id)
@@ -651,13 +683,14 @@ def check_logs_exist(
     workload_id: str,
     expect_log_contains: str,
     expected_count: int = 1,
+    namespace: str = "default",
 ) -> bool:
   """
   Counts occurrences of a regex pattern in full pod logs and
   verifies it meets the minimum count.
   """
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   if not pods.items:
     logging.info("No pods found for workload selector: %s.", workload_id)


### PR DESCRIPTION
### Summary

Migrates the MaxText End-to-End TPU Pre-Training and Post-Training DAGs to the shared NAP cluster `mlperf-v5p` (located in `europe-west4-b`) on the `automation-testing` Kubernetes namespace.

### Changes Included:
1. **Cluster Definition**:
   - Added `TPU_V5P_MLPERF_CLUSTER` to `XpkClusters` in `dags/common/vm_resource.py` configured with `namespace="automation-testing"`.
2. **Dynamic Cluster Configuration (`override`)**:
   - Added type-safe, keyword-only `override(*, core_count=..., namespace=...)` method to `XpkClusterConfig` in `xlml/apis/xpk_cluster_config.py` using `dataclasses.replace` for immutability.
3. **Namespace Propagation**:
   - Added `namespace` field to `TpuGkeTest` and `GpuXpkTest` in `xlml/apis/test_config.py`.
   - Wired `namespace` through `get_gke_config` in `dags/multipod/configs/gke_config.py`.
   - Passed `self.task_test_config.namespace` directly in `XpkTask` (`xlml/apis/task.py`) with 0 public method signature changes.
   - Updated `xlml/utils/xpk.py` to pass `--namespace` to CLI commands (`run_workload`, `clean_up_workload`, `delete_node`), K8s API sensors, and Cloud Logging query URLs.
4. **DAG Migration**:
   - Updated `dags/multipod/maxtext_e2e_tpu_pre_training.py` and `dags/multipod/maxtext_e2e_tpu_post_training.py` to use `cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER` (8-core tasks) and `cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(core_count=128)` (128-core training tasks).