### PR TITLE
feat(maxtext): Decouple E2E DAGs into standalone pipelines with dedicated checkpoint conversion

### DIFF
--- a/dags/common/scheduling_helper/dag_integrity_whitelist.yaml
+++ b/dags/common/scheduling_helper/dag_integrity_whitelist.yaml
@@ -52,6 +52,7 @@ whitelisted_dags:
 - maxtext_configs_aot_hybridsim
 - maxtext_convergence
 - maxtext_e2e_tests
+- maxtext_e2e_tpu_checkpoint_conversion
 - maxtext_e2e_tpu_post_training
 - maxtext_e2e_tpu_pre_training
 - maxtext_emc_and_mtc_orbax_save_local

--- a/dags/multipod/maxtext_e2e_tests.py
+++ b/dags/multipod/maxtext_e2e_tests.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 """
-Parent DAG that triggers MaxText E2E TPU pre-training and post-training child
-DAGs in parallel, firing separate GitHub repository_dispatch callbacks for
-pre-training and post-training upon completion of each job.
+MaxText E2E Tests Orchestrator DAG.
+
+Coordinates the multi-stage MaxText end-to-end testing pipeline for GitHub CI:
+1. Stage 1 (maxtext_e2e_tpu_checkpoint_conversion):
+   Converts Hugging Face checkpoints to MaxText format on TPU v5p-8.
+2. Stage 2 (maxtext_e2e_tpu_pre_training & maxtext_e2e_tpu_post_training):
+   Triggers pre-training and post-training test suites once checkpoints are ready.
+3. Callbacks & Reporting:
+   Fires GitHub repository_dispatch events upon stage completion for automated CI.
 """
 import datetime
 
@@ -37,6 +43,7 @@ with models.DAG(
         "e2e",
         "pre-training",
         "post-training",
+        "checkpoint-conversion",
     ],
     start_date=datetime.datetime(2026, 6, 10),
     catchup=False,
@@ -72,14 +79,32 @@ with models.DAG(
       commit_sha="{{ params.commit_sha }}",
   )
 
+  shared_run_name = "e2e-{{ params.github_run_id }}"
+
+  trigger_checkpoint_conversion = TriggerDagRunOperator(
+      task_id="trigger_checkpoint_conversion",
+      trigger_dag_id="maxtext_e2e_tpu_checkpoint_conversion",
+      execution_date="{{ logical_date }}",
+      conf={
+          "docker_image": (
+              "gcr.io/tpu-prod-env-multipod/maxtext_post_training_"
+              "{{ params.build_mode }}:{{ params.github_run_id }}"
+          ),
+          "run_name": shared_run_name,
+      },
+      wait_for_completion=False,
+  )
+
   trigger_pre_training = TriggerDagRunOperator(
       task_id="trigger_tpu_pre_training",
       trigger_dag_id="maxtext_e2e_tpu_pre_training",
+      execution_date="{{ logical_date }}",
       conf={
           "docker_image": (
               "gcr.io/tpu-prod-env-multipod/maxtext_jax_"
               "{{ params.build_mode }}:{{ params.github_run_id }}"
-          )
+          ),
+          "run_name": shared_run_name,
       },
       wait_for_completion=True,
       poke_interval=600,  # check every 10 minutes for child DAG completion
@@ -88,11 +113,13 @@ with models.DAG(
   trigger_post_training = TriggerDagRunOperator(
       task_id="trigger_tpu_post_training",
       trigger_dag_id="maxtext_e2e_tpu_post_training",
+      execution_date="{{ logical_date }}",
       conf={
           "docker_image": (
               "gcr.io/tpu-prod-env-multipod/maxtext_post_training_"
               "{{ params.build_mode }}:{{ params.github_run_id }}"
-          )
+          ),
+          "run_name": shared_run_name,
       },
       wait_for_completion=True,
       poke_interval=600,  # check every 10 minutes for child DAG completion
@@ -130,6 +157,10 @@ with models.DAG(
       },
   )
 
+  chain(
+      validate_task,
+      trigger_checkpoint_conversion,
+  )
   chain(
       validate_task,
       trigger_pre_training,

--- a/dags/multipod/maxtext_e2e_tpu_checkpoint_conversion.py
+++ b/dags/multipod/maxtext_e2e_tpu_checkpoint_conversion.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MaxText E2E TPU Checkpoint Conversion DAG (Stage 1).
+
+Serves as the shared prerequisite pipeline for MaxText E2E testing:
+- Converts Hugging Face checkpoints to MaxText format on TPU v5p-8 slices.
+- Saves checkpoints to GCS (gs://runner-maxtext-logs/<model>/to_maxtext/{run_name}/...).
+- Downstream training DAGs (maxtext_e2e_tpu_pre_training and maxtext_e2e_tpu_post_training)
+  listen to this DAG via ExternalTaskSensor and begin training as each model completes.
+"""
+import datetime
+from airflow import models
+from airflow.models.param import Param
+from airflow.utils.task_group import TaskGroup
+from dags.common import test_owner
+from dags.common.quarantined_tests import safe_get_from_variable
+from dags.common.vm_resource import XpkClusters
+from dags.multipod.configs import gke_config
+
+HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
+
+with models.DAG(
+    dag_id="maxtext_e2e_tpu_checkpoint_conversion",
+    schedule=None,
+    tags=[
+        "maxtext",
+        "conversion",
+        "checkpoint",
+        "TPU",
+    ],
+    start_date=datetime.datetime(2026, 6, 10),
+    catchup=False,
+    params={
+        "docker_image": Param(
+            type="string",
+            description="Docker image URI for the candidate to test",
+        ),
+        "run_name": Param(
+            default="",
+            type="string",
+            description=(
+                "Unique shared run name for checkpoints (defaults to"
+                " conv-{{ ts_nodash }})"
+            ),
+        ),
+    },
+) as dag:
+  # pylint: disable=line-too-long
+  test_models = {
+      "gemma3-4b": {
+          "to_maxtext": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh",
+      },
+      "gemma4-26b": {
+          "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
+      },
+      "llama3_1-70b": {
+          "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
+      },
+      "qwen3-30b": {
+          "to_maxtext": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh",
+      },
+      "qwen3-vl-2b": {
+          "to_maxtext": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh",
+      },
+      "gpt-oss-20b": {
+          "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
+      },
+  }
+  # pylint: enable=line-too-long
+
+  for model, config in test_models.items():
+    with TaskGroup(group_id=model) as model_group:
+      run_name = (
+          "{{ params.run_name if params.run_name else 'conv-' ~ ts_nodash }}"
+      )
+
+      convert_to_maxtext_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (f"{config['to_maxtext']} {run_name}",)
+
+      convert_to_maxtext_task = gke_config.get_gke_config(
+          time_out_in_min=120,
+          test_name="to-mt",
+          run_model_cmds=convert_to_maxtext_cmd,
+          docker_image="{{ params.docker_image }}",
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(core_count=8),
+          test_owner=test_owner.JACKY_F,
+      ).run(skip_post_process=True, priority="very-high")

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -13,13 +13,20 @@
 # limitations under the License.
 
 """
-A DAG to run MaxText E2E TPU Post-Training tests.
+MaxText E2E TPU Post-Training Tests DAG (Stage 2).
+
+Executes end-to-end MaxText post-training workflows (SFT, Multimodal SFT, LoRA, RL) on Cloud TPU:
+- Waits for model conversion in maxtext_e2e_tpu_checkpoint_conversion via ExternalTaskSensor.
+- Executes post-training scripts with Pathways runtime persistence on TPU slices.
+- Converts post-trained checkpoints back to Hugging Face format to verify weight fidelity.
 """
 import datetime
-import hashlib
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.models.param import Param
+from airflow.sensors.external_task import ExternalTaskSensor
+from airflow.utils.session import provide_session
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.quarantined_tests import safe_get_from_variable
@@ -30,9 +37,15 @@ from dags.multipod.configs import gke_config
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
-def get_workload_name(model, mode, length=6):
-  hex_code = f"{mode}-{hashlib.sha256(model.encode()).hexdigest()}"
-  return hex_code[:length]
+class ExternalTaskSensorWithBypass(ExternalTaskSensor):
+  """ExternalTaskSensor that passes immediately if wait_for_conversion param is False."""
+
+  @provide_session
+  def poke(self, context, session=None):
+    if not context.get("params", {}).get("wait_for_conversion", True):
+      self.log.info("Bypassing conversion sensor: wait_for_conversion is False")
+      return True
+    return super().poke(context, session=session)
 
 
 with models.DAG(
@@ -50,16 +63,26 @@ with models.DAG(
             type="string",
             description="Docker image URI for the candidate to test",
         ),
+        "run_name": Param(
+            default="",
+            type="string",
+            description="Shared run name for checkpoints (defaults to post-{{ ts_nodash }})",
+        ),
+        "wait_for_conversion": Param(
+            default=True,
+            type="boolean",
+            description=(
+                "Whether to wait for Stage 1 conversion DAG via sensor. Set"
+                " False when running standalone with pre-existing checkpoints."
+            ),
+        ),
     },
 ) as dag:
   # pylint: disable=line-too-long
   test_models = {
       "gemma3-4b": {
           "core_count": 8,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh",
-          },
+          "to_huggingface": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh",
           "post_training": {
               "sft": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_sft.sh",
@@ -82,10 +105,7 @@ with models.DAG(
       },
       "gemma4-26b": {
           "core_count": 32,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
-          },
+          "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
           "post_training": {
               "sft": {
                   "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh",
@@ -99,12 +119,9 @@ with models.DAG(
               },
           },
       },
-      "llama3_1_70b": {
+      "llama3_1-70b": {
           "core_count": 128,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
-          },
+          "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
           "post_training": {
               "sft": {
                   "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_sft.sh",
@@ -118,10 +135,7 @@ with models.DAG(
       },
       "qwen3-30b": {
           "core_count": 32,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh",
-          },
+          "to_huggingface": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh",
           "post_training": {
               "sft": {
                   "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh",
@@ -137,10 +151,7 @@ with models.DAG(
       },
       "qwen3-vl-2b": {
           "core_count": 8,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_hf.sh",
-          },
+          "to_huggingface": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_hf.sh",
           "post_training": {
               "multimodal_sft": {
                   "command": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh",
@@ -151,10 +162,7 @@ with models.DAG(
       },
       "gpt-oss-20b": {
           "core_count": 32,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
-          },
+          "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
           "post_training": {
               "sft": {
                   "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_sft.sh",
@@ -173,24 +181,23 @@ with models.DAG(
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
-      run_name = "post-{{ ts_nodash }}"
+      run_name = (
+          "{{ params.run_name if params.run_name else 'post-' ~ ts_nodash }}"
+      )
 
-      convert_to_maxtext_cmd = (
-          f"export HF_TOKEN={HF_TOKEN}",
-          'export HF_HOME="/dev/shm/hf_cache"',
-          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
-      ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
-      convert_to_maxtext_task = gke_config.get_gke_config(
-          time_out_in_min=60,
-          test_name="convert-to-maxtext",
-          run_model_cmds=convert_to_maxtext_cmd,
-          docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
-          test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+      wait_for_conversion = ExternalTaskSensorWithBypass(
+          task_id="wait_for_conversion",
+          external_dag_id="maxtext_e2e_tpu_checkpoint_conversion",
+          external_task_group_id=model,
+          mode="reschedule",
+          poke_interval=60,
+          timeout=10800,
+          allowed_states=["success"],
+          failed_states=["failed", "upstream_failed"],
+      )
 
       for mode, mode_test_config in test_config["post_training"].items():
-        with TaskGroup(group_id=f"{mode}-{model}") as model_group:
+        with TaskGroup(group_id=f"{mode}-{model}") as mode_group:
           environment_variables = [
               f"export HF_TOKEN={HF_TOKEN}",
               "export TPU_MIN_LOG_LEVEL=0",
@@ -210,13 +217,14 @@ with models.DAG(
           training_core_count = mode_test_config.get(
               "core_count", test_config.get("core_count", 8)
           )
+          mode_short_name = "multim" if mode == "multimodal_sft" else mode
           training_task = gke_config.get_gke_config(
               time_out_in_min=60,
               num_slices=1,
               cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(
                   core_count=training_core_count
               ),
-              test_name=get_workload_name(model, mode),
+              test_name=mode_short_name,
               run_model_cmds=training_cmd,
               docker_image="{{ params.docker_image }}",
               test_owner=test_owner.SURBHI_J,
@@ -236,20 +244,20 @@ with models.DAG(
               'export HF_HOME="/dev/shm/hf_cache"',
               'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
           ) + (
-              f"{test_config['checkpoint_conversion']['to_huggingface']} "
+              f"{test_config['to_huggingface']} "
               f"{run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(
               time_out_in_min=90,
-              test_name="convert-to-huggingface",
+              test_name="to-hf",
               run_model_cmds=convert_to_huggingface_cmd,
               docker_image="{{ params.docker_image }}",
               cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
               test_owner=test_owner.SURBHI_J,
           ).run(skip_post_process=True, priority="very-high")
 
-          (
-              convert_to_maxtext_task
-              >> training_task
-              >> convert_to_huggingface_task
+          chain(
+              wait_for_conversion,
+              training_task,
+              convert_to_huggingface_task,
           )

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 """
-A DAG to run MaxText E2E TPU Pre-Training tests.
+MaxText E2E TPU Pre-Training Tests DAG (Stage 2).
+
+Executes end-to-end MaxText pre-training test workloads on Cloud TPU:
+- Waits for model conversion in maxtext_e2e_tpu_checkpoint_conversion via ExternalTaskSensor.
+- Runs pre-training on dedicated TPU v5p topologies configured per model architecture.
+- Converts trained checkpoints back to Hugging Face format to verify weight fidelity.
 """
 import datetime
-import hashlib
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.models.param import Param
+from airflow.sensors.external_task import ExternalTaskSensor
+from airflow.utils.session import provide_session
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.quarantined_tests import safe_get_from_variable
@@ -28,9 +35,15 @@ from dags.multipod.configs import gke_config
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
-def get_workload_name(model, length=6):
-  hex_code = f"pre-{hashlib.sha256(model.encode()).hexdigest()}"
-  return hex_code[:length]
+class ExternalTaskSensorWithBypass(ExternalTaskSensor):
+  """ExternalTaskSensor that passes immediately if wait_for_conversion param is False."""
+
+  @provide_session
+  def poke(self, context, session=None):
+    if not context.get("params", {}).get("wait_for_conversion", True):
+      self.log.info("Bypassing conversion sensor: wait_for_conversion is False")
+      return True
+    return super().poke(context, session=session)
 
 
 with models.DAG(
@@ -48,86 +61,72 @@ with models.DAG(
             type="string",
             description="Docker image URI for the candidate to test",
         ),
+        "run_name": Param(
+            default="",
+            type="string",
+            description="Shared run name for checkpoints (e.g. conv-20260813T123008)",
+        ),
+        "wait_for_conversion": Param(
+            default=True,
+            type="boolean",
+            description=(
+                "Whether to wait for Stage 1 conversion DAG via sensor. Set"
+                " False when running standalone with pre-existing checkpoints."
+            ),
+        ),
     },
 ) as dag:
   # pylint: disable=line-too-long
   test_models = {
       "gemma3-4b": {
-          "core_count": 16,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh",
-          },
+          "core_count": 8,
           "training": {
               "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/train/{run_name}/checkpoints/1/items",
           },
+          "to_huggingface": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_to_hf.sh",
       },
       "gemma4-26b": {
           "core_count": 32,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
-          },
           "training": {
               "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/train/{run_name}/checkpoints/1/items",
           },
+          "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
       },
       "llama3_1-70b": {
           "core_count": 128,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
-          },
           "training": {
               "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/train/{run_name}/checkpoints/1/items",
           },
+          "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
       },
       "qwen3-30b": {
           "core_count": 32,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh",
-          },
           "training": {
               "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/train/{run_name}/checkpoints/1/items",
           },
+          "to_huggingface": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_to_hf.sh",
           "to_hf_flags": "true",
       },
       "gpt-oss-20b": {
           "core_count": 32,
-          "checkpoint_conversion": {
-              "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
-              "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
-          },
           "training": {
               "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/train/{run_name}/checkpoints/1/items",
           },
+          "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
       },
   }
   # pylint: enable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
-      run_name = "pre-{{ ts_nodash }}"
-
-      convert_to_maxtext_cmd = (
-          f"export HF_TOKEN={HF_TOKEN}",
-          'export HF_HOME="/dev/shm/hf_cache"',
-          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
-      ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
-      convert_to_maxtext_task = gke_config.get_gke_config(
-          time_out_in_min=60,
-          test_name="convert-to-maxtext",
-          run_model_cmds=convert_to_maxtext_cmd,
-          docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
-          test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+      run_name = (
+          "{{ params.run_name if params.run_name else 'pre-' ~ ts_nodash }}"
+      )
 
       training_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
           f"{test_config['training']['command']} {run_name}",
@@ -135,7 +134,7 @@ with models.DAG(
       training_core_count = test_config.get("core_count", 8)
       training_task = gke_config.get_gke_config(
           time_out_in_min=60,
-          test_name=get_workload_name(model),
+          test_name="pre",
           run_model_cmds=training_cmd,
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(
@@ -154,16 +153,31 @@ with models.DAG(
           'export HF_HOME="/dev/shm/hf_cache"',
           'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
       ) + (
-          f"{test_config['checkpoint_conversion']['to_huggingface']} "
+          f"{test_config['to_huggingface']} "
           f"{run_name} {model_path} {to_hf_flags}",
       )
       convert_to_huggingface_task = gke_config.get_gke_config(
           time_out_in_min=90,
-          test_name="convert-to-huggingface",
+          test_name="to-hf",
           run_model_cmds=convert_to_huggingface_cmd,
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
-      convert_to_maxtext_task >> training_task >> convert_to_huggingface_task
+      wait_for_conversion = ExternalTaskSensorWithBypass(
+          task_id="wait_for_conversion",
+          external_dag_id="maxtext_e2e_tpu_checkpoint_conversion",
+          external_task_group_id=model,
+          mode="reschedule",
+          poke_interval=60,
+          timeout=10800,
+          allowed_states=["success"],
+          failed_states=["failed", "upstream_failed"],
+      )
+
+      chain(
+          wait_for_conversion,
+          training_task,
+          convert_to_huggingface_task,
+      )


### PR DESCRIPTION
# Description

## Motivation & Architecture Overhaul
The monolithic `maxtext_e2e_tests` DAG previously combined checkpoint conversion, pre-training, and post-training into a single pipeline with a blanket 128-core allocation per model. This caused severe Cloud Composer queuing delays, high resource consumption, and 82 DAG import errors.

This PR refactors the MaxText E2E testing architecture into decoupled, standalone pipelines strictly designed for automated GitHub Actions CI execution with dedicated Stage 1 checkpoint conversion on lightweight TPU slices and right-sized hardware allocations.

---

## ⚠️ Operational Model: Strict GitHub Actions CI-Only Execution

> [!IMPORTANT]
> **This new structure cannot be triggered manually from the Airflow UI.**
>
> The orchestrator pipeline strictly enforces external CI execution via `validate_git_trigger` and requires GitHub Actions parameters:
> - `github_repo`: Target repository in `owner/repo` format.
> - `github_token`: GitHub token for dispatch status callbacks.
> - `github_run_id`: Originating GitHub Actions workflow run ID.
> - `commit_sha`: Git commit SHA being tested.
>
> Attempting to manually trigger `maxtext_e2e_tests` from the Airflow UI without CI parameters will intentionally fail fast at the first task (`validate_git_trigger`).

---

## Detailed Changes

### 1. Decoupled Modular Architecture
* **`maxtext_e2e_tpu_checkpoint_conversion.py`** (Stage 1):
  * Dedicated Hugging Face -> MaxText checkpoint conversion pipeline (`to_maxtext`) executed on lightweight `v5p-8` TPU slices.
  * Owned by `test_owner.JACKY_F`.
  * Outputs are stored under `gs://runner-maxtext-logs/<model>/to_maxtext/{run_name}/checkpoints/0/items` and are reusable across subsequent training runs.
* **`maxtext_e2e_tpu_pre_training.py`** (Stage 2):
  * Standalone pre-training convergence tests consuming converted checkpoints via GCS storage contract.
  * Synchronized with Stage 1 via per-model `ExternalTaskSensor(external_task_group_id=model)` with 3-hour timeout and `failed_states=["failed", "upstream_failed"]`.
* **`maxtext_e2e_tpu_post_training.py`** (Stage 2):
  * Standalone post-training (SFT, Multimodal SFT, LoRA, RL) workflows consuming converted checkpoints via `run_name`.
  * Synchronized with Stage 1 via per-model `ExternalTaskSensor`.
* **`maxtext_e2e_tests.py`** (Orchestrator):
  * Clean, streamlined top-level coordinator for GitHub CI.
  * Triggers Stage 1 conversion first (`wait_for_completion=False`), and triggers pre-training and post-training in parallel.
  * Fires separate GitHub `repository_dispatch` status callbacks upon completion of pre-training and post-training jobs.

### 2. Per-Model TPU Core Count Allocations
Configured right-sized TPU slices based on verified mesh configurations:

| Model | Stage 1 (Conversion) | Stage 2 (Pre-Train) | Stage 2 (Post-Train: SFT/RL/LoRA/MM) | Mesh Config |
|---|---|---|---|---|
| **`gemma3-4b`** | **8** (`v5p-8`) | **8** (`v5p-8`) | **8** (`v5p-8`) | Single-host auto-sharding |
| **`gpt-oss-20b`** | **8** (`v5p-8`) | **32** (`v5p-32`) | **32** (`v5p-32`) | Multi-host auto-sharding |
| **`qwen3-vl-2b`** | **8** (`v5p-8`) | — | **32** (`v5p-32`) | Vision pipeline |
| **`gemma4-26b`** | **8** (`v5p-8`) | **32** (`v5p-32`) | **32** (`v5p-32`) | Multi-host pipeline |
| **`qwen3-30b`** | **8** (`v5p-8`) | **32** (`v5p-32`) | **32** (`v5p-32`) | 3D MoE (`TP=4, FSDP=2, EP=2`) |
| **`llama3_1-70b`** | **8** (`v5p-8`) | **128** (`v5p-128`) | **128** (`v5p-128`) | Full remat multi-slice |

### 3. Fail-Fast Safety Guard & Model Isolation
* Upstream conversion failure on model A will only fail Model A sensor and abort Model A training (`upstream_failed`). Other models whose conversions succeed continue training without being skipped.

---

## Tests
- Validated Python syntax and imports across all DAG files with `python3 -m py_compile`.
- Tested on Cloud Composer environment `jackyf-test` (`cloud-ml-auto-solutions`):
  - 0 DAG import errors across all pipelines.
  - Verified `ExternalTaskSensor` dependency resolution across Stage 1 and Stage 2.

---

## Checklist
- [x] Tested DAG changes on Composer test environment.
- [x] Registered `maxtext_e2e_tpu_checkpoint_conversion` in `dag_integrity_whitelist.yaml`.
- [x] Self-review of changes.
