### PR TITLE
fix(xpk): Bump pinned XPK version to v1.16.0 to support --namespace flag

### DIFF
--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -35,7 +35,7 @@ from dags.common.vm_resource import GpuVersion
 
 # NOTE: This version needs to be pinned to ensure compatibility when using
 # xpk.py for workload creation.
-MAIN_BRANCH = "v0.17.3"
+MAIN_BRANCH = "v1.16.0"
 
 # Duration = past 7 days
 LOGGING_URL_FORMAT = (


### PR DESCRIPTION
## Overview
Bumps the pinned XPK version in `xlml/utils/xpk.py` from `v0.17.3` to `v1.16.0`.

## Motivation
In #1334, MaxText E2E TPU DAGs were migrated to run in the `automation-testing` Kubernetes namespace on `mlperf-v5p`.
However, the pinned XPK version (`v0.17.3`) predates XPK's `--namespace` flag support (introduced in XPK `v1.16.0` via [AI-Hypercomputer/xpk#1196](https://github.com/AI-Hypercomputer/xpk/pull/1196)).

When Composer workers execute `run_workload` with `--namespace=automation-testing`, `v0.17.3` fails with `unrecognized arguments: --namespace=automation-testing` (exit code 2).

Bumping `MAIN_BRANCH` to `v1.16.0` enables native `--namespace` flag support during workload creation and deletion on TPU clusters.

## Verification
- Deployed to Cloud Composer test environment (`jackyf-test`).
- Triggered `maxtext_e2e_tpu_post_training`.
- Verified that Composer workers successfully cloned `v1.16.0`, executed `xpk workload create ... --namespace=automation-testing`, and created active JobSets on `mlperf-v5p` in namespace `automation-testing`.
