### PR TITLE
fix: Fix XPK setup in Debian containers and refine elastic goodput validation

### DIFF
--- a/dags/maxtext_pathways/configs/utils.py
+++ b/dags/maxtext_pathways/configs/utils.py
@@ -80,17 +80,14 @@ def generate_install_dependencies_commands() -> str:
       # Update apt package list
       "sudo apt-get update",
 
-      # Install kubectl
-      "sudo apt-get install -y kubectl",
-
-      # Install GKE auth plugin for cluster authentication
-      "sudo apt-get install google-cloud-cli-gke-gcloud-auth-plugin -y",
+      # Install kubectl and GKE auth plugin
+      "sudo apt-get install -y kubectl google-cloud-cli-gke-gcloud-auth-plugin",
 
       # Install xpk
-      *xpk.get_xpk_setup_cmd("/root", xpk.MAIN_BRANCH),
+      *xpk.get_xpk_setup_cmd("/root", host=False, branch=xpk.MAIN_BRANCH),
 
       # Install dependencies for maxtext
-      "pip install omegaconf",
+      "uv pip install omegaconf",
 
       # Prepare environment for further pip installs
       "cd /deps",
@@ -270,7 +267,7 @@ def interrupt_worker_pod(
     except subprocess_utils.ProcessKilledException:
       logging.info("Process was terminated with SIGKILL")
 
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 # TODO(cienet): timeout might have conflict with steam
@@ -379,7 +376,7 @@ def check_logs_stream(
       logging.info("Using upstream XCom since_time: %s", effective_since_time)
     else:
       effective_since_time = ti.start_date.astimezone(timezone.utc).strftime(
-          "%Y-%m-%dT%H:%M:%SZ"
+          "%Y-%m-%dT%H:%M:%S.%fZ"
       )
       logging.info(
           "No upstream or internal since_time. Using task start time: %s",
@@ -408,19 +405,25 @@ def worker_pod_interruption(
     region: str = "",
     cluster_name: str = "",
     workload_id: str = "",
+    times: int = 3,
+    entry_log_pattern: str = "completed step:",
+    elastic_log_pattern: str = "Elastic attempt",
+    end_log_pattern: str = "Sufficient slices active:",
 ) -> DAGNode:
   """Run a test job with worker pod interruption."""
   with TaskGroup(group_id="worker_pod_interruption") as group:
-    previous_cycle_tail = None
-    for i in range(1, 2):
+    last_timestamp = None
+    for i in range(1, times + 1):
       wait_for_step = check_logs_stream.override(
-          task_id=f"wait_for_step_starts_{i}"
+          task_id=f"wait_for_step_starts_{i}",
+          retries=5,
       )(
           project_id=project_id,
           region=region,
           cluster_name=cluster_name,
           workload_id=workload_id,
-          expect_log_contains="completed step:",
+          expect_log_contains=entry_log_pattern,
+          since_time=last_timestamp,
       )
 
       trigger_interrupt = interrupt_worker_pod.override(
@@ -432,11 +435,7 @@ def worker_pod_interruption(
           workload_id=workload_id,
       )
 
-      # TODO(cienet): refine validation
-      #   1. more precise log content and order
-      #   2. use kubectl instead of CoreV1Api
-      #   (since it doesn't support "since_time")
-      #   3. cache a timestamp, to skip the old logs
+      wait_for_step >> trigger_interrupt
 
       wait_for_elastic_attempt = check_logs_stream.override(
           task_id=f"wait_for_elastic_attempt_{i}"
@@ -445,7 +444,8 @@ def worker_pod_interruption(
           region=region,
           cluster_name=cluster_name,
           workload_id=workload_id,
-          expect_log_contains=f"Elastic attempt {i+1}",
+          expect_log_contains=elastic_log_pattern,
+          since_time=trigger_interrupt,
       )
 
       wait_for_slices_active = check_logs_stream.override(
@@ -455,7 +455,8 @@ def worker_pod_interruption(
           region=region,
           cluster_name=cluster_name,
           workload_id=workload_id,
-          expect_log_contains="Sufficient slices active:",
+          expect_log_contains=end_log_pattern,
+          since_time=wait_for_elastic_attempt,
       )
 
       chain(
@@ -465,7 +466,6 @@ def worker_pod_interruption(
           wait_for_slices_active,
       )
 
-      if previous_cycle_tail:
-        chain(previous_cycle_tail, wait_for_step)
-      previous_cycle_tail = wait_for_slices_active
+      last_timestamp = wait_for_slices_active
+
     return group

--- a/dags/maxtext_pathways/pw_mcjax_dags.py
+++ b/dags/maxtext_pathways/pw_mcjax_dags.py
@@ -15,7 +15,6 @@
 """DAG definition for running MaxText Pathways MCJax benchmarks on GKE."""
 
 import datetime
-import time
 from absl import logging
 
 from airflow import models

--- a/dags/maxtext_pathways/pw_mcjax_elastic.py
+++ b/dags/maxtext_pathways/pw_mcjax_elastic.py
@@ -20,8 +20,6 @@ from absl import logging
 from airflow import models
 from airflow.decorators import task
 from airflow.models.baseoperator import chain
-from airflow.models.taskmixin import DAGNode
-from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
@@ -294,6 +292,7 @@ with models.DAG(
       region=calculated_params["region"],
       cluster_name=fetched_params["cluster_name"],
       workload_id=calculated_params["workload_id"],
+      end_log_pattern="Sufficient slices active: 1 >= 1",
   )
 
   wait_for_workload_complete = gke.wait_for_workload_completion.override(
@@ -426,6 +425,8 @@ with models.DAG(
       region=calculated_params["region"],
       cluster_name=fetched_params["cluster_name"],
       workload_id=calculated_params["workload_id"],
+      entry_log_pattern="live slice count: 2",
+      end_log_pattern="Sufficient slices active: 2 >= 1",
   )
 
   wait_for_workload_complete = gke.wait_for_workload_completion.override(

--- a/dags/maxtext_pathways/pw_mcjax_elastic_goodput.py
+++ b/dags/maxtext_pathways/pw_mcjax_elastic_goodput.py
@@ -239,14 +239,14 @@ def worker_pod_interruption_with_se(
           cluster_name=cluster_name,
           workload_id=workload_id,
           expect_log_contains=elastic_log_pattern,
-          since_time=wait_for_step,
+          since_time=trigger_interrupt,
       )
 
       phase2_metrics = phase2_validate(
           project_id=project_id,
           workload_id=workload_id,
           slices_phase1=phase1_metrics,
-          start_time=wait_for_elastic_attempt,
+          start_time=trigger_interrupt,
           times=i,
       )
 
@@ -288,7 +288,12 @@ RECIPE_NAME = RECIPE_INSTANCE.value.lower()
 
 
 def create_elastic_goodput_dag(
-    dag_id: str, description: str, params: dict, slice_efficiency: bool = False
+    dag_id: str,
+    description: str,
+    params: dict,
+    slice_efficiency: bool = False,
+    entry_log_pattern: str = "completed step:",
+    end_log_pattern: str = "Sufficient slices active: 1 >= 1",
 ) -> models.DAG:
   schedule = SchedulingHelper.arrange_schedule_time(dag_id)
   with models.DAG(
@@ -362,7 +367,8 @@ def create_elastic_goodput_dag(
           region=calculated_params["region"],
           cluster_name=fetched_params["cluster_name"],
           workload_id=calculated_params["workload_id"],
-          times=2,
+          entry_log_pattern=entry_log_pattern,
+          end_log_pattern=end_log_pattern,
       )
     else:
       interruption_task = worker_pod_interruption(
@@ -370,6 +376,8 @@ def create_elastic_goodput_dag(
           region=calculated_params["region"],
           cluster_name=fetched_params["cluster_name"],
           workload_id=calculated_params["workload_id"],
+          entry_log_pattern=entry_log_pattern,
+          end_log_pattern=end_log_pattern,
       )
 
     wait_for_workload_complete = gke.wait_for_workload_completion.override(
@@ -424,9 +432,9 @@ def create_elastic_goodput_dag(
         start_recipe,
         interruption_task,
         wait_for_workload_complete,
+        workload_goodput,
         goodput_logname,
         check_goodput_logs,
-        workload_goodput,
         clean_up_recipe,
     )
 
@@ -450,6 +458,7 @@ dag_replica = create_elastic_goodput_dag(
         "setting and replica resize on GKE."
     ),
     params=replica_params,
+    end_log_pattern="Sufficient slices active: 2 >= 1",
 )
 
 
@@ -472,4 +481,5 @@ dag_replica = create_elastic_goodput_dag(
     ),
     params=replica_params,
     slice_efficiency=True,
+    end_log_pattern="Sufficient slices active: 2 >= 1",
 )

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -50,7 +50,12 @@ LOGGING_URL_FORMAT = (
 )
 
 
-def get_xpk_setup_cmd(tmpdir, branch: str = MAIN_BRANCH):
+def get_xpk_setup_cmd(
+    tmpdir,
+    branch: str = MAIN_BRANCH,
+    *,
+    host: bool = True,
+):
   clone_branch = (
       f"git clone --branch {branch} https://github.com/AI-Hypercomputer/xpk"
       f" {tmpdir}/xpk"
@@ -59,12 +64,21 @@ def get_xpk_setup_cmd(tmpdir, branch: str = MAIN_BRANCH):
   bash_setup = "set -xue"
 
   # Create venv, install uv in it, then use uv to install xpk
-  setup_xpk = (
-      f"python3 -m venv {tmpdir}/xpk_venv && "
-      f"source {tmpdir}/xpk_venv/bin/activate && "
-      f"pip install uv && "
-      f"uv pip install -e {tmpdir}/xpk"
-  )
+  if host:
+    setup_xpk = (
+        f"python3 -m venv {tmpdir}/xpk_venv && "
+        f"source {tmpdir}/xpk_venv/bin/activate && "
+        f"pip install uv && "
+        f"uv pip install -e {tmpdir}/xpk"
+    )
+  # Running xpk setup commands in container
+  else:
+    # uv handles venv creation and package fetching independently of Debian's stripped Python pip
+    setup_xpk = (
+        f"uv venv {tmpdir}/xpk_venv && "
+        f"source {tmpdir}/xpk_venv/bin/activate && "
+        f"uv pip install -e {tmpdir}/xpk"
+    )
 
   cmds = [
       bash_setup,


### PR DESCRIPTION
# Description

This PR updates XPK setup for Debian-based container environments and refines MaxText Pathways elastic goodput validation.

## Changes

- Add the keyword-only `host` toggle to `get_xpk_setup_cmd`.
- Use `uv venv` and `uv pip` for XPK setup when `host=False`.
- Install `omegaconf` with `uv pip` in the active XPK virtual environment.
- Preserve the existing host setup path and positional `branch` argument.
- Use microsecond-precision UTC timestamps for log and metric queries.
- Repeat worker pod interruptions and retry the pre-interruption log wait.
- Configure log patterns for pause-resume and replica-resize validation.
- Run `check_workload_goodput` before the goodput log checks.

## Prerequisite

The container image must provide the `uv` executable. The dependency-install commands do not install `uv`.

## Validation

- Ran `pw_elastic_goodput`: [link](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pw_elastic_goodput/grid?dag_run_id=manual__2026-09-08T09%3A20%3A42%2B00%3A00&task_id=run_command_in_kpo.run_kpo-cli&tab=logs).
- Container XPK setup requires validation with the target container image.


# Tests

[pw_elastic_goodput](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pw_elastic_goodput/grid?dag_run_id=manual__2026-09-08T09%3A20%3A42%2B00%3A00&task_id=run_command_in_kpo.run_kpo-cli&tab=logs)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.