### PR TITLE
refactor(xpk): Refactor namespace usage to match priority pattern

### DIFF
--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -278,7 +278,6 @@ class XpkClusters:
       core_count=8,
       project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
       zone=Zone.EUROPE_WEST4_B.value,
-      namespace="automation-testing",
   )
   TPU_V5E_256_CLUSTER = XpkClusterConfig(
       name="v5e-256-bodaborg-europe-west4",

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -61,7 +61,6 @@ def get_gke_config(
       num_slices=num_slices,
       cluster_name=cluster.name,
       docker_image=docker_image,
-      namespace=cluster.namespace,
   )
   job_metric_config = user_specified_job_metric_config
   if job_metric_config is None:
@@ -125,7 +124,6 @@ def get_gke_config_with_interrupt(
       num_slices=num_slices,
       cluster_name=cluster.name,
       docker_image=docker_image,
-      namespace=cluster.namespace,
   )
   job_metric_config = user_specified_job_metric_config
   if job_metric_config is None:
@@ -192,7 +190,6 @@ def get_gke_config_with_name_gen_and_quarantine(
       num_slices=num_slices,
       cluster_name=cluster.name,
       docker_image=docker_image,
-      namespace=cluster.namespace,
   )
   job_metric_config = user_specified_job_metric_config
   if job_metric_config is None:

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -179,7 +179,11 @@ with models.DAG(
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+      ).run(
+          skip_post_process=True,
+          priority="very-high",
+          namespace="automation-testing",
+      )
 
       for mode, mode_test_config in test_config["post_training"].items():
         with TaskGroup(group_id=f"{mode}-{model}") as model_group:
@@ -216,6 +220,7 @@ with models.DAG(
               use_pathways=True,
               skip_post_process=True,
               priority="very-high",
+              namespace="automation-testing",
           )
 
           to_hf_flags = mode_test_config.get("to_hf_flags", "false true")
@@ -238,7 +243,11 @@ with models.DAG(
               docker_image="{{ params.docker_image }}",
               cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
               test_owner=test_owner.SURBHI_J,
-          ).run(skip_post_process=True, priority="very-high")
+          ).run(
+              skip_post_process=True,
+              priority="very-high",
+              namespace="automation-testing",
+          )
 
           (
               convert_to_maxtext_task

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -121,7 +121,11 @@ with models.DAG(
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+      ).run(
+          skip_post_process=True,
+          priority="very-high",
+          namespace="automation-testing",
+      )
 
       training_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
           f"{test_config['training']['command']} {run_name}",
@@ -136,7 +140,11 @@ with models.DAG(
               core_count=training_core_count
           ),
           test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+      ).run(
+          skip_post_process=True,
+          priority="very-high",
+          namespace="automation-testing",
+      )
 
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
@@ -158,6 +166,10 @@ with models.DAG(
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+      ).run(
+          skip_post_process=True,
+          priority="very-high",
+          namespace="automation-testing",
+      )
 
       convert_to_maxtext_task >> training_task >> convert_to_huggingface_task

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -341,6 +341,7 @@ class XpkRunner:
   xpk_branch: str = xpk.MAIN_BRANCH
   max_restart: int = 0
   priority: str = "high"
+  namespace: str = "default"
 
   def launch_workload(self) -> DAGNode:
     """Create the workload and wait for it to provision."""
@@ -366,7 +367,7 @@ class XpkRunner:
           xpk_branch=self.xpk_branch,
           max_restart=self.max_restart,
           priority=self.priority,
-          namespace=self.task_test_config.namespace,
+          namespace=self.namespace,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
           timeout=self.workload_provision_timeout.total_seconds()
@@ -375,7 +376,7 @@ class XpkRunner:
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
-          namespace=self.task_test_config.namespace,
+          namespace=self.namespace,
       )
       chain(run_workload, wait_for_workload_start)
       return group
@@ -388,7 +389,7 @@ class XpkRunner:
         project_id=self.task_gcp_config.project_name,
         region=gke.zone_to_region(self.task_gcp_config.zone),
         cluster_name=self.task_test_config.cluster_name,
-        namespace=self.task_test_config.namespace,
+        namespace=self.namespace,
     )
 
   def cleanup_workload(self, tear_down_of: BaseOperator) -> DAGNode:
@@ -398,7 +399,7 @@ class XpkRunner:
         zone=self.task_gcp_config.zone,
         cluster_name=self.task_test_config.cluster_name,
         xpk_branch=self.xpk_branch,
-        namespace=self.task_test_config.namespace,
+        namespace=self.namespace,
     ).as_teardown(
         setups=tear_down_of,
         on_failure_fail_dagrun=True,
@@ -418,7 +419,7 @@ class XpkRunner:
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
           expect_reach_to_step=str(expect_reach_to_step),
-          namespace=self.task_test_config.namespace,
+          namespace=self.namespace,
       )
 
       task_id_wait_file_exist = "wait_for_file_to_exist"
@@ -461,7 +462,7 @@ class XpkRunner:
         workload_id=self.workload_id,
         dry_run=False,
         last_node=is_targeting_on_last_node,
-        namespace=self.task_test_config.namespace,
+        namespace=self.namespace,
     )
 
 
@@ -499,6 +500,7 @@ class XpkTask(BaseTask):
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
       priority: str = "high",
+      namespace: str = "default",
   ) -> DAGNode:
     """Run a test job within a docker image.
 
@@ -521,6 +523,7 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
+          namespace=namespace,
       )
 
       run_model = self._run_model(xpk_runner)
@@ -567,6 +570,7 @@ class XpkTask(BaseTask):
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
       priority: str = "high",
+      namespace: str = "default",
   ) -> tuple[DAGNode, XpkRunner]:
     with TaskGroup(group_id="pre_process") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
@@ -586,6 +590,7 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
+          namespace=namespace,
       )
 
     return group, xpk_runner
@@ -673,6 +678,7 @@ class XpkNameGenAndQuarantineTask(XpkTask):
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
       priority: str = "high",
+      namespace: str = "default",
   ) -> DAGNode:
     """Generate a unique run name, tensorboard file location,
     and profile file location (if metric config has profile),
@@ -703,6 +709,7 @@ class XpkNameGenAndQuarantineTask(XpkTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
+          namespace=namespace,
       )
 
   def _pre_process(
@@ -715,6 +722,7 @@ class XpkNameGenAndQuarantineTask(XpkTask):
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
       priority: str = "high",
+      namespace: str = "default",
   ) -> tuple[DAGNode, XpkRunner]:
     with TaskGroup(group_id="pre_process") as group:
       run_name = name_format.generate_run_name(
@@ -766,6 +774,7 @@ class XpkNameGenAndQuarantineTask(XpkTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
+          namespace=namespace,
       )
 
       chain(*nodes)

--- a/xlml/apis/test_config.py
+++ b/xlml/apis/test_config.py
@@ -266,7 +266,6 @@ class CpuGkeTest(TestConfig[Cpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
-  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:
@@ -302,7 +301,6 @@ class TpuGkeTest(TestConfig[Tpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
-  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:
@@ -345,7 +343,6 @@ class GpuXpkTest(TestConfig[Gpu]):
     run_model_cmds: List of commands to run the model under test.
     startup_time_out_in_sec: Timeout to start up the pod.
     num_slices: Number of GPU slices.
-    namespace: Kubernetes namespace of the cluster.
   """
 
   test_name: str
@@ -355,7 +352,6 @@ class GpuXpkTest(TestConfig[Gpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
-  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:

--- a/xlml/apis/xpk_cluster_config.py
+++ b/xlml/apis/xpk_cluster_config.py
@@ -28,7 +28,6 @@ class XpkClusterConfig:
     core_count: Core count of the cluster
     project: Project of the cluster
     zone: Zone of the cluster
-    namespace: Kubernetes namespace of the cluster
   """
 
   name: str
@@ -36,18 +35,14 @@ class XpkClusterConfig:
   core_count: int
   project: str
   zone: str
-  namespace: str = 'default'
 
   def override(
       self,
       *,
       core_count: Optional[int] = None,
-      namespace: Optional[str] = None,
   ) -> 'XpkClusterConfig':
     """Returns a copy of this cluster config with specified fields overridden."""
     changes = {}
     if core_count is not None:
       changes['core_count'] = core_count
-    if namespace is not None:
-      changes['namespace'] = namespace
     return dataclasses.replace(self, **changes)

--- a/xlml/apis/xpk_cluster_config_test.py
+++ b/xlml/apis/xpk_cluster_config_test.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for xpk_cluster_config.py."""
+
+import unittest
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
+from dags.common.vm_resource import TpuVersion, Project, Zone
+
+
+class XpkClusterConfigTest(unittest.TestCase):
+
+  def test_override_core_count(self):
+    config = XpkClusterConfig(
+        name="mlperf-v5p",
+        device_version=TpuVersion.V5P,
+        core_count=8,
+        project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+        zone=Zone.EUROPE_WEST4_B.value,
+    )
+    overridden = config.override(core_count=128)
+
+    # Verify immutability
+    self.assertEqual(config.core_count, 8)
+    self.assertEqual(overridden.core_count, 128)
+    self.assertEqual(overridden.name, "mlperf-v5p")
+    self.assertEqual(overridden.device_version, TpuVersion.V5P)
+    self.assertEqual(overridden.project, Project.CLOUD_TPU_MULTIPOD_DEV.value)
+    self.assertEqual(overridden.zone, Zone.EUROPE_WEST4_B.value)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/xlml/utils/xpk_test.py
+++ b/xlml/utils/xpk_test.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for xpk.py."""
+
+import unittest
+from unittest import mock
+from xlml.utils import xpk
+
+
+class XpkTest(unittest.TestCase):
+
+  @mock.patch("xlml.utils.xpk.composer.log_metadata_for_xlml_dashboard")
+  @mock.patch("xlml.utils.xpk.SubprocessHook")
+  def test_run_workload_with_custom_namespace(
+      self, mock_hook_class, mock_log_metadata
+  ):
+    mock_hook = mock.MagicMock()
+    mock_hook.run_command.return_value.exit_code = 0
+    mock_hook_class.return_value = mock_hook
+
+    xpk.run_workload.function(
+        task_id="test_task",
+        cluster_project="test_proj",
+        zone="us-central1-a",
+        cluster_name="test_cluster",
+        benchmark_id="test_bench",
+        workload_id="workload_123",
+        gcs_path="gs://test-bucket/path",
+        docker_image="gcr.io/test-image",
+        accelerator_type="v5p-8",
+        run_cmds="echo test",
+        namespace="automation-testing",
+    )
+
+    call_args = mock_hook.run_command.call_args[0][0]
+    full_cmd = call_args[2]
+    self.assertIn("--namespace=automation-testing", full_cmd)
+
+  @mock.patch("xlml.utils.xpk.composer.log_metadata_for_xlml_dashboard")
+  @mock.patch("xlml.utils.xpk.SubprocessHook")
+  def test_run_workload_with_default_namespace_no_flag(
+      self, mock_hook_class, mock_log_metadata
+  ):
+    mock_hook = mock.MagicMock()
+    mock_hook.run_command.return_value.exit_code = 0
+    mock_hook_class.return_value = mock_hook
+
+    xpk.run_workload.function(
+        task_id="test_task",
+        cluster_project="test_proj",
+        zone="us-central1-a",
+        cluster_name="test_cluster",
+        benchmark_id="test_bench",
+        workload_id="workload_123",
+        gcs_path="gs://test-bucket/path",
+        docker_image="gcr.io/test-image",
+        accelerator_type="v5p-8",
+        run_cmds="echo test",
+        namespace="default",
+    )
+
+    call_args = mock_hook.run_command.call_args[0][0]
+    full_cmd = call_args[2]
+    self.assertNotIn("--namespace", full_cmd)
+
+  @mock.patch("xlml.utils.xpk.SubprocessHook")
+  def test_clean_up_workload_with_custom_namespace(self, mock_hook_class):
+    mock_hook = mock.MagicMock()
+    mock_hook.run_command.return_value.exit_code = 0
+    mock_hook_class.return_value = mock_hook
+
+    xpk.clean_up_workload.function(
+        workload_id="workload_123",
+        project_id="test_proj",
+        zone="us-central1-a",
+        cluster_name="test_cluster",
+        namespace="automation-testing",
+    )
+
+    call_args = mock_hook.run_command.call_args[0][0]
+    full_cmd = call_args[2]
+    self.assertIn("--namespace=automation-testing", full_cmd)
+
+  @mock.patch("xlml.utils.xpk.SubprocessHook")
+  def test_clean_up_workload_with_default_namespace(self, mock_hook_class):
+    mock_hook = mock.MagicMock()
+    mock_hook.run_command.return_value.exit_code = 0
+    mock_hook_class.return_value = mock_hook
+
+    xpk.clean_up_workload.function(
+        workload_id="workload_123",
+        project_id="test_proj",
+        zone="us-central1-a",
+        cluster_name="test_cluster",
+        namespace="default",
+    )
+
+    call_args = mock_hook.run_command.call_args[0][0]
+    full_cmd = call_args[2]
+    self.assertNotIn("--namespace", full_cmd)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Description
Follow up on #1334. Refactors `namespace` usage so that it behaves as a runtime task execution parameter (matching `priority`) rather than a property tied to cluster configurations.

### Changes
- **Decouple namespace from configs**: Removed `namespace` from `XpkClusterConfig`, `TPU_V5P_MLPERF_CLUSTER`, `TpuGkeTest`, `CpuGkeTest`, `GpuXpkTest`, and `dags/multipod/configs/gke_config.py`.
- **Pass namespace as task execution argument**: Added `namespace: str = "default"` to `XpkTask.run`, `XpkTask.run_model`, and `XpkTask.launch_workload` in `xlml/apis/task.py` and forwarded it to `xpk.*`.
- **Update DAGs**: Updated `maxtext_e2e_tpu_pre_training.py` and `maxtext_e2e_tpu_post_training.py` to pass `namespace="automation-testing"` directly to `.run()` / `.run_model()`.
- **Unit tests**: Added unit tests for `XpkClusterConfig.override` and `xpk` namespace flag generation.

### Verification
- `py_compile`: All modified and new test files compiled successfully.
- Local unit tests in `xlml/apis/xpk_cluster_config_test.py` passed.
- Validated on Cloud Composer test environment `jackyf-test` (`dags list-import-errors` reported 0 errors, and all tasks generated successfully).