### PR TITLE
Reduce Llama 3.1 70B pre-training to 64 TPU cores and configure exit-code handling

### DIFF
--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -49,6 +49,7 @@ def get_gke_config(
     mtc_enabled: bool = False,
     use_pathways: bool = False,
     xpk_branch: str = xpk.MAIN_BRANCH,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkTask:
   pass
 
@@ -79,6 +80,7 @@ def get_gke_config(
     gcluster_version: str = gcluster.DEFAULT_GCLUSTER_VERSION,
     mounts: str | Iterable[str] | None = None,
     pathways_gcs_location: str = "",
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.GclusterTask:
   pass
 
@@ -109,6 +111,7 @@ def get_gke_config(
     mounts: str | Iterable[str] | None = None,
     pathways_gcs_location: str = "",
     xpk_branch: str = xpk.MAIN_BRANCH,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.GclusterTask | task.XpkTask:
   """Constructs a GKE task for either Cluster Toolkit (gcluster) or XPK."""
   job_gcp_config = gcp_config.GCPConfig(
@@ -156,6 +159,7 @@ def get_gke_config(
         task_metric_config=job_metric_config,
         priority=priority,
         max_restart=max_restart,
+        restart_on_exit_codes=restart_on_exit_codes,
         gcluster_version=gcluster_version,
         ramdisk_directory=ramdisk_directory,
         mtc_enabled=mtc_enabled,
@@ -174,6 +178,7 @@ def get_gke_config(
       task_metric_config=job_metric_config,
       priority=priority,
       max_restart=max_restart,
+      restart_on_exit_codes=restart_on_exit_codes,
       xpk_branch=xpk_branch,
       ramdisk_directory=ramdisk_directory,
       mtc_enabled=mtc_enabled,
@@ -209,6 +214,7 @@ def get_gke_config_with_interrupt(
     ramdisk_directory: str = "",
     mtc_enabled: bool = False,
     use_pathways: bool = False,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkNodeInterruptionTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -253,6 +259,7 @@ def get_gke_config_with_interrupt(
       task_metric_config=job_metric_config,
       priority=priority,
       max_restart=max_restart,
+      restart_on_exit_codes=restart_on_exit_codes,
       xpk_branch=xpk_branch,
       ramdisk_directory=ramdisk_directory,
       mtc_enabled=mtc_enabled,
@@ -294,6 +301,7 @@ def get_gke_config_with_name_gen_and_quarantine(
     mtc_enabled: bool = False,
     use_pathways: bool = False,
     xpk_branch: str = xpk.MAIN_BRANCH,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkNameGenAndQuarantineTask:
   pass
 
@@ -327,6 +335,7 @@ def get_gke_config_with_name_gen_and_quarantine(
     gcluster_version: str = gcluster.DEFAULT_GCLUSTER_VERSION,
     mounts: str | Iterable[str] | None = None,
     pathways_gcs_location: str = "",
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.GclusterNameGenAndQuarantineTask:
   pass
 
@@ -360,6 +369,7 @@ def get_gke_config_with_name_gen_and_quarantine(
     mounts: str | Iterable[str] | None = None,
     pathways_gcs_location: str = "",
     xpk_branch: str = xpk.MAIN_BRANCH,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.GclusterNameGenAndQuarantineTask | task.XpkNameGenAndQuarantineTask:
   """Constructs a GKE name-gen/quarantine task for Cluster Toolkit or XPK."""
   job_gcp_config = gcp_config.GCPConfig(
@@ -407,6 +417,7 @@ def get_gke_config_with_name_gen_and_quarantine(
         task_metric_config=job_metric_config,
         priority=priority,
         max_restart=max_restart,
+        restart_on_exit_codes=restart_on_exit_codes,
         gcluster_version=gcluster_version,
         ramdisk_directory=ramdisk_directory,
         mtc_enabled=mtc_enabled,
@@ -428,6 +439,7 @@ def get_gke_config_with_name_gen_and_quarantine(
       task_metric_config=job_metric_config,
       priority=priority,
       max_restart=max_restart,
+      restart_on_exit_codes=restart_on_exit_codes,
       xpk_branch=xpk_branch,
       ramdisk_directory=ramdisk_directory,
       mtc_enabled=mtc_enabled,
@@ -453,6 +465,7 @@ def get_gke_maxtext_nightly_config(
     ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -523,6 +536,7 @@ def get_maxtext_end_to_end_gpu_gke_test_config(
     test_owner: str,
     docker_image: str,
     num_slices: int = 1,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -570,6 +584,7 @@ def get_gke_gpt3_6b_nightly_config(
     ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,
@@ -649,6 +664,7 @@ def get_maxtext_cpu_end_to_end_gke_config(
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,
     metric_aggregation_strategy: metric_config.AggregationStrategy = None,
+    restart_on_exit_codes: Iterable[int] | None = None,
 ) -> task.XpkTask:
   job_gcp_config = gcp_config.GCPConfig(
       project_name=cluster.project,

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -261,6 +261,7 @@ with models.DAG(
               use_pathways=True,
               priority="medium",
               max_restart=3,
+              restart_on_exit_codes=[137, 143],
               use_gcluster=True,
           ).run(skip_post_process=True)
 

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -104,7 +104,7 @@ with models.DAG(
           "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
       },
       "llama3_1-70b": {
-          "core_count": 128,
+          "core_count": 64,
           "training": {
               "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/train/{run_name}/checkpoints/1/items",
@@ -166,6 +166,7 @@ with models.DAG(
           test_owner=test_owner.SURBHI_J,
           priority="medium",
           max_restart=3,
+          restart_on_exit_codes=[137, 143],
           use_gcluster=True,
       ).run(skip_post_process=True)
 

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -366,6 +366,7 @@ class RunnerConfig:
   ramdisk_directory: str = ""
   mtc_enabled: bool = False
   use_pathways: bool = False
+  restart_on_exit_codes: Iterable[int] | None = None
 
 
 @dataclasses.dataclass
@@ -585,6 +586,7 @@ class GclusterRunner(Runner):
           mtc_enabled=self.configs.mtc_enabled,
           gcluster_version=self.configs.gcluster_version,
           max_restart=self.configs.max_restart,
+          restart_on_exit_codes=self.configs.restart_on_exit_codes,
           priority=self.configs.priority,
           namespace=self.configs.task_test_config.namespace,
           mounts=mounts,

--- a/xlml/utils/gcluster.py
+++ b/xlml/utils/gcluster.py
@@ -138,6 +138,7 @@ def run_workload(
     mtc_enabled: bool = False,
     gcluster_version: str = DEFAULT_GCLUSTER_VERSION,
     max_restart: int = 0,
+    restart_on_exit_codes: Iterable[int] | None = None,
     priority: str = "high",
     namespace: str = "default",
     mounts: str | Iterable[str] | None = None,
@@ -205,6 +206,9 @@ def run_workload(
       submit_cmd.append("--gke-mtc-enabled")
     if max_restart > 0:
       submit_cmd.append(f"--restarts={max_restart}")
+    codes = [] if restart_on_exit_codes is None else list(restart_on_exit_codes)
+    if codes:
+      submit_cmd.append(f"--restart-on-exit-codes={','.join(map(str, codes))}")
     if is_valid_gpu_version(accelerator_type):
       submit_cmd.append("--gke-scheduler=gke.io/topology-aware-auto")
 


### PR DESCRIPTION
# Description

- Reduce `llama3_1-70b` pre-training `core_count` from 128 to 64.
- Propagate `restart_on_exit_codes` from XLML task configuration to the `gcluster` CLI wrapper.
- Configure the MaxText pre-training and post-training DAGs with `restart_on_exit_codes=[137, 143]`.

This configuration lets JobSet fail immediately when the user application exits with code 137 or 143. Node preemption retries continue to use the native JobSet behavior.

# Tests

https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_pre_training/grid?search=maxtext_e2e_tpu_pre_training&dag_run_id=manual__2026-09-10T07%3A37%3A12%2B00%3A00&task_id=gemma3-4b.pre-v5p-8.run_model.wait_for_workload_completion&tab=logs

https://cloudlogging.app.goo.gl/NSVqRhsn9V4c6pw2A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.