### PR TITLE
feat(xlml): Print GKE pod logs in Airflow task logs

### DIFF
--- a/xlml/utils/gke.py
+++ b/xlml/utils/gke.py
@@ -156,6 +156,40 @@ def get_workload_jobset(
     return None
 
 
+def print_pod_logs(
+    core_api: kubernetes.client.CoreV1Api, pod: kubernetes.client.V1Pod
+) -> None:
+  """Prints logs for all containers in a pod."""
+  try:
+    for container in pod.spec.containers:
+      try:
+        response = core_api.read_namespaced_pod_log(
+            name=pod.metadata.name,
+            namespace=pod.metadata.namespace,
+            container=container.name,
+            tail_lines=10000,
+            _preload_content=False,
+        )
+        logging.info(
+            "--- Logs for pod %s, container %s ---",
+            pod.metadata.name,
+            container.name,
+        )
+        for line in response:
+          if isinstance(line, bytes):
+            line = line.decode("utf-8", "replace")
+          logging.info(line.rstrip("\n"))
+      except Exception as e:
+        logging.info(
+            "Failed to fetch logs for %s:%s: %s",
+            pod.metadata.name,
+            container.name,
+            e,
+        )
+  except Exception as e:
+    logging.info("Failed to process pod containers: %s", e)
+
+
 def log_workload_pod_statuses(
     workload_id: str, pods: kubernetes.client.V1PodList
 ) -> None:
@@ -216,6 +250,7 @@ def wait_for_workload_start(
       logging.info(f"Pod {pod.metadata.name} is in phase {pod.status.phase}")
       return False
     if pod.status.phase == "Failed":
+      print_pod_logs(core_api, pod)
       url = LOGGING_URL_FORMAT.format(
           project=project_id,
           region=region,
@@ -304,6 +339,7 @@ def wait_for_workload_completion(
       logging.info(f"Pod {pod.metadata.name} is in phase {pod.status.phase}")
       return False
     if pod.status.phase == "Failed":
+      print_pod_logs(core_api, pod)
       url = LOGGING_URL_FORMAT.format(
           project=project_id,
           region=region,
@@ -328,16 +364,20 @@ def wait_for_workload_completion(
             container_name = (
                 container_status.name or pod.spec.containers[0].name
             )
-            logs = core_api.read_namespaced_pod_log(
+            response = core_api.read_namespaced_pod_log(
                 name=pod.metadata.name,
                 namespace=namespace,
                 container=container_name,
+                tail_lines=10000,
+                _preload_content=False,
             )
-            for line in logs.split("\n"):
-              logging.info(line)
+            for line in response:
+              if isinstance(line, bytes):
+                line = line.decode("utf-8", "replace")
+              logging.info(line.rstrip("\n"))
           except kubernetes.client.exceptions.ApiException as e:
             logging.warning(
-                f"Could not retrieve pod logs for {pod.metadata.name}: {e}"
+                "Could not retrieve pod logs for %s: %s", pod.metadata.name, e
             )
           url = LOGGING_URL_FORMAT.format(
               project=project_id,
@@ -350,6 +390,10 @@ def wait_for_workload_completion(
               f"Workload {workload_id} failed with container exit code "
               f"{container_status.state.terminated.exit_code}. Logs: {url}"
           )
+
+  # Fetch logs for successful pods before returning
+  for pod in pods.items:
+    print_pod_logs(core_api, pod)
 
   logging.info("All pod(s) phase are succeeded.")
   return True


### PR DESCRIPTION
# Description

This PR adds native Kubernetes pod log output to Airflow task logs in
`xlml/utils/gke.py`.

The new `print_pod_logs` helper reads up to 10,000 log lines from each regular
container in a pod and writes the output to the Airflow task log.

The helper runs in these cases:

- A pod enters the `Failed` phase during `wait_for_workload_start`.
- A pod enters the `Failed` phase during `wait_for_workload_completion`.
- `wait_for_workload_completion` is ready to return success.

This improves log visibility for workloads that use these `gke_config` sensor
paths, including MaxText pre-training, post-training, and checkpoint
conversion workloads.

# Tests

https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_checkpoint_conversion/grid?dag_run_id=manual__2026-09-08T02%3A23%3A29%2B00%3A00&task_id=qwen3-vl-2b.to-mt-v5p-8.run_model.wait_for_workload_completion&tab=logs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.