### PR TITLE
Fix HF out-of-disk error during checkpoint conversion via shm mount

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_checkpoint_conversion.py
+++ b/dags/multipod/maxtext_e2e_tpu_checkpoint_conversion.py
@@ -89,7 +89,7 @@ with models.DAG(
       to_maxtext_cmd = config["to_maxtext"]
       convert_to_maxtext_cmd = (
           f"export HF_TOKEN={HF_TOKEN}",
-          'export HF_HOME="/dev/shm/hf_cache"',
+          'export HF_HOME="/mnt/shm/hf_cache"',
           'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
           f"{to_maxtext_cmd} {run_name}",
       )
@@ -103,4 +103,5 @@ with models.DAG(
           test_owner=test_owner.JACKY_F,
           priority="very-high",
           use_gcluster=True,
+          mounts="/dev/shm;/mnt/shm;rw",
       ).run(skip_post_process=True)

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -268,7 +268,7 @@ with models.DAG(
           to_hf_script = test_config["to_huggingface"]
           convert_to_huggingface_cmd = (
               f"export HF_TOKEN={HF_TOKEN}",
-              'export HF_HOME="/dev/shm/hf_cache"',
+              'export HF_HOME="/mnt/shm/hf_cache"',
               'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
               f"{to_hf_script} {run_name} {model_path} {to_hf_flags}",
           )
@@ -281,6 +281,7 @@ with models.DAG(
               test_owner=test_owner.SURBHI_J,
               priority="very-high",
               use_gcluster=True,
+              mounts="/dev/shm;/mnt/shm;rw",
           ).run(skip_post_process=True)
 
           chain(

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -174,7 +174,7 @@ with models.DAG(
 
       convert_to_huggingface_cmd = (
           f"export HF_TOKEN={HF_TOKEN}",
-          'export HF_HOME="/dev/shm/hf_cache"',
+          'export HF_HOME="/mnt/shm/hf_cache"',
           'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
           f"{to_hf_script} {run_name} {model_path} {to_hf_flags}",
       )
@@ -187,6 +187,7 @@ with models.DAG(
           test_owner=test_owner.SURBHI_J,
           priority="very-high",
           use_gcluster=True,
+          mounts="/dev/shm;/mnt/shm;rw",
       ).run(skip_post_process=True)
 
       wait_for_conversion = ExternalTaskSensorWithBypass(


### PR DESCRIPTION
# Description

Fix HuggingFace `Not enough free disk space` errors during checkpoint conversion and `to-hf` steps.
- **Issue**: The default container `/dev/shm` is limited to 64MB, which causes out-of-disk errors when downloading large models via HF. Mounting to `/dev/shm` directly using `gcluster` is blocked by Kubernetes as `/dev` is a reserved system directory.
- **Fix**: Mount the host node's limitless `/dev/shm` tmpfs to a safe directory (`/mnt/shm`) inside the container via `mounts="/dev/shm;/mnt/shm;rw"`.             
- **Affected DAGs**: Updated `HF_HOME` to `/mnt/shm/hf_cache` and added the mount parameter across `maxtext_e2e_tpu_checkpoint_conversion.py`, `maxtext_e2e_tpu_pre_training.py`, and `maxtext_e2e_tpu_post_training.py`.

[DAG Error Log](https://efdb2a1d6c2c435b8b7de77690c286a9-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_checkpoint_conversion/grid?search=maxtext_e2e_tpu_checkpoint_conversion&tab=logs&task_id=gemma3-4b.to-mt-v5p-8.run_model.launch_workload.run_workload&dag_run_id=manual__2026-09-01T01%3A02%3A38.638698%2B00%3A00)

# Tests

https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_checkpoint_conversion/grid?dag_run_id=manual__2026-09-01T03%3A41%3A07%2B00%3A00&task_id=gemma3-4b.to-mt-v5p-8.run_model.wait_for_workload_completion&tab=logs


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.