### PR TITLE
Explicitly set tp_hf_flags for Gemma3-4b RL tests

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -101,6 +101,7 @@ with models.DAG(
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_rl.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/rl/{run_name}/checkpoints/actor/2/model_params",
                   "core_count": 32,
+                  "to_hf_flags": "false false",
               },
           },
       },


### PR DESCRIPTION
# Description

Explicitly set tp_hf_flags for Gemma3-4b RL tests because RL training is done on unscanned checkpoint

# Tests

Tested locally

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.