### PR TITLE
fix: Organize arguments for tasks

### DIFF
--- a/dags/examples/configs/xpk_example_config.py
+++ b/dags/examples/configs/xpk_example_config.py
@@ -18,7 +18,6 @@ import datetime
 from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion
 
 
 def get_flax_resnet_xpk_config(
@@ -57,7 +56,11 @@ def get_flax_resnet_xpk_config(
       num_slices=num_slices,
   )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -23,7 +23,7 @@ import datetime
 from airflow import models
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from xlml.apis import metric_config
 
 SCHEDULED_TIME = None

--- a/dags/framework3p/configs/microbenchmarks_config.py
+++ b/dags/framework3p/configs/microbenchmarks_config.py
@@ -1,8 +1,23 @@
-from xlml.apis import gcp_config, metric_config, task, test_config
-from dags import gcs_bucket
-from dags.common import test_owner
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to construct configs for framework microbenchmarks."""
+
 import datetime
+from dags.common import test_owner as test_owners
 import dags.common.vm_resource as resource
+from xlml.apis import gcp_config, metric_config, task, test_config
 
 
 def get_microbenchmark_config(
@@ -14,8 +29,9 @@ def get_microbenchmark_config(
     project: resource.Project,
     network: str = "default",
     subnetwork: str = "default",
-    extraFlags: str = "",
+    extra_flags: str = "",
 ):
+  del extra_flags
   job_gcp_config = gcp_config.GCPConfig(
       project_name=project.value,
       zone=tpu_zone.value,
@@ -45,7 +61,10 @@ def get_microbenchmark_config(
   # Run the benchmark tests.
   run_model_cmds += (
       " rm -rf accelerator-microbenchmarks ",
-      "git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git  ",
+      (
+          "git clone https://github.com/AI-Hypercomputer/"
+          "accelerator-microbenchmarks.git "
+      ),
       "cd accelerator-microbenchmarks ",
       "pip install -r requirements.txt ",
       # Run the benchmark script
@@ -54,9 +73,10 @@ def get_microbenchmark_config(
 
   # Check if the metrics report exists, and if so, upload it to GCS
   run_model_cmds += (
-      f"if [ -f {metrics_report} ]; then "
-      f"gcloud storage cp {metrics_report} {metric_config.SshEnvVars.GCS_OUTPUT.value}; "
-      "fi",
+      (
+          f"if [ -f {metrics_report} ]; then gcloud storage cp {metrics_report}"
+          f" {metric_config.SshEnvVars.GCS_OUTPUT.value}; fi"
+      ),
   )
 
   job_test_config = test_config.TpuVmTest(
@@ -72,7 +92,7 @@ def get_microbenchmark_config(
       set_up_cmds=set_up_cmds,
       run_model_cmds=run_model_cmds,
       timeout=datetime.timedelta(minutes=time_out_in_min),
-      task_owner=test_owner.QINY_Y,
+      task_owner=test_owners.QINY_Y,
   )
 
   job_metric_config = metric_config.MetricConfig(
@@ -94,7 +114,9 @@ def get_microbenchmark_xpk_config(
     test_owner: str,
     cluster: resource.XpkClusterConfig,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = resource.Project.CLOUD_ML_AUTO_SOLUTIONS.value,
 ) -> task.XpkTask:
@@ -128,9 +150,10 @@ def get_microbenchmark_xpk_config(
 
   # Check if the metrics report exists, and if so, upload it to GCS
   run_model_cmds += (
-      f"if [ -f {metrics_report} ]; then "
-      f"gcloud storage cp {metrics_report} {metric_config.SshEnvVars.GCS_OUTPUT.value} ; "
-      "fi ",
+      (
+          f"if [ -f {metrics_report} ]; then gcloud storage cp {metrics_report}"
+          f" {metric_config.SshEnvVars.GCS_OUTPUT.value} ; fi "
+      ),
   )
 
   job_test_config = test_config.TpuGkeTest(
@@ -151,8 +174,11 @@ def get_microbenchmark_xpk_config(
       json_lines=metric_config.JSONLinesConfig("metrics_report.jsonl"),
       use_runtime_generated_gcs_folder=True,
   )
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+  )
+  return task.XpkTask(
+      runner_config=runner_config,
   )

--- a/dags/multipod/configs/jax_tests_gke_config.py
+++ b/dags/multipod/configs/jax_tests_gke_config.py
@@ -15,7 +15,7 @@
 """Utilities to construct configs for JAX tests for GCE."""
 
 from dags.common import test_owner
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.common.vm_resource import XpkClusterConfig
 
 

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -128,10 +128,14 @@ def get_maxtext_sweep_gke_config(
           file_location=base_output_directory,
       )
 
-    xpk_task = task.XpkNameGenAndQuarantineTask(
+    runner_config = task.XpkRunnerConfig(
         task_test_config=job_test_config,
         task_gcp_config=job_gcp_config,
         task_metric_config=job_metric_config,
+    )
+
+    xpk_task = task.XpkNameGenAndQuarantineTask(
+        runner_config=runner_config,
         quarantine_task_group=quarantine_task_group,
     )
     xpk_task_list.append(xpk_task)

--- a/dags/multipod/configs/pytorch_config.py
+++ b/dags/multipod/configs/pytorch_config.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dags.common.vm_resource import TpuVersion, Zone, DockerImage
-from dags.multipod.configs import gke_config
-from xlml.apis.xpk_cluster_config import XpkClusterConfig
-from xlml.apis import task
+"""Utilities to construct configs for PyTorch DAG on GKE."""
+
 from typing import List
+from dags.common.vm_resource import DockerImage
+from dags.multipod.configs import xpk_gke_config as gke_config
+from xlml.apis import task
+from xlml.apis.xpk_cluster_config import XpkClusterConfig
 
 
 def get_nightly_pytorch_config(

--- a/dags/multipod/configs/xpk_gke_config.py
+++ b/dags/multipod/configs/xpk_gke_config.py
@@ -21,6 +21,7 @@ from dags import gcs_bucket
 from dags.common.vm_resource import Project, XpkClusters
 from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
+from xlml.utils import xpk
 
 
 def get_gke_config(
@@ -39,6 +40,12 @@ def get_gke_config(
     base_output_directory: str = None,
     metric_aggregation_strategy: metric_config.AggregationStrategy = None,
     user_specified_job_metric_config: metric_config.MetricConfig = None,
+    priority: str = "high",
+    max_restart: int = 0,
+    xpk_branch: str = xpk.MAIN_BRANCH,
+    ramdisk_directory: str = "",
+    mtc_enabled: bool = False,
+    use_pathways: bool = False,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -77,10 +84,20 @@ def get_gke_config(
         else None
     )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+      priority=priority,
+      max_restart=max_restart,
+      xpk_branch=xpk_branch,
+      ramdisk_directory=ramdisk_directory,
+      mtc_enabled=mtc_enabled,
+      use_pathways=use_pathways,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )
 
 
@@ -103,6 +120,12 @@ def get_gke_config_with_interrupt(
     user_specified_job_metric_config: metric_config.MetricConfig = None,
     last_node: bool = False,
     check_file_exists: bool = False,
+    priority: str = "high",
+    max_restart: int = 0,
+    xpk_branch: str = xpk.MAIN_BRANCH,
+    ramdisk_directory: str = "",
+    mtc_enabled: bool = False,
+    use_pathways: bool = False,
 ) -> task.XpkNodeInterruptionTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -141,10 +164,20 @@ def get_gke_config_with_interrupt(
         else None
     )
 
-  return task.XpkNodeInterruptionTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+      priority=priority,
+      max_restart=max_restart,
+      xpk_branch=xpk_branch,
+      ramdisk_directory=ramdisk_directory,
+      mtc_enabled=mtc_enabled,
+      use_pathways=use_pathways,
+  )
+
+  return task.XpkNodeInterruptionTask(
+      runner_config=runner_config,
       expect_reach_to_step=expect_reach_to_step,
       last_node=last_node,
       check_file_exists=check_file_exists,
@@ -170,6 +203,12 @@ def get_gke_config_with_name_gen_and_quarantine(
     quarantine_task_group: Any = None,
     run_name_env: str = "M_RUN_NAME",
     nested_run_name_in_tb_file_location: bool = True,
+    priority: str = "high",
+    max_restart: int = 0,
+    xpk_branch: str = xpk.MAIN_BRANCH,
+    ramdisk_directory: str = "",
+    mtc_enabled: bool = False,
+    use_pathways: bool = False,
 ) -> task.XpkNameGenAndQuarantineTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -208,10 +247,20 @@ def get_gke_config_with_name_gen_and_quarantine(
         else None
     )
 
-  return task.XpkNameGenAndQuarantineTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+      priority=priority,
+      max_restart=max_restart,
+      xpk_branch=xpk_branch,
+      ramdisk_directory=ramdisk_directory,
+      mtc_enabled=mtc_enabled,
+      use_pathways=use_pathways,
+  )
+
+  return task.XpkNameGenAndQuarantineTask(
+      runner_config=runner_config,
       quarantine_task_group=quarantine_task_group,
       run_name_env=run_name_env,
       nested_run_name_in_tb_file_location=nested_run_name_in_tb_file_location,
@@ -282,9 +331,13 @@ def get_gke_maxtext_nightly_config(
       docker_image=docker_image,
   )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )
 
 
@@ -321,9 +374,13 @@ def get_maxtext_end_to_end_gpu_gke_test_config(
       num_slices=num_slices,
   )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )
 
 
@@ -392,9 +449,13 @@ def get_gke_gpt3_6b_nightly_config(
       docker_image=docker_image,
   )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )
 
 
@@ -450,8 +511,12 @@ def get_maxtext_cpu_end_to_end_gke_config(
       else None
   )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )

--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -20,7 +20,7 @@ from airflow import models
 from dags import composer_env, gcs_bucket
 from dags.common import test_owner
 from dags.common.vm_resource import DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)
@@ -70,16 +70,20 @@ with models.DAG(
           test_owner=test_owner.SURBHI_J,
       ).run()
 
-    # Checkpoint resharding test - trains a model with a specific sharding strategy and saves a checkpoint.
-    # Then train again by restoring this checkpoint using a different sharding strategy.
-    # Finally, asserts that the learning metrics are consistent, ensuring that checkpoints can be successfully loaded across different sharding strategies.
+    # Checkpoint resharding test - trains a model with a specific sharding
+    # strategy and saves a checkpoint. Then train again by restoring this
+    # checkpoint using a different sharding strategy. Finally, asserts that the
+    # learning metrics are consistent, ensuring that checkpoints can be
+    # successfully loaded across different sharding strategies.
     gke_config.get_gke_config(
         num_slices=2,
         cluster=XpkClusters.TPU_V5P_8_CLUSTER,
         time_out_in_min=60,
         test_name=f"maxtext-checkpoint-resharding-{mode.value}",
         run_model_cmds=(
-            f"bash tests/end_to_end/tpu/test_checkpoint_resharding.sh checkpoint-resharding-{mode.value} {base_output_directory} {dataset_path}",
+            "bash tests/end_to_end/tpu/test_checkpoint_resharding.sh"
+            f" checkpoint-resharding-{mode.value} {base_output_directory}"
+            f" {dataset_path}",
         ),
         docker_image=image.value,
         test_owner=test_owner.SURBHI_J,

--- a/dags/multipod/maxtext_configs_aot.py
+++ b/dags/multipod/maxtext_configs_aot.py
@@ -21,7 +21,7 @@ from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import DockerImage
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 5 am UTC (9 pm PST / 10 pm PDT)

--- a/dags/multipod/maxtext_configs_aot_gpu.py
+++ b/dags/multipod/maxtext_configs_aot_gpu.py
@@ -21,7 +21,7 @@ from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 # Run once a day at 5 am UTC (9 pm PST / 10 pm PDT)
 SCHEDULED_TIME = "45 4 * * *" if composer_env.is_prod_env() else None
@@ -47,8 +47,11 @@ with models.DAG(
       group_id="Quarantine", dag=dag, prefix_group_id=False
   )
 
-  # GPU AoT tests
-  cmd = "bash src/maxtext/configs/gpu/a3/llama_2_7b/8vm.sh EXECUTABLE=train_compile M_COMPILE_TOPOLOGY=a3 M_COMPILE_TOPOLOGY_NUM_SLICES=8"
+  cmd = (
+      "bash src/maxtext/configs/gpu/a3/llama_2_7b/8vm.sh"
+      " EXECUTABLE=train_compile M_COMPILE_TOPOLOGY=a3"
+      " M_COMPILE_TOPOLOGY_NUM_SLICES=8"
+  )
   stable_a3_gpu = gke_config.get_maxtext_end_to_end_gpu_gke_test_config(
       time_out_in_min=300,
       test_name="maxtext-aot-a3-stable",

--- a/dags/multipod/maxtext_configs_aot_hybridsim.py
+++ b/dags/multipod/maxtext_configs_aot_hybridsim.py
@@ -27,7 +27,7 @@ from dags import composer_env
 from dags.common.quarantined_tests import QuarantineTests
 from dags.common import test_owner
 from dags.common.vm_resource import TpuVersion, DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 
 # Run once a day at 1 pm UTC (5 am PST / 6 am PDT)

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -20,7 +20,7 @@ from airflow import models
 from dags import composer_env, gcs_bucket
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, DockerImage
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from xlml.apis import metric_config
 
 # Run once a day at 6 am UTC (10 pm PST)

--- a/dags/multipod/maxtext_e2e_tpu_checkpoint_conversion.py
+++ b/dags/multipod/maxtext_e2e_tpu_checkpoint_conversion.py
@@ -28,7 +28,7 @@ from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
@@ -100,4 +100,5 @@ with models.DAG(
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(core_count=8),
           test_owner=test_owner.JACKY_F,
-      ).run(skip_post_process=True, priority="very-high")
+          priority="very-high",
+      ).run(skip_post_process=True)

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -31,7 +31,7 @@ from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 # HF token retrieved from Airflow Variables for secure credential management
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
@@ -234,11 +234,9 @@ with models.DAG(
               run_model_cmds=training_cmd,
               docker_image="{{ params.docker_image }}",
               test_owner=test_owner.SURBHI_J,
-          ).run(
               use_pathways=True,
-              skip_post_process=True,
               priority="very-high",
-          )
+          ).run(skip_post_process=True)
 
           to_hf_flags = mode_test_config.get("to_hf_flags", "false true")
 
@@ -260,7 +258,8 @@ with models.DAG(
               docker_image="{{ params.docker_image }}",
               cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
               test_owner=test_owner.SURBHI_J,
-          ).run(skip_post_process=True, priority="very-high")
+              priority="very-high",
+          ).run(skip_post_process=True)
 
           chain(
               wait_for_conversion,

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -30,7 +30,7 @@ from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
@@ -141,7 +141,8 @@ with models.DAG(
               core_count=training_core_count
           ),
           test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+          priority="very-high",
+      ).run(skip_post_process=True)
 
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
@@ -163,7 +164,8 @@ with models.DAG(
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
-      ).run(skip_post_process=True, priority="very-high")
+          priority="very-high",
+      ).run(skip_post_process=True)
 
       wait_for_conversion = ExternalTaskSensorWithBypass(
           task_id="wait_for_conversion",

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -17,12 +17,13 @@
 
 import datetime
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common.quarantined_tests import QuarantineTests, safe_get_from_variable
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, DockerImage
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from xlml.utils import name_format
 
 # Run once a day at 4 am UTC (8 pm PST)
@@ -106,7 +107,7 @@ with models.DAG(
         cluster=XpkClusters.TPU_V5P_8_CLUSTER,
         test_owner=test_config["owner"],
     ).run_with_quarantine(quarantine_task_group)
-    stable_tpu >> nightly_tpu
+    chain(stable_tpu, nightly_tpu)
 
   multicluster_test_models = {
       "llama2-70b": [
@@ -136,59 +137,63 @@ with models.DAG(
   }
 
   def convert_checkpoint_and_run_training(
-      test_group_id,
-      test_name_prefix,
-      type,
-      docker_image,
-      model,
-      test_scripts_details,
+      grp_id,
+      prefix,
+      image_type,
+      img_val,
+      model_name,
+      scripts_details,
   ):
-    with TaskGroup(group_id=test_group_id, prefix_group_id=True) as group:
-      test_name = f"{test_name_prefix}-{type}-{model}"
+    with TaskGroup(group_id=grp_id, prefix_group_id=True):
+      test_name = f"{prefix}-{image_type}-{model_name}"
       shared_gcs_location = name_format.generate_gcs_folder_location.override(
-          task_id=f"{test_group_id}_generate_gcs_folder_location"
+          task_id=f"{grp_id}_generate_gcs_folder_location"
       )(
           gcs_subfolder,
-          test_group_id,
+          grp_id,
       )
+      script_name_cpu = scripts_details[0]["script_name"]
       conversion_cpu = gke_config.get_maxtext_cpu_end_to_end_gke_config(
-          time_out_in_min=test_scripts_details[0]["time_out_in_min"],
+          time_out_in_min=scripts_details[0]["time_out_in_min"],
           test_name=test_name,
           run_model_cmds=(
-              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/{test_scripts_details[0]['script_name']}.sh",
+              "export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash"
+              f" tests/end_to_end/{script_name_cpu}.sh",
           ),
-          docker_image=docker_image,
+          docker_image=img_val,
           test_owner=test_owner.ANISHA_M,
-          cluster=test_scripts_details[0]["cluster"],
+          cluster=scripts_details[0]["cluster"],
       ).run(gcs_location=shared_gcs_location)
+      script_name_tpu = scripts_details[1]["script_name"]
       training_tpu = gke_config.get_gke_config(
-          time_out_in_min=test_scripts_details[1]["time_out_in_min"],
+          time_out_in_min=scripts_details[1]["time_out_in_min"],
           test_name=test_name,
           run_model_cmds=(
-              f"export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash tests/end_to_end/{test_scripts_details[1]['script_name']}.sh",
+              "export BASE_OUTPUT_PATH=$GCS_OUTPUT; bash"
+              f" tests/end_to_end/{script_name_tpu}.sh",
           ),
-          docker_image=docker_image,
+          docker_image=img_val,
           test_owner=test_owner.ANISHA_M,
-          cluster=test_scripts_details[1]["cluster"],
+          cluster=scripts_details[1]["cluster"],
       ).run(gcs_location=shared_gcs_location)
       return conversion_cpu, training_tpu
 
-  docker_image = {
+  docker_images = {
       "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
       "nightly": DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
   }
-  tests = []
   for model, test_scripts_details in multicluster_test_models.items():
     gcs_subfolder = f"{test_owner.Team.MULTIPOD.value}/maxtext"
-    for type in docker_image.keys():
-      test_group_id = "chained_tests" + "_" + model + "_" + type
+    tests = []
+    for mode_type, image in docker_images.items():
+      test_group_id = f"chained_tests_{model}_{mode_type}"
       if QuarantineTests.is_quarantined(test_group_id):
         with quarantine_task_group:
           mode_cpu, mode_tpu = convert_checkpoint_and_run_training(
               test_group_id,
               test_name_prefix,
-              type,
-              docker_image[type],
+              mode_type,
+              image,
               model,
               test_scripts_details,
           )
@@ -196,8 +201,8 @@ with models.DAG(
         mode_cpu, mode_tpu = convert_checkpoint_and_run_training(
             test_group_id,
             test_name_prefix,
-            type,
-            docker_image[type],
+            mode_type,
+            image,
             model,
             test_scripts_details,
         )
@@ -205,5 +210,5 @@ with models.DAG(
       tests.append(mode_tpu)
 
     # stable_cpu >> stable_tpu >> nightly_cpu >> nightly_tpu
-    for i in range(len(tests) - 1):
-      tests[i] >> tests[i + 1]
+    if tests:
+      chain(*tests)

--- a/dags/multipod/maxtext_gpu_end_to_end.py
+++ b/dags/multipod/maxtext_gpu_end_to_end.py
@@ -19,13 +19,14 @@ import datetime
 import tempfile
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.decorators import task
 from airflow.hooks.subprocess import SubprocessHook
 from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, DockerImage, Project
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from xlml.utils import gke
 
 # Run once a day at 4 am UTC (8 pm PST)
@@ -122,22 +123,24 @@ def scale_down_a3_cluster():
     assert result.exit_code == 0, f"Command failed with code {result.exit_code}"
 
 
-def run_maxtext_tests(dag: models.DAG):
+def run_maxtext_tests(task_dag: models.DAG):
   test_name_prefix = "maxtext"
 
   timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M")
   train_base = (
       "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
-      "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml "
-      "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
-      "steps=2 enable_checkpointing=false attention=dot_product"
+      "python3 -m maxtext.trainers.pre_train.train"
+      " src/maxtext/configs/base.yml"
+      " base_output_directory=gs://runner-maxtext-logs"
+      " dataset_path=gs://maxtext-dataset steps=2 enable_checkpointing=false"
+      " attention=dot_product"
   )
   decode_base = (
       "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
       "python3 -m MaxText.decode src/maxtext/configs/base.yml "
-      "base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset "
-      "steps=2 enable_checkpointing=false attention=dot_product "
-      "max_target_length=128 per_device_batch_size=1"
+      "base_output_directory=gs://runner-maxtext-logs"
+      " dataset_path=gs://maxtext-dataset steps=2 enable_checkpointing=false"
+      " attention=dot_product max_target_length=128 per_device_batch_size=1"
   )
   test_models_gpu = {
       "train-c4-data": (f"{train_base} run_name=runner-{timestamp}-0", 1),
@@ -146,11 +149,13 @@ def run_maxtext_tests(dag: models.DAG):
           1,
       ),
       "train-flash": (
-          f"{train_base} run_name=runner-{timestamp}-2 attention=cudnn_flash_te",
+          f"{train_base} run_name=runner-{timestamp}-2"
+          " attention=cudnn_flash_te",
           1,
       ),
       "train-quarter-batch-size": (
-          f"{train_base} run_name=runner-{timestamp}-3 per_device_batch_size=0.25 ici_tensor_parallelism=4",
+          f"{train_base} run_name=runner-{timestamp}-3"
+          " per_device_batch_size=0.25 ici_tensor_parallelism=4",
           1,
       ),
       "train-int8": (
@@ -163,25 +168,29 @@ def run_maxtext_tests(dag: models.DAG):
       ),
       "decode": (f"{decode_base} run_name=runner-{timestamp}-4", 1),
       "decode-quarter-batch-size": (
-          f"{decode_base} run_name=runner-{timestamp}-5 per_device_batch_size=.25 ici_tensor_parallelism=4",
+          f"{decode_base} run_name=runner-{timestamp}-5"
+          " per_device_batch_size=.25 ici_tensor_parallelism=4",
           1,
       ),
       "generate-param-only-checkpoint": (
           "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
-          f"bash tests/end_to_end/test_generate_param_only_checkpoint.sh -r runner-{timestamp}-8 "
-          "-o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4 -a dot_product",
+          "bash tests/end_to_end/test_generate_param_only_checkpoint.sh"
+          f" -r runner-{timestamp}-8 -o gs://runner-maxtext-logs"
+          " -d gs://maxtext-dataset -i 4 -a dot_product",
           1,
       ),
       "generate-param-only-checkpoint-int8": (
           "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
-          f"bash tests/end_to_end/test_generate_param_only_checkpoint.sh -r runner-{timestamp}-9 "
-          "-o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4 -q int8 -a dot_product",
+          "bash tests/end_to_end/test_generate_param_only_checkpoint.sh"
+          f" -r runner-{timestamp}-9 -o gs://runner-maxtext-logs"
+          " -d gs://maxtext-dataset -i 4 -q int8 -a dot_product",
           1,
       ),
       "grain-checkpoint-determinism": (
           "XLA_PYTHON_CLIENT_MEM_FRACTION=0.65 TF_FORCE_GPU_ALLOW_GROWTH=true "
-          "bash tests/end_to_end/test_checkpointing.sh runner gs://runner-maxtext-logs "
-          "gs://maxtext-dataset c4-array_record dot_product",
+          "bash tests/end_to_end/test_checkpointing.sh runner"
+          " gs://runner-maxtext-logs gs://maxtext-dataset c4-array_record"
+          " dot_product",
           1,
       ),
       "checkpoint-compatibility": (
@@ -202,7 +211,7 @@ def run_maxtext_tests(dag: models.DAG):
   }
 
   quarantine_task_group = TaskGroup(
-      group_id="Quarantine", dag=dag, prefix_group_id=False
+      group_id="Quarantine", dag=task_dag, prefix_group_id=False
   )
 
   for model, (test_script, nnodes) in test_models_gpu.items():
@@ -224,7 +233,7 @@ def run_maxtext_tests(dag: models.DAG):
         docker_image=DockerImage.MAXTEXT_GPU_JAX_STABLE.value,
         test_owner=test_owner.DORA_H,
     ).run_with_quarantine(quarantine_task_group)
-    stable_a3_gpu >> stable_a3plus_gpu
+    chain(stable_a3_gpu, stable_a3plus_gpu)
 
 
 with models.DAG(
@@ -255,4 +264,4 @@ with models.DAG(
   with TaskGroup(group_id="scale_down", dag=dag) as scale_down:
     scale_down_a3_cluster()
 
-  scale_up >> run_tests >> scale_down
+  chain(scale_up, run_tests, scale_down)

--- a/dags/multipod/maxtext_multi_tier_checkpointing.py
+++ b/dags/multipod/maxtext_multi_tier_checkpointing.py
@@ -19,8 +19,8 @@ import datetime
 from airflow import models
 from dags import composer_env, gcs_bucket
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.common.vm_resource import DockerImage, XpkClusters
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.multipod.configs.common import SetupMode  # Run once a day at 10 am UTC (2 am PST)
 
 SCHEDULED_TIME = "0 3 * * *" if composer_env.is_prod_env() else None
@@ -72,4 +72,6 @@ with models.DAG(
             run_model_cmds=command,
             docker_image=image.value,
             test_owner=test_owner.ABHINAV_S,
-        ).run(ramdisk_directory="local", mtc_enabled=True)
+            ramdisk_directory="local",
+            mtc_enabled=True,
+        ).run()

--- a/dags/multipod/maxtext_profiling.py
+++ b/dags/multipod/maxtext_profiling.py
@@ -19,8 +19,8 @@ import datetime
 from airflow import models
 from dags import composer_env, gcs_bucket
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, DockerImage
-from dags.multipod.configs import gke_config
+from dags.common.vm_resource import DockerImage
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 6 am UTC (10 pm PST)
@@ -52,10 +52,12 @@ with models.DAG(
   for mode, image in docker_images:
     profiling_cmds = (
         f"export RUN_NAME=profiling_{mode.value}_$(date +%Y-%m-%d-%H-%M-%S)",
-        "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml"
+        "python3 -m maxtext.trainers.pre_train.train"
+        " src/maxtext/configs/base.yml"
         f" run_name=$RUN_NAME base_output_directory={base_output_directory}"
         f" dataset_path={dataset_path} profiler=xplane steps=20",
-        f"gcloud storage cp --recursive {base_output_directory}/$RUN_NAME/tensorboard .",
+        "gcloud storage cp --recursive"
+        f" {base_output_directory}/$RUN_NAME/tensorboard .",
     )
     maxtext_v4_configs_test = gke_config.get_gke_config(
         time_out_in_min=60,

--- a/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
+++ b/dags/multipod/maxtext_profiling_vertex_ai_tensorboard.py
@@ -20,8 +20,9 @@ from airflow import models
 from dags import gcs_bucket
 from dags.common import test_owner
 from dags.common.vm_resource import DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.multipod.configs.common import SetupMode
+from xlml.apis import metric_config
 
 SCHEDULED_TIME = None
 
@@ -67,7 +68,8 @@ with models.DAG(
                 f"-{accelerator}-{current_datetime}"
             ),
             (
-                "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml"
+                "python3 -m maxtext.trainers.pre_train.train"
+                " src/maxtext/configs/base.yml"
                 f" run_name=$RUN_NAME base_output_directory"
                 f"={base_output_directory} dataset_path={dataset_path}"
                 f" profiler=xplane steps=10"
@@ -89,4 +91,7 @@ with models.DAG(
             run_model_cmds=profiling_in_vertex_ai_tb_cmds,
             docker_image=image.value,
             test_owner=test_owner.SURBHI_J,
-        ).run(use_vertex_tensorboard=True)
+            user_specified_job_metric_config=metric_config.MetricConfig(
+                use_vertex_tensorboard=True
+            ),
+        ).run()

--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -20,7 +20,7 @@ from dags import composer_env, gcs_bucket
 from dags.common import test_owner
 from dags.common.quarantined_tests import safe_get_from_variable
 from dags.common.vm_resource import DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.multipod.configs.common import SetupMode
 
 # Run once a day at 10 am UTC (2 am PST)

--- a/dags/multipod/mxla_gpt3_6b_nightly_gke.py
+++ b/dags/multipod/mxla_gpt3_6b_nightly_gke.py
@@ -20,7 +20,7 @@ from airflow import models
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.vm_resource import DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 # Run once a day at 9 am UTC (1 am PST)
 # Pause test on GKE

--- a/dags/multipod/mxla_maxtext_nightly_gke.py
+++ b/dags/multipod/mxla_maxtext_nightly_gke.py
@@ -17,11 +17,12 @@ A DAG to run MXLA MaxText tests.
 """
 import datetime
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from dags import composer_env
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, DockerImage, XpkClusters, Project
-from dags.multipod.configs import gke_config
+from dags.common.vm_resource import DockerImage, XpkClusters
+from dags.multipod.configs import xpk_gke_config as gke_config
 
 # Run once a day at 5 pm UTC (1 am PST)
 SCHEDULED_TIME = "0 17 * * *" if composer_env.is_prod_env() else None
@@ -122,17 +123,17 @@ with models.DAG(
   ).run_with_quarantine(quarantine_task_group)
 
   # Define dependencies for v5p tests to run sequentially
-  (
-      maxtext_nightly_1slice_v5p_8
-      >> maxtext_nightly_2slice_v5p_8
-      >> maxtext_nightly_4slice_v5p_8
-      >> maxtext_nightly_8slice_v5p_8
+  chain(
+      maxtext_nightly_1slice_v5p_8,
+      maxtext_nightly_2slice_v5p_8,
+      maxtext_nightly_4slice_v5p_8,
+      maxtext_nightly_8slice_v5p_8,
   )
 
   # Define dependencies for v6e tests to run sequentially
-  (
-      maxtext_nightly_1slice_v6e_8
-      >> maxtext_nightly_2slice_v6e_8
-      >> maxtext_nightly_4slice_v6e_8
-      >> maxtext_nightly_8slice_v6e_8
+  chain(
+      maxtext_nightly_1slice_v6e_8,
+      maxtext_nightly_2slice_v6e_8,
+      maxtext_nightly_4slice_v6e_8,
+      maxtext_nightly_8slice_v6e_8,
   )

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -11,7 +11,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import checkpoint_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import validation_util
@@ -130,12 +130,10 @@ with models.DAG(
             test_owner=test_owner.DEPP_L,
             expect_reach_to_step=step_to_interrupt,
             last_node=True,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp.override(
             task_id="generate_end_time"

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -10,7 +10,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import checkpoint_util, test_config_util, validation_util
 from xlml.utils.gke import zone_to_region
 
@@ -127,12 +127,10 @@ with models.DAG(
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
             expect_reach_to_step=step_to_interrupt,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp.override(
             task_id="generate_end_time"

--- a/dags/orbax/maxtext_emc_resume_gcs.py
+++ b/dags/orbax/maxtext_emc_resume_gcs.py
@@ -15,7 +15,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import validation_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import checkpoint_util
@@ -156,11 +156,9 @@ with models.DAG(
             run_model_cmds=initial_workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
-        )
+        ).run(skip_post_process=True)
 
         wait_delete_first_cpc = checkpoint_util.wait_for_cpc_deletion.override(
             trigger_rule=TriggerRule.ALL_DONE
@@ -187,11 +185,9 @@ with models.DAG(
             run_model_cmds=resume_workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp.override(
             task_id="generate_end_time"

--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -12,7 +12,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import checkpoint_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import validation_util
@@ -120,12 +120,10 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.CAMILO_Q,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp()
 

--- a/dags/orbax/maxtext_mtc_emergency_save_local.py
+++ b/dags/orbax/maxtext_mtc_emergency_save_local.py
@@ -18,7 +18,7 @@ from dags import composer_env
 from dags.common import test_owner
 from dags.common.quarantined_tests import QuarantineTests
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import checkpoint_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import validation_util
@@ -155,12 +155,10 @@ with models.DAG(
                 run_model_cmds=workload_command,
                 docker_image=image.value,
                 test_owner=test_owner.CAMILO_Q,
-            ).run(
                 ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
                 mtc_enabled=True,
-                skip_post_process=True,
                 max_restart=15,
-            )
+            ).run(skip_post_process=True)
 
             end_time = validation_util.generate_timestamp()
 

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -11,7 +11,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import checkpoint_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import validation_util
@@ -130,12 +130,10 @@ with models.DAG(
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
             expect_reach_to_step=step_to_interrupt,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp.override(
             task_id="generate_end_time"

--- a/dags/orbax/maxtext_mtc_resume_gcs.py
+++ b/dags/orbax/maxtext_mtc_resume_gcs.py
@@ -15,7 +15,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import validation_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import checkpoint_util
@@ -159,11 +159,9 @@ with models.DAG(
             run_model_cmds=initial_workload_command,
             docker_image=image.value,
             test_owner=test_owner.JACKY_F,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
-        )
+        ).run(skip_post_process=True)
 
         wait_delete_first_cpc = checkpoint_util.wait_for_cpc_deletion.override(
             task_id="wait_delete_first_cpc",
@@ -193,11 +191,9 @@ with models.DAG(
             run_model_cmds=resume_workload_command,
             docker_image=image.value,
             test_owner=test_owner.JACKY_F,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp.override(
             task_id="generate_end_time"

--- a/dags/orbax/maxtext_mtc_save_gcs.py
+++ b/dags/orbax/maxtext_mtc_save_gcs.py
@@ -12,7 +12,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import checkpoint_util
 from dags.orbax.util import test_config_util
 from dags.orbax.util import validation_util
@@ -122,12 +122,10 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.CAMILO_Q,
-        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         steps_to_validate = test_config.generate_step_to_validate(is_local=True)
 

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -14,7 +14,7 @@ from airflow.decorators import task
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import validation_util, test_config_util
 from xlml.utils.xpk import MAIN_BRANCH
 from xlml.utils.gke import zone_to_region
@@ -140,11 +140,11 @@ with models.DAG(
             test_owner=test_owner.SHARON_Y,
             expect_reach_to_step=step_to_interrupt,
             check_file_exists=True,
+            xpk_branch=MAIN_BRANCH,
+            max_restart=15,
         ).run(
             gcs_location=gcs_location,
-            xpk_branch=MAIN_BRANCH,
             skip_post_process=True,
-            max_restart=15,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_reg_restore_gcs_with_resumed_workload.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_resumed_workload.py
@@ -13,7 +13,7 @@ from airflow import models
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import validation_util, test_config_util
 from xlml.utils.xpk import MAIN_BRANCH
 from xlml.utils.gke import zone_to_region
@@ -126,11 +126,9 @@ with models.DAG(
             run_model_cmds=initial_workload_command,
             docker_image=image.value,
             test_owner=test_owner.SHARON_Y,
-        ).run(
             xpk_branch=MAIN_BRANCH,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         test_config.steps = 100
         resume_workload_command = test_config.generate_workload_command(
@@ -154,11 +152,9 @@ with models.DAG(
             run_model_cmds=resume_workload_command,
             docker_image=image.value,
             test_owner=test_owner.SHARON_Y,
-        ).run(
             xpk_branch=MAIN_BRANCH,
-            skip_post_process=True,
             max_restart=15,
-        )
+        ).run(skip_post_process=True)
 
         end_time = validation_util.generate_timestamp.override(
             task_id="generate_end_time"

--- a/dags/orbax/maxtext_reg_save_gcs.py
+++ b/dags/orbax/maxtext_reg_save_gcs.py
@@ -13,7 +13,7 @@ from airflow import models
 from dags import composer_env
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from dags.orbax.util import validation_util, test_config_util
 from xlml.utils.xpk import MAIN_BRANCH
 from xlml.utils.gke import zone_to_region
@@ -116,10 +116,8 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.JACKY_F,
-        ).run(
             xpk_branch=MAIN_BRANCH,
-            skip_post_process=True,
-        )
+        ).run(skip_post_process=True)
 
         steps_to_validate = test_config.generate_step_to_validate(
             is_local=False

--- a/dags/sparsity_diffusion_devx/configs/gke_config.py
+++ b/dags/sparsity_diffusion_devx/configs/gke_config.py
@@ -84,8 +84,12 @@ def get_gke_config(
         tensorboard_summary=tensorboard_summary_config,
     )
 
-  return task.XpkTask(
+  runner_config = task.XpkRunnerConfig(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+  )
+
+  return task.XpkTask(
+      runner_config=runner_config,
   )

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -28,7 +28,7 @@ from dags.common.quarantined_tests import (
     safe_get_from_variable,
 )
 from dags.common.vm_resource import DockerImage, XpkClusters
-from dags.multipod.configs import gke_config
+from dags.multipod.configs import xpk_gke_config as gke_config
 from xlml.utils import name_format
 
 # Run once a day at 1 am UTC (5 pm PST)
@@ -106,16 +106,15 @@ with models.DAG(
   unchained_tests = []
   for model, test_scripts_details in test_models_tpu.items():
     for image, image_config in docker_image.items():
+      script_name = test_scripts_details["script_name"]
+      run_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}; export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
+          f"bash tests/end_to_end/{script_name}.sh"
+      )
       training_tpu = gke_config.get_gke_config(
           time_out_in_min=test_scripts_details["time_out_in_min"],
           test_name=f"{test_name_prefix}_{image}_{model}",
-          run_model_cmds=tuple(
-              [
-                  f"export HF_TOKEN={HF_TOKEN}; "
-                  "export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
-                  f"bash tests/end_to_end/{test_scripts_details['script_name']}.sh"
-              ]
-          ),
+          run_model_cmds=(run_cmd,),
           docker_image=image_config,
           test_owner=test_scripts_details["owner"],
           cluster=test_scripts_details["cluster"],
@@ -173,30 +172,28 @@ with models.DAG(
           gcs_subfolder,
           test_group_id_val,
       )
+      script_name_cpu = test_scripts_details_list[0]["script_name"]
+      cmd_cpu = (
+          f"export HF_TOKEN={HF_TOKEN}; export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
+          f"bash tests/end_to_end/{script_name_cpu}.sh"
+      )
       conversion_cpu = gke_config.get_maxtext_cpu_end_to_end_gke_config(
           time_out_in_min=test_scripts_details_list[0]["time_out_in_min"],
           test_name=test_name,
-          run_model_cmds=tuple(
-              [
-                  f"export HF_TOKEN={HF_TOKEN}; "
-                  "export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
-                  f"bash tests/end_to_end/{test_scripts_details_list[0]['script_name']}.sh"
-              ]
-          ),
+          run_model_cmds=(cmd_cpu,),
           docker_image=docker_image_config,
           test_owner=test_scripts_details_list[0]["owner"],
           cluster=test_scripts_details_list[0]["cluster"],
       ).run(gcs_location=shared_gcs_location)
+      script_name_tpu = test_scripts_details_list[1]["script_name"]
+      cmd_tpu = (
+          f"export HF_TOKEN={HF_TOKEN}; export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
+          f"bash tests/end_to_end/{script_name_tpu}.sh"
+      )
       training_tpu_task = gke_config.get_gke_config(
           time_out_in_min=test_scripts_details_list[1]["time_out_in_min"],
           test_name=test_name,
-          run_model_cmds=tuple(
-              [
-                  f"export HF_TOKEN={HF_TOKEN}; "
-                  "export BASE_OUTPUT_PATH=$GCS_OUTPUT; "
-                  f"bash tests/end_to_end/{test_scripts_details_list[1]['script_name']}.sh"
-              ]
-          ),
+          run_model_cmds=(cmd_tpu,),
           docker_image=docker_image_config,
           test_owner=test_scripts_details_list[0]["owner"],
           cluster=test_scripts_details_list[1]["cluster"],

--- a/xlml/apis/metric_config.py
+++ b/xlml/apis/metric_config.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import enum
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 
 # TODO(ranran): add project info to let users specify dataset location
@@ -102,9 +102,12 @@ class MetricConfig:
     profile: The config for profile input.
     use_runtime_generated_gcs_folder: Indicator to use path based on
       benchmark_id from generate_gcs_folder_location()
+    use_vertex_tensorboard: Set to True to view workload data on Vertex AI
+      Tensorboard.
   """
 
   json_lines: Optional[JSONLinesConfig] = None
   tensorboard_summary: Optional[SummaryConfig] = None
   profile: Optional[ProfileConfig] = None
   use_runtime_generated_gcs_folder: bool = False
+  use_vertex_tensorboard: bool = False

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -16,6 +16,7 @@
 
 import abc
 import contextlib
+import copy
 import dataclasses
 import datetime
 import shlex
@@ -48,12 +49,25 @@ class BaseTask(abc.ABC):
     pass
 
   def run_with_quarantine(self, quarantine_task_group):
-    """Run a test job. If the test job is flaky, wrap it in a special task grop.
+    """Run a test job.
+
+    If the test job is flaky, wrap it in a special task group.
 
     Returns:
       A DAG node that executes this test.
     """
-    test_name = self.task_test_config.benchmark_id
+    if hasattr(self, "runner_config"):
+      task_test_config = self.runner_config.task_test_config
+    elif hasattr(self, "task_test_config"):
+      task_test_config = self.task_test_config
+    elif hasattr(self, "test_cfg"):
+      task_test_config = self.test_cfg
+    else:
+      raise AttributeError(
+          f"{self.__class__.__name__} does not have a test configuration"
+          " attribute."
+      )
+    test_name = task_test_config.benchmark_id
     if QuarantineTests.is_quarantined(test_name):
       with quarantine_task_group:
         return self.run()
@@ -324,81 +338,124 @@ class AXLearnTask(BaseTask):
 
 
 @dataclasses.dataclass
-class XpkRunner:
-  """XpkRunner executes XPK workloads and manages their lifecycle."""
+class RunnerConfig:
+  """Base static configuration for all workload runners."""
 
   task_test_config: Union[
       test_config.TpuGkeTest, test_config.GpuXpkTest, test_config.CpuGkeTest
   ]
   task_gcp_config: gcp_config.GCPConfig
-  workload_id: airflow.XComArg
-  gcs_path: airflow.XComArg
-  workload_provision_timeout: datetime.timedelta
-  use_vertex_tensorboard: bool = False
-  use_pathways: bool = False
+  task_metric_config: metric_config.MetricConfig | None = None
+  workload_provision_timeout: datetime.timedelta = datetime.timedelta(
+      minutes=60
+  )
+
+
+@dataclasses.dataclass
+class XpkRunnerConfig(RunnerConfig):
+  """Static configuration specific to XPK workloads on GKE."""
+
+  xpk_branch: str = xpk.MAIN_BRANCH
+  priority: str = "high"
+  max_restart: int = 0
   ramdisk_directory: str = ""
   mtc_enabled: bool = False
-  xpk_branch: str = xpk.MAIN_BRANCH
-  max_restart: int = 0
-  priority: str = "high"
+  use_pathways: bool = False
+
+
+@dataclasses.dataclass
+class Runner(abc.ABC):
+  """Base runner managing runtime workload lifecycle and dynamic XComArgs."""
+
+  configs: RunnerConfig
+  workload_id: airflow.XComArg
+  gcs_path: airflow.XComArg
+
+  @abc.abstractmethod
+  def launch_workload(self) -> DAGNode:
+    pass
+
+  @abc.abstractmethod
+  def wait_workload_complete(self) -> DAGNode:
+    pass
+
+  @abc.abstractmethod
+  def cleanup_workload(self, tear_down_of: BaseOperator) -> DAGNode:
+    pass
+
+
+@dataclasses.dataclass
+class XpkRunner(Runner):
+  """XpkRunner executes XPK workloads and manages their lifecycle."""
+
+  configs: XpkRunnerConfig
 
   def launch_workload(self) -> DAGNode:
     """Create the workload and wait for it to provision."""
+    use_vertex_tensorboard = (
+        self.configs.task_metric_config.use_vertex_tensorboard
+        if self.configs.task_metric_config
+        else False
+    )
+
     with TaskGroup(group_id="launch_workload") as group:
       run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
+          owner=self.configs.task_test_config.task_owner
       )(
           task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
+          cluster_project=self.configs.task_gcp_config.project_name,
+          zone=self.configs.task_gcp_config.zone,
+          cluster_name=self.configs.task_test_config.cluster_name,
+          benchmark_id=self.configs.task_test_config.benchmark_id,
           workload_id=self.workload_id,
           gcs_path=self.gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
-          use_vertex_tensorboard=self.use_vertex_tensorboard,
-          use_pathways=self.use_pathways,
-          ramdisk_directory=self.ramdisk_directory,
-          mtc_enabled=self.mtc_enabled,
-          xpk_branch=self.xpk_branch,
-          max_restart=self.max_restart,
-          priority=self.priority,
-          namespace=self.task_test_config.namespace,
+          docker_image=self.configs.task_test_config.docker_image,
+          accelerator_type=self.configs.task_test_config.accelerator.name,
+          run_cmds=self.configs.task_test_config.test_script,
+          num_slices=self.configs.task_test_config.num_slices,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=self.configs.use_pathways,
+          ramdisk_directory=self.configs.ramdisk_directory,
+          mtc_enabled=self.configs.mtc_enabled,
+          xpk_branch=self.configs.xpk_branch,
+          max_restart=self.configs.max_restart,
+          priority=self.configs.priority,
+          namespace=self.configs.task_test_config.namespace,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
+          timeout=self.configs.workload_provision_timeout.total_seconds()
       )(
           workload_id=self.workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-          namespace=self.task_test_config.namespace,
+          project_id=self.configs.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.configs.task_gcp_config.zone),
+          cluster_name=self.configs.task_test_config.cluster_name,
+          namespace=self.configs.task_test_config.namespace,
       )
       chain(run_workload, wait_for_workload_start)
       return group
 
-  def wait_workload_complete(self) -> BaseOperator:
-    return xpk.wait_for_workload_completion.override(
-        timeout=int(self.task_test_config.timeout.total_seconds()),
-    )(
+  def wait_workload_complete(self) -> DAGNode:
+    op = xpk.wait_for_workload_completion
+    if self.configs.task_test_config.timeout:
+      op = op.override(
+          timeout=int(self.configs.task_test_config.timeout.total_seconds())
+      )
+    return op(
         workload_id=self.workload_id,
-        project_id=self.task_gcp_config.project_name,
-        region=gke.zone_to_region(self.task_gcp_config.zone),
-        cluster_name=self.task_test_config.cluster_name,
-        namespace=self.task_test_config.namespace,
+        project_id=self.configs.task_gcp_config.project_name,
+        region=gke.zone_to_region(self.configs.task_gcp_config.zone),
+        cluster_name=self.configs.task_test_config.cluster_name,
+        namespace=self.configs.task_test_config.namespace,
     )
 
   def cleanup_workload(self, tear_down_of: BaseOperator) -> DAGNode:
     return xpk.clean_up_workload(
         workload_id=self.workload_id,
-        project_id=self.task_gcp_config.project_name,
-        zone=self.task_gcp_config.zone,
-        cluster_name=self.task_test_config.cluster_name,
-        xpk_branch=self.xpk_branch,
-        namespace=self.task_test_config.namespace,
+        project_id=self.configs.task_gcp_config.project_name,
+        zone=self.configs.task_gcp_config.zone,
+        cluster_name=self.configs.task_test_config.cluster_name,
+        xpk_branch=self.configs.xpk_branch,
+        namespace=self.configs.task_test_config.namespace,
     ).as_teardown(
         setups=tear_down_of,
         on_failure_fail_dagrun=True,
@@ -414,11 +471,11 @@ class XpkRunner:
           task_id="wait_for_workload_reach_step"
       )(
           workload_id=self.workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
+          project_id=self.configs.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.configs.task_gcp_config.zone),
+          cluster_name=self.configs.task_test_config.cluster_name,
           expect_reach_to_step=str(expect_reach_to_step),
-          namespace=self.task_test_config.namespace,
+          namespace=self.configs.task_test_config.namespace,
       )
 
       task_id_wait_file_exist = "wait_for_file_to_exist"
@@ -453,15 +510,16 @@ class XpkRunner:
 
   def interrupt_workload(self, is_targeting_on_last_node: bool) -> DAGNode:
     return xpk.delete_node.override(
-        owner=self.task_test_config.task_owner, trigger_rule="none_failed"
+        owner=self.configs.task_test_config.task_owner,
+        trigger_rule="none_failed",
     )(
-        project=self.task_gcp_config.project_name,
-        zone=self.task_gcp_config.zone,
-        cluster_name=self.task_test_config.cluster_name,
+        project=self.configs.task_gcp_config.project_name,
+        zone=self.configs.task_gcp_config.zone,
+        cluster_name=self.configs.task_test_config.cluster_name,
         workload_id=self.workload_id,
         dry_run=False,
         last_node=is_targeting_on_last_node,
-        namespace=self.task_test_config.namespace,
+        namespace=self.configs.task_test_config.namespace,
     )
 
 
@@ -470,57 +528,31 @@ class XpkTask(BaseTask):
   """This is a class to set up tasks for TPU/GPU provisioned by XPK tool.
 
   Attributes:
-    task_test_config: Test configs to run on this TPU/GPU.
-    task_gcp_config: Runtime TPU/GPU creation parameters.
-    task_metric_config: Metric configs to process metrics.
-    workload_provision_timeout: Time allowed for provisioning a workload.
+    runner_config: Static configuration for the XPK runner.
   """
 
-  task_test_config: Union[
-      test_config.TpuGkeTest, test_config.GpuXpkTest, test_config.CpuGkeTest
-  ]
-  task_gcp_config: gcp_config.GCPConfig
-  task_metric_config: metric_config.MetricConfig | None = None
-  workload_provision_timeout: datetime.timedelta = datetime.timedelta(
-      # Set the provision timeout from 300 to 60 minutes for decreasing the
-      # duration of failed tasks
-      minutes=60
-  )
+  runner_config: XpkRunnerConfig
 
   def run(
       self,
-      *,
       gcs_location: airflow.XComArg | None = None,
-      use_vertex_tensorboard: bool = False,
-      use_pathways: bool = False,
       skip_post_process: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
   ) -> DAGNode:
     """Run a test job within a docker image.
 
     Attributes:
       gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
+      skip_post_process: If True, skip the post-processing step.
 
     Returns:
       A task group with the following tasks chained: run_model and
       post_process.
     """
-    with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
+    with TaskGroup(
+        group_id=self.runner_config.task_test_config.benchmark_id
+    ) as group:
       pre_process, xpk_runner = self._pre_process(
           gcs_location=gcs_location,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-          priority=priority,
       )
 
       run_model = self._run_model(xpk_runner)
@@ -553,39 +585,25 @@ class XpkTask(BaseTask):
       return gcs_location
 
     return name_format.generate_gcs_folder_location(
-        self.task_test_config.gcs_subfolder,
-        self.task_test_config.benchmark_id,
+        self.runner_config.task_test_config.gcs_subfolder,
+        self.runner_config.task_test_config.benchmark_id,
     )
 
   def _pre_process(
       self,
       gcs_location: airflow.XComArg | None = None,
-      use_vertex_tensorboard: bool = False,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
   ) -> tuple[DAGNode, XpkRunner]:
     with TaskGroup(group_id="pre_process") as group:
-      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+      workload_id = xpk.generate_workload_id(
+          self.runner_config.task_test_config.benchmark_id
+      )
 
       gcs_path = self._maybe_generate_gcs_location(gcs_location)
 
       xpk_runner = XpkRunner(
-          task_test_config=self.task_test_config,
-          task_gcp_config=self.task_gcp_config,
+          configs=self.runner_config,
           workload_id=workload_id,
           gcs_path=gcs_path,
-          workload_provision_timeout=self.workload_provision_timeout,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-          priority=priority,
       )
 
     return group, xpk_runner
@@ -598,26 +616,36 @@ class XpkTask(BaseTask):
     """
     with TaskGroup(group_id="post_process") as group:
       process_id = metric.generate_process_id.override(retries=0)()
-      post_process_metrics = metric.process_metrics.override(retries=0)(
-          process_id,
-          self.task_test_config,
-          self.task_metric_config,
-          self.task_gcp_config,
-          folder_location=result_location,
-      )
+      task_metric_config = self.runner_config.task_metric_config
 
-      if self.task_metric_config and self.task_metric_config.profile:
-        self.task_metric_config.profile.metrics = (
-            metric.xplane_to_metrics.override(retries=0)(
-                self.task_metric_config.profile.file_location
-            )
+      if task_metric_config and task_metric_config.profile:
+        task_metric_config = copy.copy(task_metric_config)
+        profile = copy.copy(task_metric_config.profile)
+        profile.metrics = metric.xplane_to_metrics.override(retries=0)(
+            profile.file_location
+        )
+        task_metric_config.profile = profile
+
+        post_process_metrics = metric.process_metrics.override(retries=0)(
+            process_id,
+            self.runner_config.task_test_config,
+            task_metric_config,
+            self.runner_config.task_gcp_config,
+            folder_location=result_location,
         )
         chain(
             process_id,
-            self.task_metric_config.profile.metrics,
+            profile.metrics,
             post_process_metrics,
         )
       else:
+        post_process_metrics = metric.process_metrics.override(retries=0)(
+            process_id,
+            self.runner_config.task_test_config,
+            task_metric_config,
+            self.runner_config.task_gcp_config,
+            folder_location=result_location,
+        )
         chain(process_id, post_process_metrics)
 
       return group
@@ -663,16 +691,8 @@ class XpkNameGenAndQuarantineTask(XpkTask):
 
   def run(
       self,
-      *,
       gcs_location: airflow.XComArg | None = None,
-      use_vertex_tensorboard: bool = False,
-      use_pathways: bool = False,
       skip_post_process: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
   ) -> DAGNode:
     """Generate a unique run name, tensorboard file location,
     and profile file location (if metric config has profile),
@@ -684,7 +704,7 @@ class XpkNameGenAndQuarantineTask(XpkTask):
       run provision, run_model, post_process.
     """
 
-    test_name = self.task_test_config.benchmark_id
+    test_name = self.runner_config.task_test_config.benchmark_id
     cm = (
         self.quarantine_task_group
         if QuarantineTests.is_quarantined(test_name)
@@ -695,77 +715,68 @@ class XpkNameGenAndQuarantineTask(XpkTask):
     with cm:
       return super().run(
           gcs_location=gcs_location,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
           skip_post_process=skip_post_process,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-          priority=priority,
       )
 
   def _pre_process(
       self,
       gcs_location: airflow.XComArg | None = None,
-      use_vertex_tensorboard: bool = False,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
   ) -> tuple[DAGNode, XpkRunner]:
     with TaskGroup(group_id="pre_process") as group:
       run_name = name_format.generate_run_name(
-          self.task_test_config.benchmark_id
+          self.runner_config.task_test_config.benchmark_id
       )
-      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+      workload_id = xpk.generate_workload_id(
+          self.runner_config.task_test_config.benchmark_id
+      )
 
       gcs_path = self._maybe_generate_gcs_location(gcs_location)
 
       nodes = [run_name]
 
-      tb_file_location = name_format.generate_tb_file_location(
-          run_name,
-          self.task_metric_config.tensorboard_summary.file_location,
-          self.nested_run_name_in_tb_file_location,
-      )
+      # Shallow-copy runner_config and task_test_config to prevent mutating
+      # shared configs.
+      runner_config = copy.copy(self.runner_config)
+      task_test_config = copy.copy(self.runner_config.task_test_config)
+      task_test_config.run_model_cmds = [
+          f"export {self.run_name_env}={run_name}",
+          *self.runner_config.task_test_config.run_model_cmds,
+      ]
+      runner_config.task_test_config = task_test_config
 
-      # Set run_name in run_model_cmds
-      new_run_model_cmds = [f"export {self.run_name_env}={run_name}"]
-      for cmd in self.task_test_config.run_model_cmds:
-        new_run_model_cmds.append(cmd)
-      self.task_test_config.run_model_cmds = new_run_model_cmds
+      # Update tensorboard and profile file locations
+      if (
+          self.runner_config.task_metric_config
+          and self.runner_config.task_metric_config.tensorboard_summary
+      ):
+        task_metric_config = copy.copy(self.runner_config.task_metric_config)
+        runner_config.task_metric_config = task_metric_config
 
-      # Update tensorboard file location
-      self.task_metric_config.tensorboard_summary.file_location = (
-          tb_file_location
-      )
-
-      # Update profile file location
-      if self.task_metric_config and self.task_metric_config.profile:
-        profile_file_location = name_format.generate_profile_file_location(
-            run_name, self.task_metric_config.profile.file_location
+        tensorboard_summary = copy.copy(task_metric_config.tensorboard_summary)
+        tb_file_location = name_format.generate_tb_file_location(
+            run_name,
+            tensorboard_summary.file_location,
+            self.nested_run_name_in_tb_file_location,
         )
-        self.task_metric_config.profile.file_location = profile_file_location
-        nodes.append([tb_file_location, profile_file_location])
-      else:
-        nodes.append(tb_file_location)
+        tensorboard_summary.file_location = tb_file_location
+        task_metric_config.tensorboard_summary = tensorboard_summary
+
+        if task_metric_config.profile:
+          profile = copy.copy(task_metric_config.profile)
+          profile_file_location = name_format.generate_profile_file_location(
+              run_name,
+              profile.file_location,
+          )
+          profile.file_location = profile_file_location
+          task_metric_config.profile = profile
+          nodes.append([tb_file_location, profile_file_location])
+        else:
+          nodes.append(tb_file_location)
 
       xpk_runner = XpkRunner(
-          task_test_config=self.task_test_config,
-          task_gcp_config=self.task_gcp_config,
+          configs=runner_config,
           workload_id=workload_id,
           gcs_path=gcs_path,
-          workload_provision_timeout=self.workload_provision_timeout,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-          priority=priority,
       )
 
       chain(*nodes)


### PR DESCRIPTION
## Description

Refactors `xlml/apis/task.py` and `dags/multipod/configs/gke_config.py` by introducing **`RunnerConfig`** and **`Runner`** abstractions to cleanly decouple **static configuration** from **runtime lifecycle execution**.

---

## Before vs. After

| Aspect | Before | After |
| :--- | :--- | :--- |
| **Config Passing** | 10+ execution args mixed in `Task` & `.run(...)` | Grouped into `XpkRunnerConfig` |
| **Lifecycle Ops** | Embedded directly inside `XpkTask` | Delegated to `XpkRunner` |
| **`Task.run()` Signature** | `.run(ramdisk_dir=..., mtc_enabled=..., ...)` | `.run(gcs_location=..., skip_post_process=...)` |
| **Vertex Tensorboard** | Ad-hoc arg passed across methods | Moved into `MetricConfig.use_vertex_tensorboard` |

---

## Architecture & Class Structure

| Class | Type | Responsibility | Key Fields & Methods |
| :--- | :--- | :--- | :--- |
| **`BaseTask`** | Abstract | Base task generator | **Methods:**<br>• `run()`<br>• `run_with_quarantine()` |
| **`RunnerConfig`** | Dataclass | Static workload settings | **Fields:** `task_test_config`, `task_gcp_config`, `task_metric_config`, `workload_provision_timeout` |
| **`XpkRunnerConfig`** | Dataclass | Subclass for XPK/GKE | **Fields:** Extends **`RunnerConfig`** + `xpk_branch`, `priority`, `max_restart`, `ramdisk_directory`, `mtc_enabled`, `use_pathways` |
| **`Runner`** | Abstract | Workload lifecycle manager | **Fields:** `configs`, `workload_id`, `gcs_path`<br>**Methods:**<br>• `launch_workload()`<br>• `wait_workload_complete()`<br>• `cleanup_workload(tear_down_of)` |
| **`XpkRunner`** | Class | Concrete XPK runner | **Fields:** `configs: XpkRunnerConfig`<br>**Methods:**<br>• `launch_workload()`<br>• `wait_workload_complete()`<br>• `cleanup_workload(tear_down_of)`<br>• `wait_workload_reach_to_step(expect_reach_to_step, check_file_exists)`<br>• `interrupt_workload(is_targeting_on_last_node)` |
| **`XpkTask`** | Class | Task pipeline builder | **Fields:** `runner_config: XpkRunnerConfig`<br>**Methods:**<br>• `run(gcs_location, skip_post_process)` |

---

## Key Changes

- **`task.py`**: Added `RunnerConfig`, `XpkRunnerConfig`, `Runner`, `XpkRunner`; simplified `XpkTask` & `XpkNameGenAndQuarantineTask`.
- **`gke_config.py`**: Factory functions (`get_gke_config`, etc.) build `XpkRunnerConfig` at creation time.
- Rename **`gke_config.py`** to **`xpk_gke_config.py`**
- **`metric_config.py`**: Added `use_vertex_tensorboard: bool = False` to group all metric/profiling settings into `MetricConfig`.
- **`dags/...`**: Updated call sites to pass runner options to `gke_config` instead of `.run(...)`.


# Tests
- [maxtext_profile_namegen_example_dag](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_profile_namegen_example_dag/grid?search=maxtext_profile_namegen_example_dag&dag_run_id=manual__2026-08-18T09%3A14%3A34.432109%2B00%3A00&tab=graph)
- [maxtext_profiling_vertex_ai_tensorboard](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_profiling_vertex_ai_tensorboard/grid?search=maxtext_profiling_vertex_ai_tensorboard&dag_run_id=manual__2026-08-18T09%3A14%3A07.085551%2B00%3A00&tab=graph)
- [maxtext_regular_restore_with_node_disruption](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_regular_restore_with_node_disruption/grid?search=maxtext_regular_restore_with_node_disruption&dag_run_id=manual__2026-08-18T09%3A14%3A09.030306%2B00%3A00&tab=graph)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.