### PR TITLE
Fix: Remove `restart_on_exit_codes` from `maxtext_e2e_tpu_post_training` DAG

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -261,7 +261,6 @@ with models.DAG(
               use_pathways=True,
               priority="medium",
               max_restart=3,
-              restart_on_exit_codes=[137, 143],
               use_gcluster=True,
           ).run(skip_post_process=True)
 


### PR DESCRIPTION
# Description

This PR removes `restart_on_exit_codes=[137, 143]` from the training task in `maxtext_e2e_tpu_post_training.py`.                               
`use_pathways=True`, `use_gcluster=True` and `max_restart=3` are all left unchanged — this only drops the exit-code filter.

#Reason

The post-training DAG runs on Pathways. When `gcluster` is given `--restart-on-exit-codes`, it injects a `podFailurePolicy` block into **every** replicatedJob of the generated JobSet, including the Pathways `worker` job. But Pathways workers require `restartPolicy: OnFailure`, and Kubernetes rejects any Job that combines the two:

The Job is invalid: spec.template.spec.restartPolicy:                                                                              
Invalid value: "OnFailure": only "Never" is supported when podFailurePolicy is specified

Because `JobSet` is a CRD, the API server only validates the outer JobSet schema on submission — the invalid worker spec is not caught until the JobSet controller tries to create the child Job, at which point it is silently rejected. The result:                           
                                                                                                                                           
- `pathways-head` starts normally,                                                                                                     
- the `worker` Job is never created, so **no worker Pods exist at all** (not even `Pending`, and no container logs),                   
- `pathways-rm` loops on `RESOURCE_EXHAUSTED` waiting for workers that never arrive,                                                   
- the task hangs for the full 60-minute timeout with **no error code surfaced anywhere**.

Removing the flag restores the exact configuration that was running successfully before it was introduced in #1367.

## Follow up 

We have filed a ticket against the Cluster Toolkit team: [b/559899266](https://buganizer.corp.google.com/issues/559899266).            
  
The underlying defect is in `gcluster` (cluster-toolkit `v1.102.0`): `podFailurePolicy` should only be injected where `restartPolicy:  Never`, i.e. onto `pathways-head` and not onto `worker`. Notably the head side is already wired correctly today, so that single change would both fix the hang and make exit-code filtering work for Pathways.
  
Once that fix lands we will add `restart_on_exit_codes` back to this DAG.

# Tests

https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_post_training/grid?dag_run_id=manual__2026-09-11T05%3A23%3A05%2B00%3A00&task_id=gemma3-4b.rl-gemma3-4b.rl-v5p-32.run_model.wait_for_workload_completion&tab=logs

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.