### PR TITLE
fix: Correct `hf_flags` in `maxtext_e2e_tpu_pre_training` and `maxtext_e2e_tpu_post_training` DAG

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -120,10 +120,12 @@ with models.DAG(
               "sft": {
                   "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_sft.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/sft/{run_name}/checkpoints/5/model_params",
+                  "to_hf_flags": "true",
               },
               "rl": {
                   "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/rl/{run_name}/checkpoints/actor/5/model_params",
+                  "to_hf_flags": "true",
               },
           },
       },

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -88,7 +88,7 @@ with models.DAG(
               "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/train/{run_name}/checkpoints/4/items",
           },
-          "to_hf_flags": "false true",
+          "to_hf_flags": "true",
       },
       "gpt-oss-20b": {
           "core_count": 8,
@@ -100,7 +100,6 @@ with models.DAG(
               "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/train/{run_name}/checkpoints/4/items",
           },
-          "to_hf_flags": "true",
       },
   }
   # pylint: enable=line-too-long


### PR DESCRIPTION
# Description

Correct `hf_flags` in checkpoint conversion for `GPT-OSS-20B` and `Qwen3-30B` end-to-end tests across the `maxtext_e2e_tpu_pre_training` and `maxtext_e2e_tpu_post_training` DAGs.

# Tests

Manually tested with XPK.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.